### PR TITLE
docs: dixed name typo for MX Master 2S

### DIFF
--- a/docs/devices.md
+++ b/docs/devices.md
@@ -105,7 +105,7 @@ You are able to read this feature using command-line interface of Solaar, but it
 | Anywhere MX      | 1017 | 1.0   | yes     | R/W   | smooth scrolling, side scrolling|
 | Anywhere MX 2    | 404A | 2.0   | yes     | R/W   | smooth scrolling                |
 | MX Master        | 4041 | 2.0   | yes     | R/W   | smooth scrolling, smart shift   |
-| MX Master 25     | 4069 | 2.0   | yes     | R/W   | smooth scrolling, smart shift   |
+| MX Master 2S     | 4069 | 2.0   | yes     | R/W   | smooth scrolling, smart shift   |
 | Cube             |      | 2.0   | yes     |       |                                 |
 
 


### PR DESCRIPTION
I have this mouse and I was confused at the beginning if this would be a different model but then I saw the same WPID so I thought of just fixing the typo.