### PR TITLE
hidpp20: fix error when showing battery

### DIFF
--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -166,7 +166,6 @@ def _print_device(dev):
 				print ('             %s, pos:%d, group:%1d, gmask:%d' % ( ', '.join(flags), k.pos, k.group, k.group_mask))
 	if dev.online:
 		battery = _hidpp20.get_battery(dev)
-		(voltage, charging, charge_sts, charge_lvl, charge_type) = _hidpp20.get_voltage(dev)
 		if battery is None:
 			battery = _hidpp10.get_battery(dev)
 		if battery is not None:
@@ -180,10 +179,13 @@ def _print_device(dev):
 			else:
 				text = 'N/A'
 			print ('     Battery: %s, %s.' % (text, status))
-		elif voltage:
-			print ('     Battery: %smV, %s.' % (voltage, 'Charging' if charging else 'Discharging'))
 		else:
-			print ('     Battery status unavailable.')
+			battery_voltage = _hidpp20.get_voltage(dev)
+			if battery_voltage :
+				(voltage, charging, charge_sts, charge_lvl, charge_type) = battery_voltage
+				print ('     Battery: %smV, %s.' % (voltage, 'Charging' if charging else 'Discharging'))
+			else:
+				print ('     Battery status unavailable.')
 	else:
 		print ('     Battery: unknown (device is offline).')
 


### PR DESCRIPTION
This commit fixes the error I see when showing HID++ 1.0 mice.
I tried to keep the logic as close as possible to the change in the previous commit, but it seems to me that it would be better to have something like:
- if there is voltage information, show it
- otherwise show battery information (2.0 or 1.0)
- otherwise punt

This addresses #633 