### PR TITLE
devices: support for MX Vertical mouse

### DIFF
--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -487,9 +487,6 @@ _D(
     codename='MX Vertical',
     protocol=4.5,
     wpid='407B',
-    settings=[
-        _FS.mx_vertical_dpi_sliding(),
-    ],
 )
 
 _D(

--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -482,7 +482,15 @@ _D(
     ],
 )
 
-_D('Wireless Mouse MX Vertical', codename='MX Vertical', protocol=4.5, wpid='407B')
+_D(
+    'Wireless Mouse MX Vertical',
+    codename='MX Vertical',
+    protocol=4.5,
+    wpid='407B',
+    settings=[
+        _FS.mx_vertical_dpi_sliding(),
+    ],
+)
 
 _D(
     'G7 Cordless Laser Mouse',

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -647,6 +647,7 @@ class KeysArray(object):
             return [self.__getitem__(i) for i in range(*indices)]
 
     def index(self, value):
+        self._ensure_all_keys_queried()
         for index, k in enumerate(self.keys):
             if k is not None and int(value) == int(k.key):
                 return index

--- a/lib/logitech_receiver/notifications.py
+++ b/lib/logitech_receiver/notifications.py
@@ -103,6 +103,12 @@ def _process_device_notification(device, status, n):
     # HID++ 1.0 requests, should never get here
     assert n.sub_id & 0x80 == 0
 
+    # Allow the device object to handle the notification using custom
+    # per-device state.
+    handling_ret = device.handle_notification(n)
+    if handling_ret is not None:
+        return handling_ret
+
     # 0x40 to 0x7F appear to be HID++ 1.0 or DJ notifications
     if n.sub_id >= 0x40:
         if len(n.data) == _DJ_NOTIFICATION_LENGTH:

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -109,7 +109,7 @@ class Receiver(object):
                 self._remaining_pairings = ps - 5 if ps >= 5 else -1
         return self._remaining_pairings
 
-    def enable_notifications(self, enable=True):
+    def enable_connection_notifications(self, enable=True):
         """Enable or disable device (dis)connection notifications on this
         receiver."""
         if not self.handle:

--- a/lib/logitech_receiver/status.py
+++ b/lib/logitech_receiver/status.py
@@ -290,7 +290,7 @@ class DeviceStatus(dict):
                     # get cleared when the device is turned off (but not when the device
                     # goes idle, and we can't tell the difference right now).
                     if d.protocol < 2.0:
-                        self[KEYS.NOTIFICATION_FLAGS] = d.enable_notifications()
+                        self[KEYS.NOTIFICATION_FLAGS] = d.enable_connection_notifications()
 
                     # If we've been inactive for a long time, forget anything
                     # about the battery. (This is probably unnecessary.)

--- a/lib/solaar/listener.py
+++ b/lib/solaar/listener.py
@@ -80,7 +80,7 @@ class ReceiverListener(_listener.EventsListener):
     def has_started(self):
         if _log.isEnabledFor(_INFO):
             _log.info('%s: notifications listener has started (%s)', self.receiver, self.receiver.handle)
-        notification_flags = self.receiver.enable_notifications()
+        notification_flags = self.receiver.enable_connection_notifications()
         self.receiver.status[_status.KEYS.NOTIFICATION_FLAGS] = notification_flags
         self.receiver.notify_devices()
         self._status_changed(self.receiver)  # , _status.ALERT.NOTIFICATION)

--- a/lib/solaar/ui/__init__.py
+++ b/lib/solaar/ui/__init__.py
@@ -160,7 +160,7 @@ def run_loop(startup_hook, shutdown_hook, use_tray, show_window, args=None):
 #
 
 
-def _status_changed(device, alert, reason):
+def _status_changed(device, alert, reason, refresh=False):
     assert device is not None
     if _log.isEnabledFor(_DEBUG):
         _log.debug('status changed: %s (%s) %s', device, alert, reason)
@@ -170,11 +170,11 @@ def _status_changed(device, alert, reason):
         tray.attention(reason)
 
     need_popup = alert & ALERT.SHOW_WINDOW
-    window.update(device, need_popup)
+    window.update(device, need_popup, refresh)
 
     if alert & (ALERT.NOTIFICATION | ALERT.ATTENTION):
         notify.show(device, reason)
 
 
-def status_changed(device, alert=ALERT.NONE, reason=None):
-    GLib.idle_add(_status_changed, device, alert, reason)
+def status_changed(device, alert=ALERT.NONE, reason=None, refresh=False):
+    GLib.idle_add(_status_changed, device, alert, reason, refresh)

--- a/lib/solaar/ui/notify.py
+++ b/lib/solaar/ui/notify.py
@@ -103,8 +103,10 @@ if available:
             except Exception:
                 _log.exception('showing %s', n)
 
-    def show(dev, reason=None, icon=None):
-        """Show a notification with title and text."""
+    def show(dev, reason=None, icon=None, progress=None):
+        """Show a notification with title and text.
+        Optionally displays the `progress` integer value
+        in [0, 100] as a progress bar."""
         if available and Notify.is_initted():
             summary = dev.name
 
@@ -130,6 +132,8 @@ if available:
             urgency = Notify.Urgency.LOW if dev.status else Notify.Urgency.NORMAL
             n.set_urgency(urgency)
             n.set_hint('desktop-entry', GLib.Variant('s', NAME.lower()))
+            if progress:
+                n.set_hint('value', GLib.Variant('i', progress))
 
             try:
                 # if _log.isEnabledFor(_DEBUG):

--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -840,7 +840,7 @@ def destroy(_ignore1=None, _ignore2=None):
     _model = None
 
 
-def update(device, need_popup=False):
+def update(device, need_popup=False, refresh=False):
     if _window is None:
         return
 
@@ -877,7 +877,7 @@ def update(device, need_popup=False):
         item = _device_row(path, device.number, device if bool(device) else None)
 
         if bool(device) and item:
-            update_device(device, item, selected_device_id, need_popup)
+            update_device(device, item, selected_device_id, need_popup, full=refresh)
         elif item:
             _model.remove(item)
             _config_panel.clean(device)
@@ -886,7 +886,7 @@ def update(device, need_popup=False):
     _tree.expand_all()
 
 
-def update_device(device, item, selected_device_id, need_popup):
+def update_device(device, item, selected_device_id, need_popup, full=False):
     was_online = _model.get_value(item, _COLUMN.ACTIVE)
     is_online = bool(device.online)
     _model.set_value(item, _COLUMN.ACTIVE, is_online)
@@ -912,5 +912,5 @@ def update_device(device, item, selected_device_id, need_popup):
     if selected_device_id is None or need_popup:
         select(device.receiver.path if device.receiver else device.path, device.number)
     elif selected_device_id == (device.receiver.path if device.receiver else device.path, device.number):
-        full_update = need_popup or was_online != is_online
+        full_update = full or was_online != is_online
         _update_info_panel(device, full=full_update)


### PR DESCRIPTION
Closes #573

Implementation status:

- [x] descriptor and DPI button ID for MX Vertical mouse
- [x] full support for `REPROG_CONTROLS_V4`
- [x] backend interface for diverting and remapping controls
- [x] initial support for diverted press/raw XY notifications
- [x] controlling DPI via sliding on the MX Vertical