### PR TITLE
docs: improve documentation on required system packages

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,17 +14,18 @@ most likely good to go.
 
 Solaar requires Python 3.2+
 and the `python3-pyudev` package. 
-
 To run the GUI, solaar also requires Gtk3, and its GObject
 Introspection bindings. The Debian/Ubuntu package names are
-`python3-gi` and `gir1.2-gtk-3.0`; if you're using another
+`python3-gi` and `gir1.2-gtk-3.0`;
+in Fedora you only need `python3-gobject`;
+if you're using another
 distribution the required packages are most likely named something similar.
-If the desktop notifications bindings are also installed (`gir1.2-notify-0.7`),
+
+If the desktop notifications bindings are also installed
+(`gir1.2-notify-0.7` for Debian/Ubuntu),
 you will also get desktop notifications when devices come online/go offline.
-
 For gnome-shell/Unity support, you also need to have `gir1.2-appindicator3-0.1`
-installed.
-
+installed in Debian/Ubuntu.
 
 ### Downloading
 

--- a/lib/solaar/gtk.py
+++ b/lib/solaar/gtk.py
@@ -36,7 +36,7 @@ def _require(module, os_package):
 		return importlib.import_module(module)
 	except ImportError:
 		import sys
-		sys.exit("%s: missing required package '%s'" % (NAME, os_package))
+		sys.exit("%s: missing required system package %s" % (NAME, os_package))
 
 
 def _parse_arguments():
@@ -81,7 +81,7 @@ def _parse_arguments():
 
 
 def main():
-	_require('pyudev', 'python-pyudev')
+	_require('pyudev', 'python3-pyudev')
 
 	# handle ^C in console
 	import signal
@@ -93,7 +93,7 @@ def main():
 		# if any argument, run comandline and exit
 		return _cli.run(args.action, args.hidraw_path)
 
-	gi = _require('gi', 'python-gi')
+	gi = _require('gi', 'python3-gi or python3-gobject')
 	gi.require_version('Gtk', '3.0')
 	_require('gi.repository.Gtk', 'gir1.2-gtk-3.0')
 


### PR DESCRIPTION
Change installation.md to use python3 names for required system packages.
Change gtk.py to output python3 names for missing system packages.