### PR TITLE
Add Support for C537

### DIFF
--- a/lib/logitech_receiver/base_usb.py
+++ b/lib/logitech_receiver/base_usb.py
@@ -94,6 +94,7 @@ NANO_RECEIVER_C526        = _nano_receiver(0xc526)
 NANO_RECEIVER_C52e        = _nano_receiver(0xc52e)
 NANO_RECEIVER_C531        = _nano_receiver(0xc531)
 NANO_RECEIVER_C534        = _nano_receiver_max2(0xc534)
+NANO_RECEIVER_C537        = _nano_receiver(0xc537)
 NANO_RECEIVER_6042        = _lenovo_receiver(0x6042)
 
 # Lightspeed receivers
@@ -118,6 +119,7 @@ ALL = (
 		NANO_RECEIVER_C52e,
 		NANO_RECEIVER_C531,
 		NANO_RECEIVER_C534,
+		NANO_RECEIVER_C537,
 		NANO_RECEIVER_6042,
 		LIGHTSPEED_RECEIVER_C539,
 		LIGHTSPEED_RECEIVER_C53a,

--- a/rules.d/42-logitech-unify-permissions.rules
+++ b/rules.d/42-logitech-unify-permissions.rules
@@ -33,6 +33,7 @@ ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c51a", GOTO="solaar_apply"
 ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c521", GOTO="solaar_apply"
 ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c525", GOTO="solaar_apply"
 ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c534", GOTO="solaar_apply"
+ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c537", GOTO="solaar_apply"
 
 # Lightspeed receivers
 ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c539", GOTO="solaar_apply"


### PR DESCRIPTION
replaces https://github.com/pwr-Solaar/Solaar/pull/659

This is the last bit to add support for the c537 nano receiver. Credit goes to @pfps for the changes. 

Combined with a number of other branches that have been merged it now also has preliminary support for the G602, partially addressing https://github.com/pwr-Solaar/Solaar/issues/128

Test results look good and clean:

![Screenshot from 2020-02-26 10-45-15](https://user-images.githubusercontent.com/4290536/75327843-b8a5f500-5885-11ea-925f-8a0e055eaed0.png)


```
sudo python3 ./bin/solaar -dd 
[sudo] password for rijnhard:          
10:44:37,214     INFO [MainThread] root: language en_ZA (UTF-8), translations path /Data/OpenSource/Solaar/share/locale
10:44:37,374    DEBUG [MainThread] solaar.ui.tray: using AppIndicator3
10:44:37,437     INFO [MainThread] solaar.upower: connected to system dbus, watching for suspend/resume events
10:44:37,486    DEBUG [MainThread] solaar.ui: startup registered=True, remote=False
10:44:37,488    DEBUG [AsyncUI] solaar.tasks: started
10:44:37,491     INFO [MainThread] solaar.ui.notify: starting desktop notifications
10:44:37,507    DEBUG [MainThread] solaar.ui.icons: sys.path[0] = /Data/OpenSource/Solaar/lib
10:44:37,507    DEBUG [MainThread] solaar.ui.icons: looking for icons in /Data/OpenSource/Solaar/icons
10:44:37,508    DEBUG [MainThread] solaar.ui.icons: looking for icons in /Data/OpenSource/Solaar/share/solaar/icons
10:44:37,508    DEBUG [MainThread] solaar.ui.icons: looking for icons in /home/rijnhard/.local/share/solaar/icons
10:44:37,508    DEBUG [MainThread] solaar.ui.icons: looking for icons in /Data/OpenSource/Solaar/share/solaar/icons
10:44:37,508    DEBUG [MainThread] solaar.ui.icons: looking for icons in /usr/local/share/solaar/icons
10:44:37,508    DEBUG [MainThread] solaar.ui.icons: looking for icons in /usr/share/solaar/icons
10:44:37,508    DEBUG [MainThread] solaar.ui.icons: icon theme paths: ['/usr/share/solaar/icons', '/Data/OpenSource/Solaar/share/solaar/icons', '/Data/OpenSource/Solaar/share/solaar/icons', '/home/rijnhard/.local/share/icons', '/home/rijnhard/.icons', '/usr/local/share/icons', '/usr/share/icons', '/usr/local/share/pixmaps', '/usr/share/pixmaps']
10:44:37,524    DEBUG [MainThread] solaar.ui.icons: detected icon sets: Mint True, gpm True, oxygen True, gnome True, elementary True
10:44:37,541     INFO [MainThread] solaar.listener: starting receiver listening threads
10:44:37,576     INFO [MainThread] solaar.listener: receiver event add DeviceInfo(path='/dev/hidraw3', vendor_id='046d', product_id='c537', serial='', release=b'3400', manufacturer=b'Logitech', product=b'USB Receiver', interface=1, driver='hid-generic')
10:44:37,577    DEBUG [MainThread] logitech_receiver.base: (12) <= w[10 FF 83B5 030000]
10:44:37,578    DEBUG [MainThread] logitech_receiver.base: (12) => r[11 FF 83B5 0384E398F30101070000000000000000]
10:44:37,578    DEBUG [MainThread] logitech_receiver.base: (12) <= w[10 FF 80B2 000000]
10:44:37,579    DEBUG [MainThread] logitech_receiver.base: (12) => r[10 FF 8F80 B20300]
10:44:37,579    DEBUG [MainThread] logitech_receiver.base: (12) device 0xFF error on request {80B2}: 3 = invalid value
10:44:37,579     INFO [ReceiverListener:hidraw3] logitech_receiver.listener: started with <NanoReceiver(/dev/hidraw3,12)> (12)
10:44:37,579     INFO [ReceiverListener:hidraw3] solaar.listener: <NanoReceiver(/dev/hidraw3,12)>: notifications listener has started (12)
10:44:37,580    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 FF 8000 100900]
10:44:37,581    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[10 FF 8000 000000]
10:44:37,581    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 FF 8100 000000]
10:44:37,582    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[10 FF 8100 000900]
10:44:37,582     INFO [ReceiverListener:hidraw3] logitech_receiver.receiver: <NanoReceiver(/dev/hidraw3,12)>: receiver notifications enabled => ('wireless', 'software present')
10:44:37,582    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 FF 8002 020000]
10:44:37,583    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[10 01 4107 122C40]
10:44:37,584    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[10 FF 8002 000000]
10:44:37,584     INFO [ReceiverListener:hidraw3] solaar.listener: status_changed <NanoReceiver(/dev/hidraw3,12)>: present, No paired devices. (0) 
10:44:37,585    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 FF 83B5 400000]
10:44:37,586    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 FF 83B5 40044736303200000000000000000000]
10:44:37,586     INFO [ReceiverListener:hidraw3] logitech_receiver.receiver: <NanoReceiver(/dev/hidraw3,12)>: found new device 1 (402C)
10:44:37,587    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 FF 83B5 300000]
10:44:37,588    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 FF 83B5 308D13D0BD0E00000001000000000000]
10:44:37,586     INFO [ReceiverListener:hidraw3] solaar.listener: Notification(1,41,07,122C40) triggered new device <PairedDevice(1,402C,G602,8D13D0BD)> (mouse)
10:44:37,589    DEBUG [ReceiverListener:hidraw3] solaar.configuration: load => {'402C:8D13D0BD': {'_name': 'Wireless Gaming Mouse'}, '_version': '1.0.1'}
10:44:37,589    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) pinging device 1
10:44:37,589    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 001D 0000A8]
10:44:37,593    DEBUG [MainThread] solaar.ui: activate
10:44:37,594    DEBUG [MainThread] solaar.ui: status changed: <NanoReceiver(/dev/hidraw3,12)> (NONE) None
10:44:37,595    DEBUG [MainThread] solaar.ui.window: new receiver row ('/dev/hidraw3', 0, True, 'Nano Receiver', 'preferences-desktop-peripherals', None, None, <NanoReceiver(/dev/hidraw3,12)>)

(solaar:12416): Gdk-CRITICAL **: 10:44:37.988: gdk_window_thaw_toplevel_updates: assertion 'window->update_and_descendants_freeze_count > 0' failed
10:44:38,450    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 001D 0200A800000000000000000000000000]
10:44:38,451    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 0009 000100]
10:44:38,465    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 0009 01000000000000000000000000000000]
10:44:38,466    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 0109 000000]
10:44:38,481    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 0109 16000000000000000000000000000000]
10:44:38,482    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 0008 000500]
10:44:38,497    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 0008 03000000000000000000000000000000]
10:44:38,498    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 030F 000000]
10:44:38,513    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 030F 15000000000000000000000000000000]
10:44:38,513    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 031B 000000]
10:44:38,529    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 031B 576972656C6573732047616D696E6720]
10:44:38,530    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 0319 100000]
10:44:38,545    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 0319 4D6F7573650000000000000000000000]
10:44:38,546     INFO [ReceiverListener:hidraw3] solaar.listener: status_changed <NanoReceiver(/dev/hidraw3,12)>: present, 1 paired device. (0) 
10:44:38,546    DEBUG [ReceiverListener:hidraw3] logitech_receiver.notifications: <PairedDevice(1,402C,G602,8D13D0BD)>: eQUAD step 4 Gaming connection notification: software=True, encrypted=False, link=True, payload=False
10:44:38,547    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 0009 212000]
10:44:38,547    DEBUG [MainThread] solaar.ui: status changed: <NanoReceiver(/dev/hidraw3,12)> (NONE) None
10:44:38,561    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 0009 00000000000000000000000000000000]
10:44:38,561    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 000E 213000]
10:44:38,577    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000E 00000000000000000000000000000000]
10:44:38,577    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 000D 212100]
10:44:38,593    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000D 00000000000000000000000000000000]
10:44:38,593    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 000E 212100]
10:44:38,609    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000E 00000000000000000000000000000000]
10:44:38,609    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 000E 40A000]
10:44:38,625    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000E 00000000000000000000000000000000]
10:44:38,625    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 000C 40A200]
10:44:38,641    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000C 00000000000000000000000000000000]
10:44:38,642    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 000B 40A300]
10:44:38,673    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000B 00000000000000000000000000000000]
10:44:38,674    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 000D 220100]
10:44:38,689    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000D 0D000000000000000000000000000000]
10:44:38,690    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 0D1B 000000]
10:44:38,777    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 FF0D 1B020000000000000000000000000000]
10:44:38,778    ERROR [ReceiverListener:hidraw3] logitech_receiver.base: (12) device 1 error on feature request {0D1B}: 2 = invalid argument
10:44:38,778    ERROR [ReceiverListener:hidraw3] logitech_receiver.settings_templates: check_feature[ADJUSTABLE DPI] inconsistent feature {'number': 1, 'request': 3355, 'error': 2, 'params': b''}
10:44:38,778    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 0009 220500]
10:44:38,793    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 0009 00000000000000000000000000000000]
10:44:38,793    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 0009 211000]
10:44:38,809    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 0009 00000000000000000000000000000000]
10:44:38,810    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 000F 198200]
10:44:38,825    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000F 00000000000000000000000000000000]
10:44:38,825    DEBUG [ReceiverListener:hidraw3] logitech_receiver.status: <PairedDevice(1,402C,G602,8D13D0BD)> pushing device settings []
10:44:38,826    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 000D 212000]
10:44:38,841    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000D 00000000000000000000000000000000]
10:44:38,842    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 000A 213000]
10:44:38,857    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000A 00000000000000000000000000000000]
10:44:38,858    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 0008 212100]
10:44:38,873    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 0008 00000000000000000000000000000000]
10:44:38,873    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 000D 212100]
10:44:38,889    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000D 00000000000000000000000000000000]
10:44:38,889    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 0009 40A000]
10:44:38,905    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 0009 00000000000000000000000000000000]
10:44:38,905    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 000D 40A200]
10:44:38,921    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000D 00000000000000000000000000000000]
10:44:38,921    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 000E 40A300]
10:44:38,937    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000E 00000000000000000000000000000000]
10:44:38,937    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 0D1F 000000]
10:44:38,953    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 FF0D 1F020000000000000000000000000000]
10:44:38,953    ERROR [ReceiverListener:hidraw3] logitech_receiver.base: (12) device 1 error on feature request {0D1F}: 2 = invalid argument
10:44:38,953    ERROR [ReceiverListener:hidraw3] logitech_receiver.settings_templates: check_feature[ADJUSTABLE DPI] inconsistent feature {'number': 1, 'request': 3359, 'error': 2, 'params': b''}
10:44:38,953    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 000D 220500]
10:44:38,969    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000D 00000000000000000000000000000000]
10:44:38,969    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 000D 211000]
10:44:38,985    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000D 00000000000000000000000000000000]
10:44:38,985    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 000D 198200]
10:44:39,001    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000D 00000000000000000000000000000000]
10:44:39,001    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 0009 100000]
10:44:39,017    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 0009 05000000000000000000000000000000]
10:44:39,018    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) <= w[10 01 050B 000000]
10:44:39,033    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 050B 32140000000000000000000000000000]
10:44:39,033    DEBUG [ReceiverListener:hidraw3] logitech_receiver.hidpp20: device 1 battery 50% charged, next level 20% charge, status 0 = discharging
10:44:39,034    DEBUG [ReceiverListener:hidraw3] logitech_receiver.status: <PairedDevice(1,402C,G602,8D13D0BD)>: battery 50, discharging
10:44:39,034     INFO [ReceiverListener:hidraw3] solaar.listener: status_changed <PairedDevice(1,402C,G602,8D13D0BD)>: paired online, {'LINK ENCRYPTED': False, 'BATTERY LEVEL': 50, 'BATTERY STATUS': NamedInt(0, 'discharging'), 'BATTERY CHARGING': False, 'ERROR': None} (1) 
10:44:39,034     INFO [ReceiverListener:hidraw3] solaar.listener: status_changed <PairedDevice(1,402C,G602,8D13D0BD)>: paired online, {'LINK ENCRYPTED': False, 'BATTERY LEVEL': 50, 'BATTERY STATUS': NamedInt(0, 'discharging'), 'BATTERY CHARGING': False, 'ERROR': None} (0) 
10:44:39,034    DEBUG [MainThread] solaar.ui: status changed: <PairedDevice(1,402C,G602,8D13D0BD)> (1) None
10:44:39,036    DEBUG [MainThread] solaar.ui.tray: picked device with lowest battery: ('/dev/hidraw3', 1, 'Wireless Gaming Mouse', {'LINK ENCRYPTED': False, 'BATTERY LEVEL': 50, 'BATTERY STATUS': NamedInt(0, 'discharging'), 'BATTERY CHARGING': False, 'ERROR': None})
10:44:39,040    DEBUG [MainThread] solaar.ui.window: new device row ('/dev/hidraw3', 1, True, 'G602', 'input-mouse', None, None, <PairedDevice(1,402C,G602,8D13D0BD)>) at index 0
10:44:39,045    ERROR [MainThread] solaar.ui.notify: showing <Notify.Notification object at 0x7f7f7034c360 (NotifyNotification at 0x22ff660)>
Traceback (most recent call last):
  File "/Data/OpenSource/Solaar/lib/solaar/ui/notify.py", line 142, in show
    n.show()
GLib.GError: g-dbus-error-quark: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name org.freedesktop.Notifications was not provided by any .service files (2)
10:44:39,052    DEBUG [MainThread] solaar.ui: status changed: <PairedDevice(1,402C,G602,8D13D0BD)> (NONE) None
10:44:39,052    DEBUG [MainThread] solaar.ui.tray: picked device with lowest battery: ('/dev/hidraw3', 1, 'Wireless Gaming Mouse', {'LINK ENCRYPTED': False, 'BATTERY LEVEL': 50, 'BATTERY STATUS': NamedInt(0, 'discharging'), 'BATTERY CHARGING': False, 'ERROR': None})
10:44:39,053    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 000F 212000]
10:44:39,065    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 000F 00000000000000000000000000000000]
10:44:39,065    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000F 00000000000000000000000000000000]
10:44:39,065    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 000E 213000]
10:44:39,081    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000E 00000000000000000000000000000000]
10:44:39,081    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 000E 00000000000000000000000000000000]
10:44:39,082    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 000A 212100]
10:44:39,097    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 000A 00000000000000000000000000000000]
10:44:39,097    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000A 00000000000000000000000000000000]
10:44:39,098    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 000E 212100]
10:44:39,113    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 000E 00000000000000000000000000000000]
10:44:39,113    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000E 00000000000000000000000000000000]
10:44:39,114    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 0008 40A000]
10:44:39,129    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 0008 00000000000000000000000000000000]
10:44:39,129    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 0008 00000000000000000000000000000000]
10:44:39,130    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 000D 40A200]
10:44:39,145    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 000D 00000000000000000000000000000000]
10:44:39,146    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 000A 40A300]
10:44:39,146    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000D 00000000000000000000000000000000]
10:44:39,161    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000A 00000000000000000000000000000000]
10:44:39,161    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 000A 00000000000000000000000000000000]
10:44:39,162    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 0D1A 000000]
10:44:39,177    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 FF0D 1A020000000000000000000000000000]
10:44:39,178    ERROR [MainThread] logitech_receiver.base: (13) device 1 error on feature request {0D1A}: 2 = invalid argument
10:44:39,178    ERROR [MainThread] logitech_receiver.settings_templates: check_feature[ADJUSTABLE DPI] inconsistent feature {'number': 1, 'request': 3354, 'error': 2, 'params': b''}
10:44:39,178    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 0008 220500]
10:44:39,179    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 FF0D 1A020000000000000000000000000000]
10:44:39,193    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 0008 00000000000000000000000000000000]
10:44:39,193    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 0008 00000000000000000000000000000000]
10:44:39,194    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 000C 211000]
10:44:39,209    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000C 00000000000000000000000000000000]
10:44:39,209    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 000C 00000000000000000000000000000000]
10:44:39,209    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 000F 198200]
10:44:39,225    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000F 00000000000000000000000000000000]
10:44:39,225    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 000F 00000000000000000000000000000000]
10:44:46,280    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 FF 8102 000000]
10:44:46,282    DEBUG [MainThread] logitech_receiver.base: (13) => r[10 FF 8102 000100]
10:44:46,282    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[10 FF 8102 000100]
10:44:48,176    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 0009 212000]
10:44:48,188    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 0009 00000000000000000000000000000000]
10:44:48,188    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 000A 213000]
10:44:48,189    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 0009 00000000000000000000000000000000]
10:44:48,259    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 000A 00000000000000000000000000000000]
10:44:48,259    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 000B 212100]
10:44:48,260    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000A 00000000000000000000000000000000]
10:44:48,275    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 000B 00000000000000000000000000000000]
10:44:48,275    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 0008 212100]
10:44:48,276    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000B 00000000000000000000000000000000]
10:44:48,379    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 0008 00000000000000000000000000000000]
10:44:48,379    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 0008 40A000]
10:44:48,380    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 0008 00000000000000000000000000000000]
10:44:48,483    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 0008 00000000000000000000000000000000]
10:44:48,483    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 0008 40A200]
10:44:48,484    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 0008 00000000000000000000000000000000]
10:44:48,579    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 0008 00000000000000000000000000000000]
10:44:48,579    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 000A 40A300]
10:44:48,579    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 0008 00000000000000000000000000000000]
10:44:48,683    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 000A 00000000000000000000000000000000]
10:44:48,683    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 0D1D 000000]
10:44:48,683    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000A 00000000000000000000000000000000]
10:44:48,787    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 FF0D 1D020000000000000000000000000000]
10:44:48,787    ERROR [MainThread] logitech_receiver.base: (13) device 1 error on feature request {0D1D}: 2 = invalid argument
10:44:48,787    ERROR [MainThread] logitech_receiver.settings_templates: check_feature[ADJUSTABLE DPI] inconsistent feature {'number': 1, 'request': 3357, 'error': 2, 'params': b''}
10:44:48,788    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 000B 220500]
10:44:48,788    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 FF0D 1D020000000000000000000000000000]
10:44:48,803    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 000B 00000000000000000000000000000000]
10:44:48,803    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 000F 211000]
10:44:48,804    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000B 00000000000000000000000000000000]
10:44:48,819    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 000F 00000000000000000000000000000000]
10:44:48,819    DEBUG [MainThread] logitech_receiver.base: (13) <= w[10 01 000D 198200]
10:44:48,820    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000F 00000000000000000000000000000000]
10:44:48,843    DEBUG [MainThread] logitech_receiver.base: (13) => r[11 01 000D 00000000000000000000000000000000]
10:44:48,843    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000D 00000000000000000000000000000000]
10:45:14,138    DEBUG [AsyncUI] logitech_receiver.base: (14) <= w[10 FF 83B5 200000]
10:45:14,139    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 FF 83B5 200708402C0701023200000000000000]
10:45:14,139    DEBUG [AsyncUI] logitech_receiver.base: (14) => r[11 FF 83B5 200708402C0701023200000000000000]
10:45:14,140    DEBUG [AsyncUI] logitech_receiver.base: (14) <= w[10 01 000F 000300]
10:45:14,205    DEBUG [AsyncUI] logitech_receiver.base: (14) => r[11 01 000F 02000000000000000000000000000000]
10:45:14,205    DEBUG [AsyncUI] logitech_receiver.base: (14) <= w[10 01 020E 000000]
10:45:14,206    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 000F 02000000000000000000000000000000]
10:45:14,221    DEBUG [AsyncUI] logitech_receiver.base: (14) => r[11 01 020E 03000000000000000000000000000000]
10:45:14,222    DEBUG [AsyncUI] logitech_receiver.base: (14) <= w[10 01 0219 000000]
10:45:14,222    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 020E 03000000000000000000000000000000]
10:45:14,237    DEBUG [AsyncUI] logitech_receiver.base: (14) => r[11 01 0219 0052514D4700001000402C0000000000]
10:45:14,238    DEBUG [AsyncUI] logitech_receiver.base: (14) <= w[10 01 021E 010000]
10:45:14,238    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 0219 0052514D4700001000402C0000000000]
10:45:14,253    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 021E 01424C200200000100402C0000000000]
10:45:14,254    DEBUG [AsyncUI] logitech_receiver.base: (14) => r[11 01 021E 01424C200200000100402C0000000000]
10:45:14,254    DEBUG [AsyncUI] logitech_receiver.base: (14) <= w[10 01 021A 020000]
10:45:14,269    DEBUG [AsyncUI] logitech_receiver.base: (14) => r[11 01 021A 024857200200000000402C0000000000]
10:45:14,270    DEBUG [ReceiverListener:hidraw3] logitech_receiver.base: (12) => r[11 01 021A 024857200200000000402C0000000000]
```