### PR TITLE
packaging: remove last vestiges of python2

### DIFF
--- a/packaging/build_deb.sh
+++ b/packaging/build_deb.sh
@@ -34,8 +34,8 @@ DIST_DIR="$PWD/dist"
 # Build a python sdist package, then unpack and create .orig and source dir.
 #
 
-P_NAME="$(python2.7 setup.py --name)"
-P_VERSION="$(python2.7 setup.py --version)"
+P_NAME="$(python3 setup.py --name)"
+P_VERSION="$(python3 setup.py --version)"
 SDIST_FILE="$DIST_DIR/$P_NAME-$P_VERSION.tar.gz"
 ORIG_FILE="$DIST_DIR/${P_NAME}_${P_VERSION}.orig.tar.gz"
 
@@ -48,7 +48,7 @@ fi
 export TMPDIR="$(/bin/mktemp --directory --tmpdir debbuild-$P_NAME-$P_VERSION-$USER-XXXXXX)"
 
 ./tools/po-compile.sh
-python2.7 setup.py sdist --formats=gztar --quiet
+python3 setup.py sdist --formats=gztar --quiet
 /bin/tar --extract --gunzip --file "$SDIST_FILE" --directory "$DIST_DIR"
 test -d "$BUILD_DIR"
 

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -9,10 +9,10 @@ PREFIX = /usr
 
 %:
 	# Adding the required helpers
-	dh $@ --with=python2
+	dh $@ --with=python3
 
 override_dh_auto_install:
 	dh_auto_install -- --prefix=$(PREFIX) --install-lib=$(PREFIX)/share/solaar/lib
 
-override_dh_python2:
-	dh_python2 $(PREFIX)/share/solaar/lib
+override_dh_python3:
+	dh_python3 $(PREFIX)/share/solaar/lib


### PR DESCRIPTION
I was communicating with the contact person for the ubuntu packages about updating, and mentioned that python3 is required now.  The contact person pointed to some remaining bits where python2 is used, so I'm changing them to python3.