### PR TITLE
receiver: don't check that device kind matches feature kind

### DIFF
--- a/lib/logitech_receiver/settings.py
+++ b/lib/logitech_receiver/settings.py
@@ -60,7 +60,8 @@ class Setting(object):
 
 	def __call__(self, device):
 		assert not hasattr(self, '_value')
-		assert self.device_kind is None or device.kind in self.device_kind
+		# combined keyboards and touchpads (e.g., K400) break this assertion so don't use it
+		# assert self.device_kind is None or device.kind in self.device_kind
 		p = device.protocol
 		if p == 1.0:
 			# HID++ 1.0 devices do not support features


### PR DESCRIPTION
Combined devices like the K400 have a keyboard and a trackpad but identify as keyboards so they can break the assumption that the kind of a feature matches the kind of the device.  To fix this remove the check in settings.py for this match.  Otherwise there would have to be special information about these kinds of devices and the check isn't doing anything particularly useful.
The feature in question for the K400 is hi res scroll.

Fixes #266