### PR TITLE
ui: remove assert that updated receiver is still in window

### DIFF
--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -783,7 +783,6 @@ def update(device, need_popup=False):
 		# receiver
 		is_alive = bool(device)
 		item = _receiver_row(device.path, device if is_alive else None)
-		assert item
 
 		if is_alive and item:
 			was_pairing = bool(_model.get_value(item, _COLUMN.STATUS_ICON))


### PR DESCRIPTION
The assert was violated in a few cases where nothing seemed to be wrong.
I looked over the code and it doesn't appear that anything bad will happen if the condition is false.

Fixes #651 