### PR TITLE
don't have window always be on top

### DIFF
--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -337,7 +337,6 @@ def _create():
 	# window.set_type_hint(Gdk.WindowTypeHint.UTILITY)
 	# window.set_skip_taskbar_hint(True)
 	# window.set_skip_pager_hint(True)
-	window.set_keep_above(True)
 	window.connect('delete-event', _hide)
 
 	vbox = _create_window_layout()


### PR DESCRIPTION
The solaar window is set up to always be on top.  This can be very distracting.  It is also not needed as the window can always be shown by clicking on a receiver or device in the tray menu.
Closes #617