### PR TITLE
ui: add quit button to main window

### DIFF
--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -306,6 +306,10 @@ def _create_window_layout():
 
 	bottom_buttons_box = Gtk.ButtonBox(Gtk.Orientation.HORIZONTAL)
 	bottom_buttons_box.set_layout(Gtk.ButtonBoxStyle.START)
+	bottom_buttons_box.set_spacing(20)
+	quit_button = _new_button(_("Quit") + ' ' + NAME,  'application-exit', 
+					icon_size=_SMALL_BUTTON_ICON_SIZE, clicked=destroy)
+	bottom_buttons_box.add(quit_button)
 	about_button = _new_button(_("About") + ' ' + NAME, 'help-about',
 					icon_size=_SMALL_BUTTON_ICON_SIZE, clicked=_show_about_window)
 	bottom_buttons_box.add(about_button)


### PR DESCRIPTION
Using some code in a suggestion in #662 I added a quit button to the main window.
This allows completely quitting Solaar from the main window when the tray is active instead of having to quit from the tray.

Replacement for PR #663 
Note comment against this change by @mickleby