### PR TITLE
Parse battery status of HID++ 1.0 devices

### DIFF
--- a/lib/logitech/unifying_receiver/hidpp10.py
+++ b/lib/logitech/unifying_receiver/hidpp10.py
@@ -94,8 +94,16 @@ def get_battery(device):
 
 	reply = get_register(device, 'battery_status', 0x07)
 	if reply:
-		battery_status = ord(reply[:1])
-		_log.info("%s: battery status %02X", device, battery_status)
+		level = ord(reply[:1])
+		battery_status = ord(reply[2:3])
+		charge = (90 if level == 7 # full
+			else 50 if level == 5 # good
+			else 20 if level == 3 # low
+			else 5 if level == 1 # critical
+			else 0 ) # wtf?
+		status = ('charging' if battery_status == 0x25
+			else 'discharging')
+		return charge, status
 
 
 def get_serial(device):


### PR DESCRIPTION
This applies to K800 but it seems also to apply to M510. The numbers are based
on the HID++ 2.0 spec that state the following for GetBatteryCapability:

```
If number of levels < 10 or if mileage is disabled then report are
mapped to 4 levels this way.

0%->10%     critical
11%->30%    low
31%->80%    good
81%->100%   full

i.e. to report battery low, FW send 25%, to report battery good, FW send 50%.
```

This patch likely closes #5.
