### PR TITLE
ui: don't show warning in pairing window for receivers with unlimited pairing

### DIFF
--- a/lib/solaar/ui/pair_window.py
+++ b/lib/solaar/ui/pair_window.py
@@ -202,7 +202,7 @@ def create(receiver):
 	assistant.set_role('pair-device')
 
 	page_text = _("If the device is already turned on, turn if off and on again.")
-	if receiver.remaining_pairings():
+	if receiver.remaining_pairings() and receiver.remaining_pairings() >= 0:
 		page_text += _("\n\nThis receiver has %d pairing(s) remaining.")%receiver.remaining_pairings()
 		page_text += _("\nCancelling at this point will not use up a pairing.")
 


### PR DESCRIPTION
I messed up the logic for showing the warning in the pairing window. 
Now the warning only shows up for devices that have a limited number of pairings.