### PR TITLE
add logind signal for suspend/resume

### DIFF
--- a/lib/logitech_receiver/status.py
+++ b/lib/logitech_receiver/status.py
@@ -223,7 +223,7 @@ class DeviceStatus(dict):
 			# broadcasting it's battery status anyway, it will just take a little while.
 			# However, when the device has just been detected, it will not show
 			# any battery status for a while (broadcasts happen every 90 seconds).
-			if battery is None and _hidpp20.FEATURE.SOLAR_DASHBOARD in d.features:
+			if battery is None and d.features and _hidpp20.FEATURE.SOLAR_DASHBOARD in d.features:
 				d.feature_request(_hidpp20.FEATURE.SOLAR_DASHBOARD, 0x00, 1, 1)
 				return
 
@@ -261,7 +261,8 @@ class DeviceStatus(dict):
 
 					# Devices lose configuration when they are turned off,
 					# make sure they're up-to-date.
-					# _log.debug("%s settings %s", d, d.settings)
+					if _log.isEnabledFor(_DEBUG):
+						_log.debug("%s pushing device settings %s", d, d.settings)
 					for s in d.settings:
 						s.apply()
 

--- a/lib/solaar/upower.py
+++ b/lib/solaar/upower.py
@@ -31,7 +31,7 @@ _suspend_callback = None
 def _suspend():
 	if _suspend_callback:
 		if _log.isEnabledFor(_INFO):
-			_log.info("received suspend event from UPower")
+			_log.info("received suspend event")
 		_suspend_callback()
 
 
@@ -39,9 +39,11 @@ _resume_callback = None
 def _resume():
 	if _resume_callback:
 		if _log.isEnabledFor(_INFO):
-			_log.info("received resume event from UPower")
+			_log.info("received resume event")
 		_resume_callback()
 
+def _suspend_or_resume(suspend):
+	_suspend() if suspend else _resume()
 
 def watch(on_resume_callback=None, on_suspend_callback=None):
 	"""Register callback for suspend/resume events.
@@ -56,6 +58,8 @@ try:
 
 	_UPOWER_BUS = 'org.freedesktop.UPower'
 	_UPOWER_INTERFACE = 'org.freedesktop.UPower'
+	_LOGIND_BUS = 'org.freedesktop.login1.Manager'
+	_LOGIND_INTERFACE = 'org.freedesktop.login1'
 
 	# integration into the main GLib loop
 	from dbus.mainloop.glib import DBusGMainLoop
@@ -69,6 +73,9 @@ try:
 
 	bus.add_signal_receiver(_resume, signal_name='Resuming',
 					dbus_interface=_UPOWER_INTERFACE, bus_name=_UPOWER_BUS)
+
+	bus.add_signal_receiver(_suspend_or_resume,'PrepareForSleep',
+					_LOGIND_BUS, _LOGIND_INTERFACE)
 
 	if _log.isEnabledFor(_INFO):
 		_log.info("connected to system dbus, watching for suspend/resume events")


### PR DESCRIPTION
Upower no longer emits signals for suspend/resume.  I update to the current logind signals.

I left the old signals just in case some distribution uses them.

Also fix a bug for devices that haven't been completely initialized.

Fixes #692 
Should solve #686 and maybe some older bugs

