### PR TITLE
Attempt to fix PPA building issues

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -4,7 +4,6 @@ Priority: optional
 Maintainer: Daniel Pavel <daniel.pavel@gmail.com>
 Build-Depends: debhelper (>= 9)
 Build-Depends-Indep: python, po-debconf
-X-Python-Version: >= 2.7
 X-Python3-Version: >= 3.2
 Standards-Version: 3.9.4
 Homepage: http://pwr-solaar.github.io/Solaar
@@ -14,10 +13,10 @@ Vcs-browser: http://github.com/pwr/Solaar
 Package: solaar
 Architecture: all
 Depends: ${misc:Depends}, ${debconf:Depends}, udev (>= 175), passwd | adduser,
- ${python:Depends}, python3-pyudev (>= 0.13), python-gi (>= 3.2), gir1.2-gtk-3.0 (>= 3.4),
+ ${python3:Depends}, python3-pyudev (>= 0.13), python3-gi (>= 3.2), gir1.2-gtk-3.0 (>= 3.4),
  ${solaar:Desktop-Icon-Theme}
 Recommends: gir1.2-notify-0.7, consolekit (>= 0.4.3) | systemd (>= 44),
- python-dbus (>= 1.1.0), upower
+ python3-dbus (>= 1.1.0), upower
 Suggests: gir1.2-appindicator3-0.1
 Description: Logitech Unifying Receiver peripherals manager for Linux
  Solaar is a Linux device manager for Logitech's Unifying Receiver peripherals.


### PR DESCRIPTION
change all debian deps to python3
drop python2 completely

relates to https://github.com/pwr-Solaar/Solaar/issues/656

Attempting to address https://github.com/pwr-Solaar/Solaar/issues/696

@pfps I dont know who has access to the PPA, it would be useful if we could build a separate branch to test. This is guesswork at this stage 