### PR TITLE
fix: #531 #537. Better handling of EPIPE during hid write.

### DIFF
--- a/lib/hidapi/udev.py
+++ b/lib/hidapi/udev.py
@@ -260,9 +260,17 @@ def write(device_handle, data):
 	assert device_handle
 	assert data
 	assert isinstance(data, bytes), (repr(data), type(data))
-	bytes_written = _os.write(device_handle, data)
-	if bytes_written != len(data):
-		raise IOError(_errno.EIO, 'written %d bytes out of expected %d' % (bytes_written, len(data)))
+	retrycount = 0
+	while(True and retrycount < 3):
+		try:
+			bytes_written = _os.write(device_handle, data)
+			if bytes_written != len(data):
+				raise IOError(_errno.EIO, 'written %d bytes out of expected %d' % (bytes_written, len(data)))
+		except IOError as e:
+			if e.errno != _errno.EPIPE:
+				raise e
+			retrycount += 1
+			continue
 
 
 def read(device_handle, bytes_count, timeout_ms=-1):

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -345,7 +345,7 @@ class Receiver(object):
 			self.serial = 0
 			self.max_devices = 6
 
-		if self.product_id == 'c539' or slef.product_id == 'c53a':
+		if self.product_id == 'c539' or self.product_id == 'c53a':
 			self.name = 'Lightspeed Receiver'
 		elif self.max_devices == 6:
 			self.name = 'Unifying Receiver'


### PR DESCRIPTION
I found the cause for not being able to detect receivers sometimes.
It was related to error out when SIGPIPE is fired during the write inside the hidapi.

I've created a loop with retrycount and catching EPIPE and trying the write 3 times.
I tested it as well with just ignoring EPIPE, which is working too, but has the drawback, that the read loop inside the base.request has to time out once.