### PR TITLE
add --tray option - without this option solaar starts with window visible

### DIFF
--- a/lib/solaar/gtk.py
+++ b/lib/solaar/gtk.py
@@ -48,6 +48,7 @@ def _parse_arguments():
 							help='unifying receiver to use; the first detected receiver if unspecified. Example: /dev/hidraw2')
 	arg_parser.add_argument('--restart-on-wake-up', action='store_true',
 							help='restart Solaar on sleep wake-up (experimental)')
+	arg_parser.add_argument('-t', '--tray', action='store_true', help='start GUI with only tray icon')
 	arg_parser.add_argument('-V', '--version', action='version', version='%(prog)s ' + __version__)
 	arg_parser.add_argument('--help-actions', action='store_true',
 							help='print help for the optional actions')
@@ -105,7 +106,7 @@ def main():
 			_upower.watch(listener.ping_all)
 
 		# main UI event loop
-		ui.run_loop(listener.start_all, listener.stop_all)
+		ui.run_loop(listener.start_all, listener.stop_all, args.tray)
 	except Exception as e:
 		import sys
 		sys.exit('%s: error: %s' % (NAME.lower(), e))

--- a/lib/solaar/ui/__init__.py
+++ b/lib/solaar/ui/__init__.py
@@ -86,7 +86,7 @@ def ui_async(function, *args, **kwargs):
 from . import notify, tray, window
 
 
-def _startup(app, startup_hook):
+def _startup(app, startup_hook, tray_only):
 	if _log.isEnabledFor(_DEBUG):
 		_log.debug("startup registered=%s, remote=%s", app.get_is_registered(), app.get_is_remote())
 
@@ -97,7 +97,7 @@ def _startup(app, startup_hook):
 
 	notify.init()
 	tray.init(lambda _ignore: window.destroy())
-	window.init()
+	window.init(tray_only)
 
 	startup_hook()
 
@@ -133,12 +133,12 @@ def _shutdown(app, shutdown_hook):
 	notify.uninit()
 
 
-def run_loop(startup_hook, shutdown_hook, args=None):
+def run_loop(startup_hook, shutdown_hook, tray_only, args=None):
 	# from gi.repository.Gio import ApplicationFlags as _ApplicationFlags
 	APP_ID = 'io.github.pwr.solaar'
 	application = Gtk.Application.new(APP_ID, 0) # _ApplicationFlags.HANDLES_COMMAND_LINE)
 
-	application.connect('startup', _startup, startup_hook)
+	application.connect('startup', lambda app, startup_hook:_startup(app,startup_hook,tray_only), startup_hook)
 	application.connect('command-line', _command_line)
 	application.connect('activate', _activate)
 	application.connect('shutdown', _shutdown, shutdown_hook)

--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -345,7 +345,7 @@ def _create():
 	geometry = Gdk.Geometry()
 	geometry.min_width = 600
 	geometry.min_height = 320
-	geometry.max_width = 800
+	geometry.max_width = 1000
 	geometry.max_height = 600
 	window.set_geometry_hints(vbox, geometry, Gdk.WindowHints.MIN_SIZE | Gdk.WindowHints.MAX_SIZE)
 	window.set_position(Gtk.WindowPosition.CENTER)
@@ -726,7 +726,7 @@ _empty = None
 _window = None
 
 
-def init():
+def init(tray_only):
 	Gtk.Window.set_default_icon_name(NAME.lower())
 	Gtk.Window.set_default_icon_from_file(_icons.icon_file(NAME.lower()))
 
@@ -737,6 +737,7 @@ def init():
 	_info = _create_info_panel()
 	_empty = _create_empty_panel()
 	_window = _create()
+	if (not tray_only) : _window.present()
 
 
 def destroy():

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def _data_files():
 		yield _dirname(mo), [mo]
 
 	yield 'share/applications', ['share/applications/solaar.desktop']
-	yield autostart_path, ['share/applications/solaar.desktop']
+	yield autostart_path, ['share/applications/autostart/solaar.desktop']
 
 	del _dirname
 

--- a/share/applications/autostart/solaar.desktop
+++ b/share/applications/autostart/solaar.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Name=Solaar (window starts invisible)
+Comment=Logitech Unifying Receiver peripherals manager
+Comment[fr]=Gestionnaire de périphériques pour les récepteurs Logitech Unifying
+Comment[hr]=Upravitelj Logitechovih uređaja povezanih putem Unifying i Nano prijemnika
+Comment[ru]=Управление приёмником Logitech Unifying Receiver
+Exec=solaar --tray
+Icon=solaar
+StartupNotify=true
+Terminal=false
+Type=Application
+Keywords=logitech;unifying;receiver;mouse;keyboard;
+Categories=Utility;GTK;
+#Categories=Utility;GTK;Settings;HardwareSettings;


### PR DESCRIPTION
With this change
solaar
will start with the window visible (this is a change)
and
solaar -tray
will start with only the icon in the tray.

Documentation is in --help message.

Also create new desktop file for starting with window invisible and use this for autostart.