### PR TITLE
Fix broken github.io link to new repo url

### DIFF
--- a/lib/solaar/ui/about.py
+++ b/lib/solaar/ui/about.py
@@ -75,7 +75,7 @@ def _create():
 					'Dimitriy Ryazantcev (Russian)',
 					)))
 
-	about.set_website('http://pwr.github.io/Solaar/')
+	about.set_website('http://pwr-solaar.github.io/Solaar/')
 	about.set_website_label(NAME)
 
 	about.connect('response', lambda x, y: x.hide())

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -7,7 +7,7 @@ Build-Depends-Indep: python, po-debconf
 X-Python-Version: >= 2.7
 X-Python3-Version: >= 3.2
 Standards-Version: 3.9.4
-Homepage: http://pwr.github.io/Solaar
+Homepage: http://pwr-solaar.github.io/Solaar
 Vcs-Git: git://github.com/pwr/Solaar.git
 Vcs-browser: http://github.com/pwr/Solaar
 

--- a/packaging/gentoo/solaar-0.8.8.1.ebuild
+++ b/packaging/gentoo/solaar-0.8.8.1.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python{2_7,3_2} )
 inherit distutils-r1 udev user linux-info gnome2-utils
 
 DESCRIPTION="Solaar is a Linux device manager for Logitech's Unifying Receiver peripherals"
-HOMEPAGE="http://pwr.github.io/Solaar/"
+HOMEPAGE="http://pwr-solaar.github.io/Solaar/"
 SRC_URI="https://github.com/pwr/Solaar/archive/${PV}.tar.gz"
 
 LICENSE="GPL-2"

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ battery status.
 		author='Daniel Pavel',
 		author_email='daniel.pavel@gmail.com',
 		license='GPLv2',
-		url='http://pwr.github.io/Solaar/',
+		url='http://pwr-solaar.github.io/Solaar/',
 		classifiers=[
 			'Development Status :: 4 - Beta',
 			'Environment :: X11 Applications :: GTK',


### PR DESCRIPTION
After repo transfered to pwr-solaar(#407), github.io link url also changed. 

Signed-off-by: Daehyeok Mun <daehyeok@google.com>