### PR TITLE
added 'solaar.cli' on setup.py files (line 74 "packages=")

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ battery status.
 		requires=['pyudev (>= 0.13)', 'gi.repository.GObject (>= 2.0)', 'gi.repository.Gtk (>= 3.0)'],
 
 		package_dir={'': 'lib'},
-		packages=['hidapi', 'logitech_receiver', 'solaar', 'solaar.ui'],
+		packages=['hidapi', 'logitech_receiver', 'solaar', 'solaar.ui', 'solaar.cli'],
 		data_files=list(_data_files()),
 		scripts=_glob('bin/*'),
 	)


### PR DESCRIPTION
missing packages 'cli' from "/lib/solaar/" and needed for building package rpm.

[david@david ~]$ solaar -dd
Traceback (most recent call last):
  File "/usr/bin/solaar", line 43, in <module>
    import solaar.gtk
  File "/usr/lib/python2.7/site-packages/solaar/gtk.py", line 26, in <module>
    import solaar.cli as _cli
ImportError: No module named cli
