### PR TITLE
don't remove already-disconnected devices; change receiver usb list entries to dictionary;  get receiver name from list of receivers; better printing of receivers

### DIFF
--- a/lib/hidapi/udev.py
+++ b/lib/hidapi/udev.py
@@ -78,7 +78,13 @@ def exit():
 	return True
 
 
-def _match(action, device, vendor_id=None, product_id=None, interface_number=None, hid_driver=None):
+# The filter is used to determine whether this is a device of interest to Solaar
+def _match(action, device, filter):
+	vendor_id=filter.get('vendor_id')
+	product_id=filter.get('product_id')
+	interface_number=filter.get('usb_interface')
+	hid_driver=filter.get('hid_driver')
+
 	usb_device = device.find_parent('usb', 'usb_device')
 	# print ("* parent", action, device, "usb:", usb_device)
 	if not usb_device:
@@ -164,7 +170,7 @@ def monitor_glib(callback, *device_filters):
 				# print ("***", action, device)
 				if action == 'add':
 					for filter in filters:
-						d_info = _match(action, device, *filter)
+						d_info = _match(action, device, filter)
 						if d_info:
 							GLib.idle_add(cb, action, d_info)
 							break
@@ -189,7 +195,7 @@ def monitor_glib(callback, *device_filters):
 	m.start()
 
 
-def enumerate(vendor_id=None, product_id=None, interface_number=None, hid_driver=None):
+def enumerate(usb_id):
 	"""Enumerate the HID Devices.
 
 	List all the HID devices attached to the system, optionally filtering by
@@ -197,8 +203,9 @@ def enumerate(vendor_id=None, product_id=None, interface_number=None, hid_driver
 
 	:returns: a list of matching ``DeviceInfo`` tuples.
 	"""
+
 	for dev in _Context().list_devices(subsystem='hidraw'):
-		dev_info = _match('add', dev, vendor_id, product_id, interface_number, hid_driver)
+		dev_info = _match('add', dev, usb_id)
 		if dev_info:
 			yield dev_info
 

--- a/lib/hidapi/udev.py
+++ b/lib/hidapi/udev.py
@@ -92,6 +92,8 @@ def _match(action, device, filter):
 
 	vid = usb_device.get('ID_VENDOR_ID')
 	pid = usb_device.get('ID_MODEL_ID')
+	if vid is None or pid is None:
+		return # there are reports that sometimes the usb_device isn't set up right so be defensive
 	if not ((vendor_id is None or vendor_id == int(vid, 16)) and
 			(product_id is None or product_id == int(pid, 16))):
 		return

--- a/lib/logitech_receiver/base.py
+++ b/lib/logitech_receiver/base.py
@@ -83,7 +83,7 @@ from .base_usb import ALL as _RECEIVER_USB_IDS
 def receivers():
 	"""List all the Linux devices exposed by the UR attached to the machine."""
 	for receiver_usb_id in _RECEIVER_USB_IDS:
-		for d in _hid.enumerate(*receiver_usb_id):
+		for d in _hid.enumerate(receiver_usb_id):
 			yield d
 
 

--- a/lib/logitech_receiver/base_usb.py
+++ b/lib/logitech_receiver/base_usb.py
@@ -105,3 +105,11 @@ ALL = (
 		LIGHTSPEED_RECEIVER_C53a,
 		LIGHTSPEED_RECEIVER_C53f,
 	)
+
+def product_information(usb_id):
+	if isinstance(usb_id,str):
+		usb_id = int(usb_id,16)
+	for r in ALL:
+		if usb_id == r.get('product_id'):
+			return r
+	return { }

