### PR TITLE
fix problem with Solaar not applying saved settings for features discovered at run time

### DIFF
--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -30,12 +30,12 @@ from .settings_templates import RegisterSettings as _RS, FeatureSettings as _FS
 
 from collections import namedtuple
 _DeviceDescriptor = namedtuple('_DeviceDescriptor',
-				('name', 'kind', 'wpid', 'codename', 'protocol', 'registers', 'settings'))
+				('name', 'kind', 'wpid', 'codename', 'protocol', 'registers', 'settings', 'persister'))
 del namedtuple
 
 DEVICES = {}
 
-def _D(name, codename=None, kind=None, wpid=None, protocol=None, registers=None, settings=None):
+def _D(name, codename=None, kind=None, wpid=None, protocol=None, registers=None, settings=None, persister=None):
 	assert name
 
 	if kind is None:
@@ -72,7 +72,7 @@ def _D(name, codename=None, kind=None, wpid=None, protocol=None, registers=None,
 
 	device_descriptor = _DeviceDescriptor(name=name, kind=kind,
 					wpid=wpid, codename=codename, protocol=protocol,
-					registers=registers, settings=settings)
+					registers=registers, settings=settings, persister=persister)
 
 	assert codename not in DEVICES, 'duplicate codename in device descriptors: %s' % (DEVICES[codename], )
 	DEVICES[codename] = device_descriptor

--- a/lib/solaar/configuration.py
+++ b/lib/solaar/configuration.py
@@ -127,7 +127,4 @@ def attach_to(device):
 		_load()
 
 	persister = _device_entry(device)
-	for s in device.settings:
-		if s.persister is None:
-			s.persister = persister
-		assert s.persister == persister
+	device.persister = persister


### PR DESCRIPTION
Solaar attaches the saved device settings to each individual setting, but this is not done for features discovered at run time.  This patch moves the saved device settings from the individual settings to the device itself, which is, I think, a better place for them.  Individual settings then get the saved device settings from the device and also store changes there.
Fixes #551 

