### PR TITLE
changes to better handle receivers like c534

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,15 @@ devices with Logitech Nano receivers but not all Logitech devices can be
 paired with Nano receivers.  Logitech devices without a Unifying logo
 generally cannot be paired with Unifying receivers.
 
+Some (maybe all) Nano receivers can only pair a limited number of times.
+Solaar reports how many successful pairings remain for such receivers.
+Some (maybe all) Nano receivers cannot unpair and pair by replacing an old device by
+a new device instead of adding the new device.
+For receivers that solaar believes work this way, the solaar GUI will not allow unpairing
+and will allow pairing even if the receiver already has its maximum number of paired devices.
+Solaar command line pairing and unpairing do not check whether solaar believes
+pairing or unpairing is impossible before trying to pair or unpair.
+
 For some devices, extra settings (usually not available through the standard
 Linux system configuration) are supported. For a full list of supported devices
 and their features, see [docs/devices.md](https://pwr-solaar.github.io/Solaar/devices).

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -336,14 +336,17 @@ class Receiver(object):
 
 		# read the serial immediately, so we can find out max_devices
 		# this will tell us if it's a Unifying or Nano receiver
-		if self.product_id != 'c534':
-			serial_reply = self.read_register(_R.receiver_info, 0x03)
-			assert serial_reply
+		# Should this be done differently?
+		serial_reply = self.read_register(_R.receiver_info, 0x03)
+		if serial_reply is None :
+			# some receivers have this information in a different place
+			serial_reply = self.read_register(_R.receiver_info, 0x10)
+		if serial_reply :
 			self.serial = _strhex(serial_reply[1:5])
 			self.max_devices = ord(serial_reply[6:7])
-		else:
+		else: # devices that don't provide this information are likely limited receivers
 			self.serial = 0
-			self.max_devices = 6
+			self.max_devices = 2 # a guess
 
 		if self.product_id == 'c539' or self.product_id == 'c53a' or self.product_id == 'c53f':
 			self.name = 'Lightspeed Receiver'

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -320,6 +320,9 @@ class PairedDevice(object):
 
 # Lightspeed receivers
 lightspeed_receiver_product_ids = { 'c539', 'c53a', 'c53f' }
+# Receivers that don't unpair but instead pairing replaces existing paired devices
+# Maybe all nano receivers are like this
+repairing_receiver_product_ids = { 'c534' }
 
 class Receiver(object):
 	"""A Unifying Receiver instance.
@@ -362,7 +365,8 @@ class Receiver(object):
 		self._str = '<%s(%s,%s%s)>' % (self.name.replace(' ', ''), self.path, '' if isinstance(self.handle, int) else 'T', self.handle)
 
 		# TODO _properly_ figure out which receivers do and which don't support unpairing
-		self.may_unpair = self.write_register(_R.receiver_pairing) is None
+		self.may_unpair = ( self.write_register(_R.receiver_pairing) is None and 
+				    ( self.product_id not in repairing_receiver_product_ids ) )
 
 		self._firmware = None
 		self._devices = {}

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -370,6 +370,8 @@ class Receiver(object):
 
 		self._firmware = None
 		self._devices = {}
+		# remaining pairings (remaining pairings field - 5, -1 for no limit)
+		self._pairings = None
 
 	def close(self):
 		handle, self.handle = self.handle, None
@@ -384,6 +386,14 @@ class Receiver(object):
 		if self._firmware is None and self.handle:
 			self._firmware = _hidpp10.get_firmware(self)
 		return self._firmware
+
+	def pairings(self,cache=True):
+		if self._pairings is None   or  not cache :
+			ps = self.read_register(_R.receiver_connection)
+			if ps is not None:
+				ps = ord(ps[2:3])
+				self._pairings = ps-5 if ps >= 5 else -1
+		return self._pairings
 
 	def enable_notifications(self, enable=True):
 		"""Enable or disable device (dis)connection notifications on this

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -318,6 +318,9 @@ class PairedDevice(object):
 #
 #
 
+# Lightspeed receivers
+lightspeed_receiver_product_ids = { 'c539', 'c53a', 'c53f' }
+
 class Receiver(object):
 	"""A Unifying Receiver instance.
 
@@ -348,7 +351,7 @@ class Receiver(object):
 			self.serial = 0
 			self.max_devices = 2 # a guess
 
-		if self.product_id == 'c539' or self.product_id == 'c53a' or self.product_id == 'c53f':
+		if self.product_id in lightspeed_receiver_product_ids :
 			self.name = 'Lightspeed Receiver'
 		elif self.max_devices == 6:
 			self.name = 'Unifying Receiver'

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -346,7 +346,7 @@ class Receiver(object):
 		serial_reply = self.read_register(_R.receiver_info, 0x03)
 		if serial_reply is None :
 			# some receivers have this information in a different place
-			serial_reply = self.read_register(_R.receiver_info, 0x10)
+			serial_reply = self.read_register(_R.receiver_info, 0x11)
 		if serial_reply :
 			self.serial = _strhex(serial_reply[1:5])
 			self.max_devices = ord(serial_reply[6:7])

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -311,7 +311,7 @@ class PairedDevice(object):
 	__bool__ = __nonzero__ = lambda self: self.wpid is not None and self.number in self.receiver
 
 	def __str__(self):
-		return '<PairedDevice(%d,%s,%s)>' % (self.number, self.wpid, self.codename or '?')
+		return '<PairedDevice(%d,%s,%s,%s)>' % (self.number, self.wpid, self.codename or '?', self.serial)
 	__unicode__ = __repr__ = __str__
 
 #

--- a/lib/solaar/cli/pair.py
+++ b/lib/solaar/cli/pair.py
@@ -86,6 +86,9 @@ def run(receivers, args, find_receiver, _ignore):
 	if receiver.status.new_device:
 		dev = receiver.status.new_device
 		print ('Paired device %d: %s (%s) [%s:%s]' % (dev.number, dev.name, dev.codename, dev.wpid, dev.serial))
-	else:
-		error = receiver.status.get(_status.KEYS.ERROR) or 'no device detected?'
-		raise Exception("pairing failed: %s" % error)
+	else :
+		error = receiver.status.get(_status.KEYS.ERROR)
+		if error :
+			raise Exception("pairing failed: %s" % error)
+		else :
+			print ('Paired a device') # Better would be to check for a changed device

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -30,7 +30,7 @@ from logitech_receiver import (
 def _print_receiver(receiver):
 	paired_count = receiver.count()
 
-	print ('Unifying Receiver')
+	print (receiver.name)
 	print ('  Device path  :', receiver.path)
 	print ('  USB id       : 046d:%s' % receiver.product_id)
 	print ('  Serial       :', receiver.serial)

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -38,6 +38,8 @@ def _print_receiver(receiver):
 		print ('    %-11s: %s' % (f.kind, f.version))
 
 	print ('  Has', paired_count, 'paired device(s) out of a maximum of %d.' % receiver.max_devices)
+	if receiver.pairings() and receiver.pairings() >= 0 :
+		print ('  Has %d successful pairing(s) remaining.' % receiver.pairings() )
 
 	notification_flags = _hidpp10.get_notification_flags(receiver)
 	if notification_flags is not None:

--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -573,7 +573,7 @@ def _update_receiver_panel(receiver, panel, buttons, full=False):
 		paired_text += '\n\n<small>%s</small>' % _('Only one device can be paired to this receiver.')
 	pairings = receiver.pairings(False) 
 	if ( pairings and pairings >= 0 ) :
-		paired_text += '\n<small>%s</small>' % _('This receiver has %d pairing(s) remaing.') % pairings
+		paired_text += '\n<small>%s</small>' % _('This receiver has %d pairing(s) remaining.') % pairings
 
 
 	panel._count.set_markup(paired_text)

--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -595,9 +595,10 @@ def _update_receiver_panel(receiver, panel, buttons, full=False):
 	# b._insecure.set_visible(False)
 	buttons._unpair.set_visible(False)
 
-	may_pair = receiver.may_unpair and not is_pairing
+	may_pair = ( not is_pairing and 
+		     ( receiver.pairings() is None or receiver.pairings() != 0 ) )
 	if may_pair and devices_count >= receiver.max_devices:
-		online_devices = tuple(n for n in range(1, receiver.max_devices) if n in receiver and receiver[n].online)
+		online_devices = tuple(n for n in range(1, receiver.max_devices+1) if n in receiver and receiver[n].online)
 		may_pair &= len(online_devices) < receiver.max_devices
 	buttons._pair.set_sensitive(may_pair)
 	buttons._pair.set_visible(True)

--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -571,6 +571,10 @@ def _update_receiver_panel(receiver, panel, buttons, full=False):
 		paired_text += '\n\n<small>%s</small>' % ngettext('Up to %(max_count)s device can be paired to this receiver.', 'Up to %(max_count)s devices can be paired to this receiver.', receiver.max_devices) % { 'max_count': receiver.max_devices }
 	elif(devices_count > 0):
 		paired_text += '\n\n<small>%s</small>' % _('Only one device can be paired to this receiver.')
+	pairings = receiver.pairings(False) 
+	if ( pairings and pairings >= 0 ) :
+		paired_text += '\n<small>%s</small>' % _('This receiver has %d pairing(s) remaing.') % pairings
+
 
 	panel._count.set_markup(paired_text)
 


### PR DESCRIPTION
The receiver c534 is different from a Unifying receiver in several ways.
It can only pair with some keyboards and mice.  It can only pair with 2 (or 1, for some receivers) devices.
It can only perform a limited number of pairings.
It cannot unpair.  Pairing replaces a previously paired device of  the same kind.
Its serial number is in a different place - maybe, this change needs to be checked.   Will Logitech confirm?

This pull request improves handling of c534 and other non-Unifying receivers.
This pull request addresses Issues https://github.com/pwr-Solaar/Solaar/issues/598 and https://github.com/pwr-Solaar/Solaar/issues/579