### PR TITLE
Repair low resolution smooth scrolling

### DIFF
--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -118,7 +118,7 @@ def feature_range(name, feature, min_value, max_value,
 
 _SMOOTH_SCROLL = ('smooth-scroll', _("Smooth Scrolling"),
 							_("High-sensitivity mode for vertical scroll with the wheel."))
-_LOW_RES_SCROLL = ('low-res-scroll', _("HID++ Scrolling"),
+_LOW_RES_SCROLL = ('lowres-smooth-scroll', _("HID++ Scrolling"),
 							_("HID++ mode for vertical scroll with the wheel."))
 
 _HI_RES_SCROLL = ('hi-res-scroll', _("High Resolution Scrolling"),


### PR DESCRIPTION
This addresses #544.

Previous output from `solaar -dd`:
```
Traceback (most recent call last):
  File "/home/chad/Documents/Solaar/lib/logitech_receiver/listener.py", line 185, in run
    self._notifications_callback(n)
  File "/home/chad/Documents/Solaar/lib/solaar/listener.py", line 213, in _notifications_handler
    configuration.attach_to(dev)
  File "/home/chad/Documents/Solaar/lib/solaar/configuration.py", line 130, in attach_to
    for s in device.settings:
  File "/home/chad/Documents/Solaar/lib/logitech_receiver/receiver.py", line 254, in settings
    _check_feature_settings(self, self._settings)
  File "/home/chad/Documents/Solaar/lib/logitech_receiver/settings_templates.py", line 385, in check_feature_settings
    check_feature(_SMOOTH_SCROLL[0], _F.LOWRES_WHEEL)
  File "/home/chad/Documents/Solaar/lib/logitech_receiver/settings_templates.py", line 381, in check_feature
    feature = getattr(FeatureSettings, field_name)()
TypeError: 'NoneType' object is not callable
10:30:49,905    ERROR [ReceiverListener:hidraw3] logitech_receiver.listener: processing Notification(1,08,00,00000100000000000000000000000000)
Traceback (most recent call last):
  File "/home/chad/Documents/Solaar/lib/logitech_receiver/listener.py", line 185, in run
    self._notifications_callback(n)
  File "/home/chad/Documents/Solaar/lib/solaar/listener.py", line 219, in _notifications_handler
    assert dev.status is not None
AttributeError: 'PairedDevice' object has no attribute 'status'
10:30:49,905    ERROR [ReceiverListener:hidraw3] logitech_receiver.listener: processing Notification(1,08,10,0404C0780A0000000000000000000000)
Traceback (most recent call last):
  File "/home/chad/Documents/Solaar/lib/logitech_receiver/listener.py", line 185, in run
    self._notifications_callback(n)
  File "/home/chad/Documents/Solaar/lib/solaar/listener.py", line 219, in _notifications_handler
    assert dev.status is not None
AttributeError: 'PairedDevice' object has no attribute 'status'
```