### PR TITLE
receiver: use None for serial number of c534

### DIFF
--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -342,7 +342,7 @@ class Receiver(object):
 			self.serial = _strhex(serial_reply[1:5])
 			self.max_devices = ord(serial_reply[6:7])
 		else:
-			self.serial = 0
+			self.serial = None
 			self.max_devices = 6
 
 		if self.product_id == 'c539' or self.product_id == 'c53a' or self.product_id == 'c53f':

--- a/lib/solaar/cli/__init__.py
+++ b/lib/solaar/cli/__init__.py
@@ -98,7 +98,7 @@ def _find_receiver(receivers, name):
 	assert name
 
 	for r in receivers:
-		if name in r.name.lower() or name == r.serial.lower():
+		if name in r.name.lower() or (r.serial is not None and name == r.serial.lower()):
 			return r
 
 


### PR DESCRIPTION
This only fixes the error caused by using an integer for the serial number of c534.

It does not fix the number of pairable devices.  That needs more of my earlier changes for the c534, which are waiting for information from Logitech.

Addresses #636