### PR TITLE
SJL/add pebble M350

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ __pycache__/
 /docs/captures/
 /share/logitech_icons/
 /share/locale/
+/.idea/
+/venv/

--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -273,7 +273,7 @@ _D('Wireless Mouse M345', protocol=2.0, wpid='4017')
 _D('Wireless Mouse M350', protocol=1.0, wpid='101C',
 				registers=(_R.battery_charge, ),
 				)
-_D('Wireless Mouse Pebble M350', protocol=2.0, wpid='4080')
+_D('Wireless Mouse Pebble M350', codename='Pebble', protocol=2.0, wpid='4080')
 _D('Wireless Mouse M505', codename='M505/B605', protocol=1.0, wpid='101D',
 				registers=(_R.battery_charge, ),
 				settings=[

--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -273,6 +273,7 @@ _D('Wireless Mouse M345', protocol=2.0, wpid='4017')
 _D('Wireless Mouse M350', protocol=1.0, wpid='101C',
 				registers=(_R.battery_charge, ),
 				)
+_D('Wireless Mouse Pebble M350', protocol=2.0, wpid='4080')
 _D('Wireless Mouse M505', codename='M505/B605', protocol=1.0, wpid='101D',
 				registers=(_R.battery_charge, ),
 				settings=[


### PR DESCRIPTION
Added a line to `descriptors.py` for Pebble M350 mouse. On my machine I find that it now shows battery level, `HID++ Scrolling` toggle and a `dpi` control.