### PR TITLE
Fixing a crash when level is type None

### DIFF
--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -107,7 +107,7 @@ def _print_device(dev):
 		if battery is not None:
 			from logitech_receiver.common import NamedInt as _NamedInt
 			level, status = battery
-			if level:
+			if level is not None:
 				if isinstance(level, _NamedInt):
 					text = str(level)
 				else:


### PR DESCRIPTION
level is returned as None in hidpp10.py when the performanceMX mouse is charging. Since the battery state is unknown when beeing recharged it
will now return "N/A".
Before it would crash becasue level was None and could not be inserted
using %d.
