### PR TITLE
Installation from source sometimes fails with userwarning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 
 from glob import glob as _glob
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 autostart_path = '/etc/xdg/autostart'
 


### PR DESCRIPTION
Installation from source sometimes fails with userwarning unknown distribution option.
I have found a solution that works for me. See: https://stackoverflow.com/questions/9810603/adding-install-requires-to-setup-py-when-making-a-python-package a