### PR TITLE
Added basic smooth scroll implementation that works in the same fashion as SetPoint

### DIFF
--- a/lib/logitech_receiver/listener.py
+++ b/lib/logitech_receiver/listener.py
@@ -133,7 +133,7 @@ class EventsListener(_threading.Thread):
 
 	Incoming packets will be passed to the callback function in sequence.
 	"""
-	def __init__(self, receiver, notifications_callback):
+	def __init__(self, receiver, notifications_callback, check_notify_updates=None):
 		super(EventsListener, self).__init__(name=self.__class__.__name__ + ':' + receiver.path.split('/')[2])
 
 		self.daemon = True
@@ -142,6 +142,7 @@ class EventsListener(_threading.Thread):
 		self.receiver = receiver
 		self._queued_notifications = _Queue(16)
 		self._notifications_callback = notifications_callback
+		self._check_notify_updates = check_notify_updates
 
 		# self.tick_period = 0
 
@@ -173,7 +174,7 @@ class EventsListener(_threading.Thread):
 					break
 
 				if n:
-					n = _base.make_notification(*n)
+					n = _base.make_notification(*n, check_notify_updates=self._check_notify_updates)
 			else:
 				# deliver any queued notifications
 				n = self._queued_notifications.get()

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -76,6 +76,10 @@ class PairedDevice(object):
 		self._polling_rate = None
 		self._power_switch = None
 
+		# Current status of smooth scrolling as measured by the preliminary check
+		self._pre_smooth_status = None
+		self._smooth_status = None
+
 		# if _log.isEnabledFor(_DEBUG):
 		# 	_log.debug("new PairedDevice(%s, %s, %s)", receiver, number, link_notification)
 


### PR DESCRIPTION
Fixes #179 and addresses #158 

There is still **lots** of work and testing to do here, but I'd appreciate any comments and thoughts so far.

This code requires the "side scrolling" option be disabled (currently..). It then listens for when the smooth scroll button is pressed and sets the mouse into smooth scroll mode and sets the `Evdev Scrolling Distance` such that scrolls don't overshoot. It also disables the mouse button that represents the smooth scroll button since that button being pressed all the time interferes with changing windows and so on.

It also sets the horizontal scrolling distance to a large number to make fast side scrolls behave reasonably when "side scrolling" is disabled (this gives a smooth effect for side scrolls too).
