### PR TITLE
Fix bug in not applying settings after resume

### DIFF
--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -373,7 +373,7 @@ del _SETTINGS_LIST
 
 def check_feature_settings(device, already_known):
 	"""Try to auto-detect device settings by the HID++ 2.0 features they have."""
-	if device.features is None:
+	if device.features is None or not device.online:
 		return
 	if device.protocol and device.protocol < 2.0:
 		return

--- a/lib/solaar/gtk.py
+++ b/lib/solaar/gtk.py
@@ -106,7 +106,7 @@ def main():
 		if args.restart_on_wake_up:
 			_upower.watch(listener.start_all, listener.stop_all)
 		else:
-			_upower.watch(listener.ping_all)
+			_upower.watch(lambda: listener.ping_all(True))
 
 		# main UI event loop
 		ui.run_loop(listener.start_all, listener.stop_all, args.window!='only', args.window!='hide')

--- a/lib/solaar/listener.py
+++ b/lib/solaar/listener.py
@@ -291,12 +291,16 @@ def stop_all():
 		for l in listeners:
 			l.join()
 
-
-def ping_all():
+# ping all devices to find out whether they are connected
+# after a resume, the device may have been off
+# so mark its saved status to ensure that the status is pushed to the device when it comes back
+def ping_all(resuming = False):
 	for l in _all_listeners.values():
 		count = l.receiver.count()
 		if count:
 			for dev in l.receiver:
+				if resuming:
+					dev.status._active = False
 				dev.ping()
 				l._status_changed(dev)
 				count -= 1

--- a/lib/solaar/upower.py
+++ b/lib/solaar/upower.py
@@ -58,8 +58,8 @@ try:
 
 	_UPOWER_BUS = 'org.freedesktop.UPower'
 	_UPOWER_INTERFACE = 'org.freedesktop.UPower'
-	_LOGIND_BUS = 'org.freedesktop.login1.Manager'
-	_LOGIND_INTERFACE = 'org.freedesktop.login1'
+	_LOGIND_BUS = 'org.freedesktop.login1'
+	_LOGIND_INTERFACE = 'org.freedesktop.login1.Manager'
 
 	# integration into the main GLib loop
 	from dbus.mainloop.glib import DBusGMainLoop
@@ -75,7 +75,7 @@ try:
 					dbus_interface=_UPOWER_INTERFACE, bus_name=_UPOWER_BUS)
 
 	bus.add_signal_receiver(_suspend_or_resume,'PrepareForSleep',
-					_LOGIND_BUS, _LOGIND_INTERFACE)
+					dbus_interface=_LOGIND_INTERFACE, bus_name=_LOGIND_BUS)
 
 	if _log.isEnabledFor(_INFO):
 		_log.info("connected to system dbus, watching for suspend/resume events")


### PR DESCRIPTION
There was nothing that told Solaar that device settings needed to be re-applied after a resume, which needs to be done because the device might have been turned off and on again, or gone into some other mode that loses settings, while the computer was suspended.
Also don't check features when the device is offline.

Also fix style in adding logind suspend/resume dbus watcher.

Addresses #686