### PR TITLE
Extend changes for c534 to all nano receivers

### DIFF
--- a/lib/logitech_receiver/base_usb.py
+++ b/lib/logitech_receiver/base_usb.py
@@ -44,7 +44,9 @@ _nano_receiver = lambda product_id: {
 	'product_id':product_id,
 	'usb_interface':1,
 	'hid_driver':_DRIVER,
-	'name':'Nano Receiver'
+	'name':'Nano Receiver',
+	'may_unpair': False,
+	're_pairs': True 
 }
 
 _nano_receiver_max2 = lambda product_id: {

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -336,10 +336,9 @@ class Receiver(object):
 		self.product_id = device_info.product_id
 		product_info = _product_information(self.product_id)
 		if not product_info:
-			raise Exception("unknown receiver type", self.product_id)
+			raise Exception("Unknown receiver type", self.product_id)
 
 		# read the serial immediately, so we can find out max_devices
-		# this will tell us if it's a Unifying or Nano receiver
 		serial_reply = self.read_register(_R.receiver_info, 0x03)
 		if serial_reply :
 			self.serial = _strhex(serial_reply[1:5])
@@ -376,7 +375,7 @@ class Receiver(object):
 
 	# how many pairings remain (None for unknown, -1 for unlimited)
 	def remaining_pairings(self,cache=True):
-		if self._remaining_pairings is None or not cache :
+		if self._remaining_pairings is None or not cache:
 			ps = self.read_register(_R.receiver_connection)
 			if ps is not None:
 				ps = ord(ps[2:3])

--- a/lib/solaar/cli/unpair.py
+++ b/lib/solaar/cli/unpair.py
@@ -27,7 +27,7 @@ def run(receivers, args, find_receiver, find_device):
 	device_name = args.device.lower()
 	dev = find_device(receivers, device_name)
 
-	if not dev.receiver.may_unpair :
+	if not dev.receiver.may_unpair:
 		print('Receiver for %s [%s:%s] does not unpair' % (dev.name,dev.wpid,dev.serial))
 		return
 

--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -569,7 +569,7 @@ def _update_receiver_panel(receiver, panel, buttons, full=False):
 
 	if(receiver.max_devices > 0):
 		paired_text += '\n\n<small>%s</small>' % ngettext('Up to %(max_count)s device can be paired to this receiver.', 'Up to %(max_count)s devices can be paired to this receiver.', receiver.max_devices) % { 'max_count': receiver.max_devices }
-	elif(devices_count > 0):
+	elif devices_count > 0:
 		paired_text += '\n\n<small>%s</small>' % _('Only one device can be paired to this receiver.')
 	pairings = receiver.remaining_pairings(False) 
 	if ( pairings is not None and pairings >= 0 ) :
@@ -594,12 +594,16 @@ def _update_receiver_panel(receiver, panel, buttons, full=False):
 	# b._insecure.set_visible(False)
 	buttons._unpair.set_visible(False)
 
-	may_pair = ( receiver.may_unpair or receiver.re_pairs ) and not is_pairing and \
-		( receiver.remaining_pairings() is None or receiver.remaining_pairings() != 0 )
-	if may_pair and not receiver.re_pairs and devices_count >= receiver.max_devices:
-		paired_devices = tuple(n for n in range(1, receiver.max_devices+1) if n in receiver)
-		may_pair &= len(paired_devices) < receiver.max_devices
-	buttons._pair.set_sensitive(may_pair)
+	if ( receiver.may_unpair or receiver.re_pairs ) and not is_pairing and \
+	   ( receiver.remaining_pairings() is None or receiver.remaining_pairings() != 0 ):
+		if not receiver.re_pairs and devices_count >= receiver.max_devices:
+			paired_devices = tuple(n for n in range(1, receiver.max_devices+1) if n in receiver)
+			buttons._pair.set_sensitive(len(paired_devices) < receiver.max_devices)
+		else:
+			buttons._pair.set_sensitive(True)
+	else:
+		buttons._pair.set_sensitive(False)
+
 	buttons._pair.set_visible(True)
 
 


### PR DESCRIPTION
Make other nano receivers not unpair and replace when pairing.   Extends PR #674

I don't have any such receivers so I am unable to test whether all nano receivers work this way.

Fixes #406