### PR TITLE
cli: force unpairing attempt when using cli

### DIFF
--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -478,6 +478,9 @@ class Receiver(object):
 		return self.register_new_device(key)
 
 	def __delitem__(self, key):
+		self._unpair_device(self, key, False)
+
+	def _unpair_device(self, key, force=False):
 		key = int(key)
 
 		if self._devices.get(key) is None:
@@ -489,7 +492,7 @@ class Receiver(object):
 				del self._devices[key]
 			return
 
-		if self.re_pairs:
+		if self.re_pairs and not force:
 			# invalidate the device, but these receivers don't unpair per se
 			dev.online = False
 			dev.wpid = None

--- a/lib/solaar/cli/unpair.py
+++ b/lib/solaar/cli/unpair.py
@@ -28,13 +28,12 @@ def run(receivers, args, find_receiver, find_device):
 	dev = find_device(receivers, device_name)
 
 	if not dev.receiver.may_unpair:
-		print('Receiver for %s [%s:%s] does not unpair' % (dev.name,dev.wpid,dev.serial))
-		return
+		print('Receiver for %s [%s:%s] does not unpair, but attempting anyway' % (dev.name,dev.wpid,dev.serial))
 
-	# query these now, it's last chance to get them
 	try:
+		# query these now, it's last chance to get them
 		number, codename, wpid, serial  = dev.number, dev.codename, dev.wpid, dev.serial
-		del dev.receiver[number]
+		dev.receiver._unpair_device(number, True) # force an unpair
 		print ('Unpaired %d: %s (%s) [%s:%s]' % (number, dev.name, codename, wpid, serial))
 	except Exception as e:
 		raise Exception('failed to unpair device %s: %s' % (dev.name, e))


### PR DESCRIPTION
The command line interface generally just does the command without checking whether it makes sense to Solaar, on the assumption that users of the CLI know what they are doing.  When I fixed up the unpairing for Nano receivers I had to handle unpairing differently for Universal and Nano receivers so the low-level code didn't try to unpair for Nano receivers. This PR adds in a forced unpair and uses that version in ``solaar unpair <n>``, restoring the old behaviour for the CLI.