### PR TITLE
docs: devices: add MX Master 2s

### DIFF
--- a/docs/devices/mx-master-2s.txt
+++ b/docs/devices/mx-master-2s.txt
@@ -1,0 +1,84 @@
+Unifying Receiver
+  Device path  : /dev/hidraw7
+  USB id       : 046d:c52b
+  Serial       : BB7D9447
+    Firmware   : 24.01.B0023
+    Bootloader : 01.08
+    Other      : AA.AD
+  Has 2 paired device(s) out of a maximum of 6.
+  Notifications: wireless, software present (0x000900)
+  Device activity counters: 2=156
+
+  1: Wireless Mouse MX Master 2S
+     Codename     : MX Master 2S
+     Kind         : mouse
+     Wireless PID : 4069
+     Protocol     : HID++ 4.5
+     Polling rate : 8 ms (125Hz)
+     Serial number: EAB71F76
+        Bootloader: BOT 56.01.B0006
+          Firmware: MPM 12.01.B0006
+          Firmware: MPM 12.01.B0006
+             Other:
+     The power switch is located on the base.
+     Supports 32 HID++ 2.0 features:
+         0: ROOT                   {0000}
+         1: FEATURE SET            {0001}
+         2: DEVICE FW VERSION      {0003}
+         3: DEVICE NAME            {0005}
+         4: WIRELESS DEVICE STATUS {1D4B}
+         5: RESET                  {0020}
+         6: unknown:0021           {0021}
+         7: BATTERY STATUS         {1000}
+         8: unknown:1806           {1806}   internal, hidden
+         9: CHANGE HOST            {1814}
+        10: REPROG CONTROLS V4     {1B04}
+        11: ADJUSTABLE DPI         {2201}
+        12: VERTICAL SCROLLING     {2100}
+            Roller type: 3G
+            Ratchet per turn: 24
+            Scroll lines: 0
+        13: SMART SHIFT            {2110}
+        14: HIRES WHEEL            {2121}
+            Multiplier: 8
+            Has invert
+              Normal wheel motion
+            Has ratchet switch
+              Normal wheel mode
+            High resolution mode
+            HID notification
+        15: GESTURE 2              {6501}
+        16: unknown:00C2           {00C2}
+        17: unknown:1813           {1813}   internal, hidden
+        18: unknown:1830           {1830}   internal, hidden
+        19: unknown:1890           {1890}   internal, hidden
+        20: unknown:1891           {1891}   internal, hidden
+        21: unknown:18A1           {18A1}   internal, hidden
+        22: unknown:18C0           {18C0}   internal, hidden
+        23: unknown:1DF3           {1DF3}   internal, hidden
+        24: unknown:1E00           {1E00}   hidden
+        25: unknown:1EB0           {1EB0}   internal, hidden
+        26: unknown:1803           {1803}   internal, hidden
+        27: unknown:1861           {1861}   internal, hidden
+        28: unknown:9001           {9001}   internal, hidden
+        29: unknown:9200           {9200}   internal, hidden
+        30: unknown:9202           {9202}   internal, hidden
+        31: unknown:1805           {1805}   internal, hidden
+     Has 8 reprogrammable keys:
+         0: LEFT CLICK                , default: LeftClick                   => LEFT CLICK
+             mse, pos:0, group:1, gmask:1
+         1: RIGHT CLICK               , default: RightClick                  => RIGHT CLICK
+             mse, pos:0, group:1, gmask:1
+         2: MIDDLE BUTTON             , default: MiddleMouseButton           => MIDDLE BUTTON
+             mse, reprogrammable, divertable, pos:0, group:3, gmask:7
+         3: BACK AS BUTTON 4          , default: BackEx                      => BACK AS BUTTON 4
+             mse, reprogrammable, divertable, pos:0, group:2, gmask:3
+         4: FORWARD AS BUTTON 5       , default: BrowserForwardEx            => FORWARD AS BUTTON 5
+             mse, reprogrammable, divertable, pos:0, group:2, gmask:3
+         5: unknown:00C3              , default: unknown:00A9                => unknown:00C3
+             mse, reprogrammable, divertable, pos:0, group:3, gmask:7
+         6: unknown:00C4              , default: unknown:009D                => unknown:00C4
+             mse, reprogrammable, divertable, pos:0, group:3, gmask:7
+         7: unknown:00D7              , default: unknown:00B4                => unknown:00D7
+             divertable, virtual, pos:0, group:4, gmask:0
+     Battery: 50%, discharging.


### PR DESCRIPTION
Added an information text file with the show command data about the MX Master 2s mouse. The source of this information is: https://github.com/pwr-Solaar/Solaar/issues/595.