--- a/lib/logitech_receiver/base_usb.py
+++ b/lib/logitech_receiver/base_usb.py
@@ -26,11 +26,37 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 _DRIVER = ('hid-generic', 'generic-usb', 'logitech-djreceiver')
 
 
-# each tuple contains (vendor_id, product_id, usb interface number, hid driver)
-_unifying_receiver = lambda product_id: (0x046d, product_id, 2, _DRIVER)
-_nano_receiver = lambda product_id: (0x046d, product_id, 1, _DRIVER)
-_lenovo_receiver = lambda product_id: (0x17ef, product_id, 1, _DRIVER)
-_lightspeed_receiver = lambda product_id: (0x046d, product_id, 2, _DRIVER)
+_unifying_receiver = lambda product_id: {
+	'vendor_id':0x046d,
+	'product_id':product_id, 
+	'usb_interface':2,
+	'hid_driver':_DRIVER,
+	'name':'Unifying Receiver'
+}
+
+_nano_receiver = lambda product_id: {
+	'vendor_id':0x046d,
+	'product_id':product_id,
+	'usb_interface':1,
+	'hid_driver':_DRIVER,
+	'name':'Nano Receiver'
+}
+
+_lenovo_receiver = lambda product_id: {
+	'vendor_id':0x17ef, 
+	'product_id':product_id, 
+	'usb_interface':1, 
+	'hid_driver':_DRIVER, 
+	'name':'Nano Receiver'
+}
+
+_lightspeed_receiver = lambda product_id: {
+	'vendor_id':0x046d,
+	'product_id':product_id,
+	'usb_interface':2,
+	'hid_driver':_DRIVER,
+	'name':'Lightspeed Receiver'
+}
 
 # standard Unifying receivers (marked with the orange Unifying logo)
 UNIFYING_RECEIVER_C52B    = _unifying_receiver(0xc52b)

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -33,6 +33,7 @@ from . import hidpp20 as _hidpp20
 from .common import strhex as _strhex
 from .descriptors import DEVICES as _DESCRIPTORS
 from .settings_templates import check_feature_settings as _check_feature_settings
+from .base_usb import product_information as _product_information
 
 _R = _hidpp10.REGISTERS
 
@@ -345,14 +346,10 @@ class Receiver(object):
 			self.serial = None
 			self.max_devices = 6
 
-		if self.product_id == 'c539' or self.product_id == 'c53a' or self.product_id == 'c53f':
-			self.name = 'Lightspeed Receiver'
-		elif self.max_devices == 6:
-			self.name = 'Unifying Receiver'
-		elif self.max_devices < 6:
-			self.name = 'Nano Receiver'
-		else:
-			raise Exception("unknown receiver type", self.max_devices)
+		product_info = _product_information(self.product_id)
+		if not product_info:
+			raise Exception("unknown receiver type", self.product_id)
+		self.name = product_info.get('name','')
 		self._str = '<%s(%s,%s%s)>' % (self.name.replace(' ', ''), self.path, '' if isinstance(self.handle, int) else 'T', self.handle)
 
 		# TODO _properly_ figure out which receivers do and which don't support unpairing

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -311,7 +311,7 @@ class PairedDevice(object):
 	__bool__ = __nonzero__ = lambda self: self.wpid is not None and self.number in self.receiver
 
 	def __str__(self):
-		return '<PairedDevice(%d,%s,%s)>' % (self.number, self.wpid, self.codename or '?')
+		return '<PairedDevice(%d,%s,%s,%s)>' % (self.number, self.wpid, self.codename or '?', self.serial)
 	__unicode__ = __repr__ = __str__
 
 #

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -30,7 +30,7 @@ from logitech_receiver import (
 def _print_receiver(receiver):
 	paired_count = receiver.count()
 
-	print ('Unifying Receiver')
+	print (receiver.name)
 	print ('  Device path  :', receiver.path)
 	print ('  USB id       : 046d:%s' % receiver.product_id)
 	print ('  Serial       :', receiver.serial)

--- a/lib/solaar/listener.py
+++ b/lib/solaar/listener.py
@@ -195,6 +195,9 @@ class ReceiverListener(_listener.EventsListener):
 		if not device_ready:
 			time.sleep(0.01)
 
+		if n.sub_id == 0x40 and not already_known:
+			return # disconnecting something that is not known - nothing to do
+
 		if n.sub_id == 0x41 and not already_known:
 			dev = self.receiver.register_new_device(n.devnumber, n)
 		else:


### PR DESCRIPTION
Fixes #657 

Code cleanup:
Create list of lightspeed receiver usb ids instead of checking directly

Better output (solaar show and debugging):
Show type of receiver in solaar show
Add serial number in stringify of receivers.