### PR TITLE
solaar: use python3, not generic python

### DIFF
--- a/bin/solaar
+++ b/bin/solaar
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- python-mode -*-
 # -*- coding: UTF-8 -*-
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from glob import glob as _glob
 try:


### PR DESCRIPTION
Force use of python3 in solaar and setup.py