### PR TITLE
Python3 compatibility for hidconsole

### DIFF
--- a/lib/hidapi/hidconsole.py
+++ b/lib/hidapi/hidconsole.py
@@ -15,12 +15,17 @@ import hidapi
 #
 #
 
-# no Python 3 support :(
-read_packet = raw_input
+try:
+	read_packet = raw_input
+except NameError:
+	# Python 3 equivalent of raw_input
+	read_packet = input
+
 interactive = os.isatty(0)
 prompt = '?? Input: ' if interactive else ''
 
 strhex = lambda d: hexlify(d).decode('ascii').upper()
+is_string = lambda d: type(d) == (str if type(u'') == str else unicode)
 start_time = time.time()
 
 #
@@ -33,7 +38,7 @@ del Lock
 
 def _print(marker, data, scroll=False):
 	t = time.time() - start_time
-	if type(data) == unicode:
+	if is_string(data):
 		s = marker + ' ' + data
 	else:
 		hexs = strhex(data)

--- a/tools/hidconsole
+++ b/tools/hidconsole
@@ -19,9 +19,6 @@ def init_paths():
 
 
 if __name__ == '__main__':
-	if sys.version_info >= (2, 8):
-		sys.exit("Python 3 is not supported by hidconsole.")
-
 	init_paths()
 	from hidapi import hidconsole
 	hidconsole.main()


### PR DESCRIPTION
`type(u'')` is 'str' in Python 3, it was `unicode` on Python 2 (with
`unicode_literals` from `__future__`).

This patch adds Python3 support for hidconsole.
