### PR TITLE
fix sensitivity of Pair new device button

### DIFF
--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -593,8 +593,8 @@ def _update_receiver_panel(receiver, panel, buttons, full=False):
 
 	may_pair = receiver.may_unpair and not is_pairing
 	if may_pair and devices_count >= receiver.max_devices:
-		online_devices = tuple(n for n in range(1, receiver.max_devices) if n in receiver and receiver[n].online)
-		may_pair &= len(online_devices) < receiver.max_devices
+		paired_devices = tuple(n for n in range(1, receiver.max_devices+1) if n in receiver)
+		may_pair &= len(paired_devices) < receiver.max_devices
 	buttons._pair.set_sensitive(may_pair)
 	buttons._pair.set_visible(True)
 


### PR DESCRIPTION
Offline devices should not be counted when determining whether a receiver has open slots to pair in.

This PR replaces #631 but has the same changes is that PR does.