### PR TITLE
also look up attention icon filename to get around libappindicator bug

### DIFF
--- a/lib/solaar/ui/tray.py
+++ b/lib/solaar/ui/tray.py
@@ -212,7 +212,7 @@ try:
 
 	def attention(reason=None):
 		if _icon.get_status != AppIndicator3.IndicatorStatus.ATTENTION:
-			_icon.set_attention_icon_full(_icons.TRAY_ATTENTION, reason or '')
+			_icon.set_attention_icon_full(_icon_file(_icons.TRAY_ATTENTION), reason or '')
 			_icon.set_status(AppIndicator3.IndicatorStatus.ATTENTION)
 			GLib.timeout_add(10 * 1000, _icon.set_status, AppIndicator3.IndicatorStatus.ACTIVE)
 


### PR DESCRIPTION
The original PR didn't fix up the problem when setting the attention icon.