### PR TITLE
install: fix up errors when required packages not installed

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,7 +17,7 @@ and the `python3-pyudev` package.
 To run the GUI, solaar also requires Gtk3, and its GObject
 Introspection bindings. The Debian/Ubuntu package names are
 `python3-gi` and `gir1.2-gtk-3.0`;
-in Fedora you only need `python3-gobject`;
+in Fedora you need  `gtk3` and `python3-gobject`;
 if you're using another
 distribution the required packages are most likely named something similar.
 

--- a/lib/solaar/gtk.py
+++ b/lib/solaar/gtk.py
@@ -31,10 +31,12 @@ import solaar.cli as _cli
 #
 #
 
-def _require(module, os_package):
+def _require(module, os_package, gi=None, gi_package=None, gi_version=None):
 	try:
+		if gi is not None:
+			gi.require_version(gi_package,gi_version)
 		return importlib.import_module(module)
-	except ImportError:
+	except (ImportError, ValueError):
 		import sys
 		sys.exit("%s: missing required system package %s" % (NAME, os_package))
 
@@ -94,8 +96,7 @@ def main():
 		return _cli.run(args.action, args.hidraw_path)
 
 	gi = _require('gi', 'python3-gi or python3-gobject')
-	gi.require_version('Gtk', '3.0')
-	_require('gi.repository.Gtk', 'gir1.2-gtk-3.0')
+	_require('gi.repository.Gtk', 'gir1.2-gtk-3.0', gi, 'Gtk', '3.0')
 
 	try:
 		import solaar.ui as ui


### PR DESCRIPTION
The code had a require_version for Gtk 3.0 before the call to the _require function that caught the exception.  This change moves that check into the _require function so that the error message is printed instead of dumping core.

Fixes #462 

I checked the code by setting up a Fedora container and running solaar from within the container with several variations of packages installed.