### PR TITLE
scripts/debian: switch to python3

### DIFF
--- a/bin/solaar
+++ b/bin/solaar
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- python-mode -*-
 # -*- coding: UTF-8 -*-
 

--- a/bin/solaar-cli
+++ b/bin/solaar-cli
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- python-mode -*-
 # -*- coding: UTF-8 -*-
 

--- a/lib/solaar/gtk.py
+++ b/lib/solaar/gtk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- python-mode -*-
 # -*- coding: UTF-8 -*-
 

--- a/lib/solaar/tasks.py
+++ b/lib/solaar/tasks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- python-mode -*-
 # -*- coding: UTF-8 -*-
 

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -14,7 +14,7 @@ Vcs-browser: http://github.com/pwr/Solaar
 Package: solaar
 Architecture: all
 Depends: ${misc:Depends}, ${debconf:Depends}, udev (>= 175), passwd | adduser,
- ${python:Depends}, python-pyudev (>= 0.13), python-gi (>= 3.2), gir1.2-gtk-3.0 (>= 3.4),
+ ${python:Depends}, python3-pyudev (>= 0.13), python-gi (>= 3.2), gir1.2-gtk-3.0 (>= 3.4),
  ${solaar:Desktop-Icon-Theme}
 Recommends: gir1.2-notify-0.7, consolekit (>= 0.4.3) | systemd (>= 44),
  python-dbus (>= 1.1.0), upower

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from glob import glob as _glob
 try:

--- a/tools/hidconsole
+++ b/tools/hidconsole
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- python-mode -*-
 """Takes care of starting the main function."""
 


### PR DESCRIPTION
As an outcome of issues #652 and #653 , looks like Solaar does not support python2 anymore at least under Debian/Ubuntu and their derivatives. 
The following pull request updates python version. There are separate deb packages for python3-pyudev and python-pyudev, so the pull request updates deb package dependency as well.
Under Arch, python-pyudev contains code for python3 so no update is required. Probably the same for Gentoo, but could not check that.