### PR TITLE
ui: support Ayatana AppIndicator

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+1.0.2-rc2:
+  * Add support for Ayatana AppIndicator
+
 1.0.2-rc1:
   * Look up tray icon filenames to get around a bug in libappindicator.
   * Make the default behavior be to show the main window at startup.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,8 +24,11 @@ distribution the required packages are most likely named something similar.
 If the desktop notifications bindings are also installed
 (`gir1.2-notify-0.7` for Debian/Ubuntu),
 you will also get desktop notifications when devices come online/go offline.
-For gnome-shell/Unity support, you also need to have `gir1.2-appindicator3-0.1`
-installed in Debian/Ubuntu.
+For GNOME Shell/Budgie Desktop/KDE/XFCE support, you also need to have
+`gir1.2-ayatanaappindicator3-0.1` installed in Debian/Ubuntu. Although it is
+recommended to install and use `gir1.2-ayatanaappindicator3-0.1` if it is
+available, you can also use `gir1.2-appindicator3-0.1` if necessary (e.g.,
+for Unity in Ubuntu).
 
 ### Downloading
 

--- a/lib/solaar/ui/tray.py
+++ b/lib/solaar/ui/tray.py
@@ -146,14 +146,23 @@ def _scroll(tray_icon, event, direction=None):
 try:
 	import gi
 	try:
-		gi.require_version('AppIndicator3', '0.1')
+		gi.require_version('AyatanaAppIndicator3', '0.1')
+		ayatana_appindicator_found = True
 	except ValueError:
-		# Treat unavailable versions the same as unavailable packages
-		raise ImportError
-	from gi.repository import AppIndicator3
+		try:
+			gi.require_version('AppIndicator3', '0.1')
+			ayatana_appindicator_found = False
+		except ValueError:
+			# treat unavailable versions the same as unavailable packages
+			raise ImportError
+
+	if ayatana_appindicator_found:
+		from gi.repository import AyatanaAppIndicator3 as AppIndicator3
+	else:
+		from gi.repository import AppIndicator3
 
 	if _log.isEnabledFor(_DEBUG):
-		_log.debug("using AppIndicator3")
+		_log.debug("using %sAppIndicator3" % ('Ayatana ' if ayatana_appindicator_found else ''))
 
 	# Defense against AppIndicator3 bug that treats files in current directory as icon files
 	# https://bugs.launchpad.net/ubuntu/+source/libappindicator/+bug/1363277

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -14,11 +14,11 @@ Vcs-browser: http://github.com/pwr/Solaar
 Package: solaar
 Architecture: all
 Depends: ${misc:Depends}, ${debconf:Depends}, udev (>= 175), passwd | adduser,
- ${python:Depends}, python3-pyudev (>= 0.13), python-gi (>= 3.2), gir1.2-gtk-3.0 (>= 3.4),
+ ${python:Depends}, python3-pyudev (>= 0.13), python3-gi (>= 3.2), gir1.2-gtk-3.0 (>= 3.4),
  ${solaar:Desktop-Icon-Theme}
 Recommends: gir1.2-notify-0.7, consolekit (>= 0.4.3) | systemd (>= 44),
- python-dbus (>= 1.1.0), upower
-Suggests: gir1.2-appindicator3-0.1
+ python3-dbus (>= 1.1.0), upower
+Suggests: gir1.2-ayatanaappindicator3-0.1 | gir1.2-appindicator3-0.1
 Description: Logitech Unifying Receiver peripherals manager for Linux
  Solaar is a Linux device manager for Logitech's Unifying Receiver peripherals.
  It is able to pair/unpair devices to the receiver, and for some devices read

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ battery status.
 		platforms=['linux'],
 
 		# sudo apt install python-gi python3-gi \
-		#        gir1.2-gtk-3.0 gir1.2-notify-0.7 gir1.2-appindicator3-0.1
+		#        gir1.2-gtk-3.0 gir1.2-notify-0.7 gir1.2-ayatanaappindicator3-0.1
 		# os_requires=['gi.repository.GObject (>= 2.0)', 'gi.repository.Gtk (>= 3.0)'],
 
 		python_requires='>=3.2',


### PR DESCRIPTION
Unity's libappindicator is deprecated in Debian since almost more than two years (for several reasons). This also includes Debian 10 (buster) which is the current stable distribution. For more information, please have a look at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=895037 and https://wiki.debian.org/Ayatana/IndicatorsTransition.
They started to use [GNOME's libayatana-appindicator](https://ayatanaindicators.github.io/) instead which is a maintained fork of Unity's libappindicator. libayatana-appindicator has also been in Ubuntu since Ubuntu 18.04LTS (bionic beaver). So users of Ubuntu Budgie, Kubuntu and Xubuntu can also benefit from this additional support.

Please consider this PR to support the transition to Ayatana Indicators.