### PR TITLE
Remove solaar-gnome3

### DIFF
--- a/docs/debian.md
+++ b/docs/debian.md
@@ -5,4 +5,4 @@ layout: page
 
 # Debian repository
 
-Solaar is now part of the [official debian repository](https://packages.debian.org/solaar-gnome3), to install it on your debian machine, use the following command: `sudo apt install solaar-gnome3`
+Solaar is now part of the [official debian repository](https://packages.debian.org/solaar), to install it on your debian machine, use the following command: `sudo apt install solaar`

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,17 +64,16 @@ Pre-built packages are available for a few Linux distros.
 
 * Arch `solaar` package in the [community repository][arch]
 * Debian 7 (Wheezy) or higher: packages in this [repository](https://pwr-solaar.github.io/Solaar/debian)
-* Ubuntu/Kubuntu 16.04+: use the `solaar-gnome3` and/or `solaar` package from [universe repository][universe repository]
-* Ubuntu/Kubuntu stable packages: use `solaar-gnome3` and/or `solaar`  package from [Solaar stable ppa][ppa2]
-* Ubuntu/Kubuntu git build packages: use `solaar-gnome3` and/or `solaar`  package from [Solaar git ppa][ppa1]
+* Ubuntu/Kubuntu 16.04+: use the `solaar` package from [universe repository][universe repository]
+* Ubuntu/Kubuntu stable packages: use the `solaar` package from [Solaar stable ppa][ppa2]
+* Ubuntu/Kubuntu git build packages: use the `solaar` package from [Solaar git ppa][ppa1]
 * a [Fedora package][fedora], courtesy of Eric Smith
 * a [Gentoo package][gentoo], courtesy of Carlos Silva and Tim Harder
 * a [Mageia package][mageia], courtesy of David Geiger
 * an [OpenSUSE rpm][opensuse], courtesy of Mathias Homann
 * an [Ubuntu/Kubuntu git and stable ppa][ppa3], courtesy of [gogo][ppa4]
 
-The `solaar` package uses a standard system tray implementation; to ensure
-integration with *gnome-shell* or *Unity*, install `solaar-gnome3`.
+The `solaar` package uses a standard system tray implementation; `solaar-gnome3` is no longer required for `gnome` or `unity` integration.
 
 [ppa4]: https://launchpad.net/~trebelnik-stefina
 [ppa3]: https://launchpad.net/~solaar-unifying

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -18,22 +18,8 @@ Depends: ${misc:Depends}, ${debconf:Depends}, udev (>= 175), passwd | adduser,
  ${solaar:Desktop-Icon-Theme}
 Recommends: gir1.2-notify-0.7, consolekit (>= 0.4.3) | systemd (>= 44),
  python-dbus (>= 1.1.0), upower
-Suggests: gir1.2-appindicator3-0.1, solaar-gnome3 (= ${source:Version})
+Suggests: gir1.2-appindicator3-0.1
 Description: Logitech Unifying Receiver peripherals manager for Linux
  Solaar is a Linux device manager for Logitech's Unifying Receiver peripherals.
  It is able to pair/unpair devices to the receiver, and for some devices read
  battery status.
-
-Package: solaar-gnome3
-Architecture: all
-Section: gnome
-Depends: ${misc:Depends}, solaar (= ${source:Version}),
- gir1.2-appindicator3-0.1, gnome-shell (>= 3.4) | unity (>= 5.10),
- ${solaar:Gnome-Icon-Theme}
-Enhances: solaar
-Description: gnome-shell/Unity integration for Solaar
- Solaar is a Linux device manager for Logitech's Unifying Receiver peripherals.
- It is able to pair/unpair devices to the receiver, and for some devices read
- battery status.
- .
- This metapackage ensures integration with gnome-shell/Unity.


### PR DESCRIPTION
After much discussion, it seems `solaar-gnome3` is no longer needed, as the `solaar` package handles app indicators perfectly, and there appears to be no more use case for `solaar-gnome3` as a separate package. 

Addresses https://github.com/pwr-Solaar/Solaar/issues/656