### PR TITLE
better handling of DJ notifications and reports; don't halt on unexpected report IDs or lengths

### DIFF
--- a/lib/logitech_receiver/base.py
+++ b/lib/logitech_receiver/base.py
@@ -297,6 +297,7 @@ from collections import namedtuple
 _HIDPP_Notification = namedtuple('_HIDPP_Notification', ('devnumber', 'sub_id', 'address', 'data'))
 _HIDPP_Notification.__str__ = lambda self: 'Notification(%d,%02X,%02X,%s)' % (self.devnumber, self.sub_id, self.address, _strhex(self.data))
 _HIDPP_Notification.__unicode__ = _HIDPP_Notification.__str__
+DJ_NOTIFICATION_LENGTH = _MEDIUM_MESSAGE_SIZE - 4 # to allow easy distinguishing of DJ notifications
 del namedtuple
 
 #

--- a/lib/logitech_receiver/notifications.py
+++ b/lib/logitech_receiver/notifications.py
@@ -92,7 +92,7 @@ def _process_device_notification(device, status, n):
 	# HID++ 1.0 requests, should never get here
 	assert n.sub_id & 0x80 == 0
 
-	# 0x40 to 0x7F appear to be HID++ 1.0 notifications
+	# 0x40 to 0x7F appear to be HID++ 1.0 or DJ notifications
 	if n.sub_id >= 0x40:
 		return _process_hidpp10_notification(device, status, n)
 
@@ -184,6 +184,11 @@ def _process_hidpp10_notification(device, status, n):
 		else:
 			_log.warn("%s: connection notification with unknown protocol %02X: %s", device.number, n.address, n)
 
+		return True
+
+	if n.sub_id == 0x42:
+		if _log.isEnabledFor(_INFO):
+			_log.info("%s: ignoring DJ connection: %s", device, n)
 		return True
 
 	if n.sub_id == 0x49:


### PR DESCRIPTION
Solaar creates notifications for DJ reports, e.g., mouse movement and keystrokes.  
Solaar treats DJ notifications as HID++ 1.0 notifications resulting in warnings and errors.

This PR does not create notifications for DJ mouse movement and keystroke reports.
This PR segregates DJ notifications into their own handler, which currently ignores them all as the events that might cause changes have HID++ 1.0 notifications as well.

Instead of halting Solaar when a message with unexpected report id or size is found, log a waning and ignore the message.   This was tested by removing information on one of the expected report ids and size - Solaar correctly handled the now-unexpected messages.
