### PR TITLE
base-usb: add support for Lightspeed receivers

### DIFF
--- a/lib/logitech_receiver/base_usb.py
+++ b/lib/logitech_receiver/base_usb.py
@@ -31,7 +31,7 @@ _GENERIC_DRIVER = ('hid-generic', 'generic-usb')
 _unifying_receiver = lambda product_id: (0x046d, product_id, 2, _UNIFYING_DRIVER)
 _nano_receiver = lambda product_id: (0x046d, product_id, 1, _GENERIC_DRIVER)
 _lenovo_receiver = lambda product_id: (0x17ef, product_id, 1, _GENERIC_DRIVER)
-
+_lightspeed_receiver = lambda product_id: (0x046d, product_id, 2, _GENERIC_DRIVER)
 
 # standard Unifying receivers (marked with the orange Unifying logo)
 UNIFYING_RECEIVER_C52B    = _unifying_receiver(0xc52b)
@@ -53,6 +53,10 @@ NANO_RECEIVER_C531        = _nano_receiver(0xc531)
 NANO_RECEIVER_C534        = _nano_receiver(0xc534)
 NANO_RECEIVER_6042        = _lenovo_receiver(0x6042)
 
+# Lightspeed receivers
+LIGHTSPEED_RECEIVER_C539  = _lightspeed_receiver(0xc539)
+LIGHTSPEED_RECEIVER_C53a  = _lightspeed_receiver(0xc53a)
+
 del _unifying_receiver, _nano_receiver
 
 
@@ -71,4 +75,6 @@ ALL = (
 		NANO_RECEIVER_C531,
 		NANO_RECEIVER_C534,
 		NANO_RECEIVER_6042,
+		LIGHTSPEED_RECEIVER_C539,
+		LIGHTSPEED_RECEIVER_C53a,
 	)

--- a/lib/logitech_receiver/notifications.py
+++ b/lib/logitech_receiver/notifications.py
@@ -157,6 +157,7 @@ def _process_hidpp10_notification(device, status, n):
 		protocol_name = ('unifying (eQuad DJ)' if n.address == 0x04
 					else 'eQuad' if n.address == 0x03
 					else 'M185' if n.address == 0x0A
+					else 'Lightspeed' if n.address == 0x0C
 					else None)
 		if protocol_name:
 			if _log.isEnabledFor(_DEBUG):

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -345,7 +345,9 @@ class Receiver(object):
 			self.serial = 0
 			self.max_devices = 6
 
-		if self.max_devices == 6:
+		if self.product_id == 'c539' or slef.product_id == 'c53a':
+			self.name = 'Lightspeed Receiver'
+		elif self.max_devices == 6:
 			self.name = 'Unifying Receiver'
 		elif self.max_devices < 6:
 			self.name = 'Nano Receiver'

--- a/rules.d/42-logitech-unify-permissions.rules
+++ b/rules.d/42-logitech-unify-permissions.rules
@@ -34,6 +34,10 @@ ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c521", GOTO="solaar_apply"
 ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c525", GOTO="solaar_apply"
 ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c534", GOTO="solaar_apply"
 
+# Lightspeed receivers
+ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c539", GOTO="solaar_apply"
+ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c53a", GOTO="solaar_apply"
+
 # Lenovo nano receiver
 ATTRS{idVendor}=="17ef", ATTRS{idProduct}=="6042", GOTO="solaar_apply"
 


### PR DESCRIPTION
I was waiting for the migration to send this patch but since it has been put on hold, here it is.