### PR TITLE
Support receivers that don't unpair but replace when pairing, like c534

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -45,7 +45,7 @@ receivers.  For Unifying receivers, pairing adds a new paired device, but
 only if there is an open slot on the receiver.  So these receivers need to
 be able to unpair devices that they have been paired with or else they will
 not have any open slots for pairing.  Some other receivers, like the
-receiver with USB ID `046d:c532`, can only pair with particular kinds of
+Nano receiver with USB ID `046d:c534`, can only pair with particular kinds of
 devices and pairing a new device replaces whatever device of that kind was
 previously paired to the receiver.  These receivers cannot unpair.  Further,
 some receivers can pair an unlimited number of times but others can only

--- a/lib/logitech_receiver/base_usb.py
+++ b/lib/logitech_receiver/base_usb.py
@@ -25,6 +25,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 _DRIVER = ('hid-generic', 'generic-usb', 'logitech-djreceiver')
 
+# max_devices is only used for receivers that do not support reading from _R.receiver_info offset 0x03, default to 1
+# may_unpair is only used for receivers that do not support reading from _R.receiver_info offset 0x03, default to False
+## should this last be changed so that may_unpair is used for all receivers? writing to _R.receiver_pairing doesn't seem right
+# re_pairs determines whether a receiver pairs by replacing existing pairings, default to False
+## currently only one receiver is so marked - should there be more?
 
 _unifying_receiver = lambda product_id: {
 	'vendor_id':0x046d,
@@ -40,6 +45,17 @@ _nano_receiver = lambda product_id: {
 	'usb_interface':1,
 	'hid_driver':_DRIVER,
 	'name':'Nano Receiver'
+}
+
+_nano_receiver_max2 = lambda product_id: {
+	'vendor_id':0x046d,
+	'product_id':product_id,
+	'usb_interface':1,
+	'hid_driver':_DRIVER,
+	'name':'Nano Receiver',
+	'max_devices': 2,
+	'may_unpair': False,
+	're_pairs': True 
 }
 
 _lenovo_receiver = lambda product_id: {
@@ -75,7 +91,7 @@ NANO_RECEIVER_C525        = _nano_receiver(0xc525)
 NANO_RECEIVER_C526        = _nano_receiver(0xc526)
 NANO_RECEIVER_C52e        = _nano_receiver(0xc52e)
 NANO_RECEIVER_C531        = _nano_receiver(0xc531)
-NANO_RECEIVER_C534        = _nano_receiver(0xc534)
+NANO_RECEIVER_C534        = _nano_receiver_max2(0xc534)
 NANO_RECEIVER_6042        = _lenovo_receiver(0x6042)
 
 # Lightspeed receivers

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -490,18 +490,25 @@ class Receiver(object):
 				del self._devices[key]
 			return
 
-		action = 0x03
-		reply = self.write_register(_R.receiver_pairing, action, key)
-		if reply:
-			# invalidate the device
+		if self.re_pairs:
+			# invalidate the device, but these receivers don't unpair per se
 			dev.online = False
 			dev.wpid = None
 			if key in self._devices:
 				del self._devices[key]
-			_log.warn("%s unpaired device %s", self, dev)
+			_log.warn("%s removed device %s", self, dev)
 		else:
-			_log.error("%s failed to unpair device %s", self, dev)
-			raise IndexError(key)
+			reply = self.write_register(_R.receiver_pairing, 0x03, key)
+			if reply:
+				# invalidate the device
+				dev.online = False
+				dev.wpid = None
+				if key in self._devices:
+					del self._devices[key]
+				_log.warn("%s unpaired device %s", self, dev)
+			else:
+				_log.error("%s failed to unpair device %s", self, dev)
+				raise IndexError(key)
 
 	def __len__(self):
 		return len([d for d in self._devices.values() if d is not None])

--- a/lib/solaar/cli/pair.py
+++ b/lib/solaar/cli/pair.py
@@ -57,8 +57,12 @@ def run(receivers, args, find_receiver, _ignore):
 			assert n
 			if n.devnumber == 0xFF:
 				_notifications.process(receiver, n)
-			elif n.sub_id == 0x41 and n.address == 0x04:
+			elif n.sub_id == 0x41: # allow for other protocols! (was and n.address == 0x04)
 				if n.devnumber not in known_devices:
+					receiver.status.new_device = receiver[n.devnumber]
+				elif receiver.re_pairs:
+		                        # unfortunately this breaks encapsulation but the nice way tries to unpair
+					del receiver._devices[n.devnumber] # get rid of information on device re-paired away
 					receiver.status.new_device = receiver[n.devnumber]
 
 	timeout = 20  # seconds

--- a/lib/solaar/cli/pair.py
+++ b/lib/solaar/cli/pair.py
@@ -87,5 +87,9 @@ def run(receivers, args, find_receiver, _ignore):
 		dev = receiver.status.new_device
 		print ('Paired device %d: %s (%s) [%s:%s]' % (dev.number, dev.name, dev.codename, dev.wpid, dev.serial))
 	else:
-		error = receiver.status.get(_status.KEYS.ERROR) or 'no device detected?'
-		raise Exception("pairing failed: %s" % error)
+		error = receiver.status.get(_status.KEYS.ERROR)
+		if error :
+			raise Exception("pairing failed: %s" % error)
+		else :
+			print ('Paired a device') # this is better than an error
+

--- a/lib/solaar/cli/pair.py
+++ b/lib/solaar/cli/pair.py
@@ -61,8 +61,7 @@ def run(receivers, args, find_receiver, _ignore):
 				if n.devnumber not in known_devices:
 					receiver.status.new_device = receiver[n.devnumber]
 				elif receiver.re_pairs:
-		                        # unfortunately this breaks encapsulation but the nice way tries to unpair
-					del receiver._devices[n.devnumber] # get rid of information on device re-paired away
+					del receiver[n.devnumber] # get rid of information on device re-paired away
 					receiver.status.new_device = receiver[n.devnumber]
 
 	timeout = 20  # seconds

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -38,6 +38,8 @@ def _print_receiver(receiver):
 		print ('    %-11s: %s' % (f.kind, f.version))
 
 	print ('  Has', paired_count, 'paired device(s) out of a maximum of %d.' % receiver.max_devices)
+	if receiver.remaining_pairings() and receiver.remaining_pairings() >= 0 :
+		print ('  Has %d successful pairing(s) remaining.' % receiver.remaining_pairings() )
 
 	notification_flags = _hidpp10.get_notification_flags(receiver)
 	if notification_flags is not None:

--- a/lib/solaar/cli/unpair.py
+++ b/lib/solaar/cli/unpair.py
@@ -27,6 +27,10 @@ def run(receivers, args, find_receiver, find_device):
 	device_name = args.device.lower()
 	dev = find_device(receivers, device_name)
 
+	if not dev.receiver.may_unpair :
+		print('Receiver for %s [%s:%s] does not unpair' % (dev.name,dev.wpid,dev.serial))
+		return
+
 	# query these now, it's last chance to get them
 	try:
 		number, codename, wpid, serial  = dev.number, dev.codename, dev.wpid, dev.serial

--- a/lib/solaar/listener.py
+++ b/lib/solaar/listener.py
@@ -201,7 +201,7 @@ class ReceiverListener(_listener.EventsListener):
 		if n.sub_id == 0x41:
 			if not already_known:
 				dev = self.receiver.register_new_device(n.devnumber, n)
-			elif self.receiver.status.lock_open and self.receiver.re_pairs:
+			elif self.receiver.status.lock_open and self.receiver.re_pairs and not ord(n.data[0:1]) & 0x40:
 				dev = self.receiver[n.devnumber]
 				del self.receiver[n.devnumber] # get rid of information on device re-paired away
 				self._status_changed(dev) # signal that this device has changed

--- a/lib/solaar/listener.py
+++ b/lib/solaar/listener.py
@@ -198,8 +198,17 @@ class ReceiverListener(_listener.EventsListener):
 		if n.sub_id == 0x40 and not already_known:
 			return # disconnecting something that is not known - nothing to do
 
-		if n.sub_id == 0x41 and not already_known:
-			dev = self.receiver.register_new_device(n.devnumber, n)
+		if n.sub_id == 0x41:
+			if not already_known:
+				dev = self.receiver.register_new_device(n.devnumber, n)
+			elif self.receiver.status.lock_open and self.receiver.re_pairs:
+				dev = self.receiver[n.devnumber]
+				del self.receiver[n.devnumber] # get rid of information on device re-paired away
+				self._status_changed(dev) # signal that this device has changed
+				dev = self.receiver.register_new_device(n.devnumber, n)
+				self.receiver.status.new_device = self.receiver[n.devnumber]
+			else:
+				dev = self.receiver[n.devnumber]
 		else:
 			dev = self.receiver[n.devnumber]
 

--- a/lib/solaar/ui/pair_window.py
+++ b/lib/solaar/ui/pair_window.py
@@ -201,9 +201,14 @@ def create(receiver):
 	assistant.set_resizable(False)
 	assistant.set_role('pair-device')
 
+	page_text = _("If the device is already turned on, turn if off and on again.")
+	if receiver.remaining_pairings():
+		page_text += _("\n\nThis receiver has %d pairing(s) remaining.")%receiver.remaining_pairings()
+		page_text += _("\nCancelling at this point will not use up a pairing.")
+
 	page_intro = _create_page(assistant, Gtk.AssistantPageType.PROGRESS,
 					_("Turn on the device you want to pair."), 'preferences-desktop-peripherals',
-					_("If the device is already turned on,\nturn if off and on again."))
+					page_text)
 	spinner = Gtk.Spinner()
 	spinner.set_visible(True)
 	page_intro.pack_end(spinner, True, True, 24)

--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -595,8 +595,9 @@ def _update_receiver_panel(receiver, panel, buttons, full=False):
 	# b._insecure.set_visible(False)
 	buttons._unpair.set_visible(False)
 
-	may_pair = receiver.may_unpair and not is_pairing
-	if may_pair and devices_count >= receiver.max_devices:
+	may_pair = ( receiver.may_unpair or receiver.re_pairs ) and not is_pairing and \
+		( receiver.remaining_pairings() is None or receiver.remaining_pairings() != 0 )
+	if may_pair and not receiver.re_pairs and devices_count >= receiver.max_devices:
 		paired_devices = tuple(n for n in range(1, receiver.max_devices+1) if n in receiver)
 		may_pair &= len(paired_devices) < receiver.max_devices
 	buttons._pair.set_sensitive(may_pair)

--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -572,6 +572,9 @@ def _update_receiver_panel(receiver, panel, buttons, full=False):
 		paired_text += '\n\n<small>%s</small>' % ngettext('Up to %(max_count)s device can be paired to this receiver.', 'Up to %(max_count)s devices can be paired to this receiver.', receiver.max_devices) % { 'max_count': receiver.max_devices }
 	elif(devices_count > 0):
 		paired_text += '\n\n<small>%s</small>' % _('Only one device can be paired to this receiver.')
+	pairings = receiver.remaining_pairings(False) 
+	if ( pairings is not None and pairings >= 0 ) :
+		paired_text += '\n<small>%s</small>' % _('This receiver has %d pairing(s) remaining.') % pairings
 
 	panel._count.set_markup(paired_text)
 


### PR DESCRIPTION
Correctly handle receivers like the c534:

Support devices that only allow a limited number of total re-pairings
Support devices that do not unpair or when pairing replace existing pairings
Add information about max_pairings, unpairing, and re-pairing to the list of receivers by USB id
Set up c534 as receiver with max 2 pairings, no unpairing, re-pairing

It may be that all nano receivers work the same way as the c534.  This PR only sets up the c534, as that is the only nano receiver I have access to.  Changing all nano receivers to work this way is simply a matter of changing _nano_receiver in base_usb.py

This updates PR #614
