### PR TITLE
descriptors.py: Clarify use of negative values

### DIFF
--- a/lib/logitech/unifying_receiver/descriptors.py
+++ b/lib/logitech/unifying_receiver/descriptors.py
@@ -76,6 +76,8 @@ def _D(name, codename=None, kind=None, registers=None, settings=None):
 
 # Some HID++1.0 registers and HID++2.0 features can be discovered at run-time,
 # so they are not specified here.
+# Registers are only supported for HID++ 1.0 devices. Specify a negative value
+# to blacklist that register (prevent Solaar from accessing the register)
 
 # Keyboards
 


### PR DESCRIPTION
The negative behavior is not obvious, document it in the descriptors.py file
such that people who edit it to add new devices know how it works.
