### PR TITLE
receiver: battery level 0 is unknown level

### DIFF
--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -520,6 +520,7 @@ def get_battery(device):
 	battery = feature_request(device, FEATURE.BATTERY_STATUS)
 	if battery:
 		discharge, dischargeNext, status = _unpack('!BBB', battery[:3])
+		discharge = None if discharge == 0 else discharge
 		if _log.isEnabledFor(_DEBUG):
 			_log.debug("device %d battery %d%% charged, next level %d%% charge, status %d = %s",
 						device.number, discharge, dischargeNext, status, BATTERY_STATUS[status])

--- a/lib/logitech_receiver/notifications.py
+++ b/lib/logitech_receiver/notifications.py
@@ -211,6 +211,7 @@ def _process_feature_notification(device, status, n, feature):
 	if feature == _F.BATTERY_STATUS:
 		if n.address == 0x00:
 			discharge_level = ord(n.data[:1])
+			discharge_level = None if discharge_level == 0 else discharge_level
 			discharge_next_level = ord(n.data[1:2])
 			battery_status = ord(n.data[2:3])
 			status.set_battery_info(discharge_level, _hidpp20.BATTERY_STATUS[battery_status])

--- a/lib/logitech_receiver/status.py
+++ b/lib/logitech_receiver/status.py
@@ -191,7 +191,7 @@ class DeviceStatus(dict):
 		changed = old_level != level or old_status != status or old_charging != charging
 		alert, reason = ALERT.NONE, None
 
-		if _hidpp20.BATTERY_OK(status) and level > _BATTERY_ATTENTION_LEVEL:
+		if _hidpp20.BATTERY_OK(status) and ( level is None or level > _BATTERY_ATTENTION_LEVEL ):
 			self[KEYS.ERROR] = None
 		else:
 			_log.warn("%s: battery %d%%, ALERT %s", self._device, level, status)


### PR DESCRIPTION
The Logitech specs say that 0 for BatteryDischargeLevel in 0x1000 is not 0% but is instead unknown.  Solaar incorrectly records it as 0%.   Fortunately most uses of this information handle None specially, so not much code needs to be changed.

Fixes #265 

I don't have the hardware to test this but have asked the reporters to test it.