### PR TITLE
prepare for release 1.0.2rc2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,23 @@
-1.0.2-rc2:
-  * Add support for Ayatana AppIndicator
+1.0.2rc2:
+  * Pip installs udev rule and solaar autostart when not doing --user install
+  * Use only standard icons for battery levels.  Symbolic icons do not change to white in dark themes because of problems external to Solaar.
+  * Better reporting of battery levels when charging for some devices.
+  * Add information on K600 TV, M350 WIPD 4080, and MX Keys
+  * Remove assertion requiring receivers to still be in window when they are updated.
+  * Augment long description of Solaar showing up in repositories.
+  * Update installation directions.
+  * Install udev rule as well as autostart file when doing system install.
+  * Add support for Ayatana AppIndicator.
+  * Use setuptools icon directory on system installs when not using pip.
+  * Add receiver C517 and several older devices.
+  * Improved translations for polish.
+  * Bypass bug in appindicator when solaar is file in current directory.
+  * Don't check that device kind matches feature kind.
+  * Better determination of icons for battery levels.
+  * Use Ayatana AppIndicator if available.
+  * Improve error reporting when required system packages are not install.
+  * Better tooltip description
+  * Add release script to help when creating releases
 
 1.0.2-rc1:
   * Look up tray icon filenames to get around a bug in libappindicator.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,7 +4,7 @@ tagline: Linux Device manager for the Logitech Unifying Receiver.
 owner: pwr-Solaar
 owner_url: https://github.com/pwr-Solaar
 repository: pwr-Solaar/Solaar
-version: 1.0.2-rc1
+version: 1.0.2rc2
 show_downloads: false
 encoding: utf-8
 theme: jekyll-theme-slate

--- a/lib/solaar/__init__.py
+++ b/lib/solaar/__init__.py
@@ -19,5 +19,5 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-__version__ = '1.0.2-rc1'
+__version__ = '1.0.2rc2'
 NAME = 'Solaar'

--- a/release.sh
+++ b/release.sh
@@ -40,7 +40,7 @@ done
 version=$(sed '/^__version__/!d' setup.py | cut -d\' -f2)
 
 prerelease=false
-echo $version | grep '.*-rc.*' >/dev/null
+echo $version | grep '.*rc.*' >/dev/null
 [ $? -eq 0 ] && prerelease=true
 
 ref=$(git symbolic-ref HEAD)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
 autostart_path = '/etc/xdg/autostart'
 
 #from solaar import NAME, __version__
-__version__ = '1.0.2-rc1'
+__version__ = '1.0.2rc2'
 NAME = 'Solaar'
 
 


### PR DESCRIPTION
Note that this PR removes the hyphen before rc2, as this seems to be what Python releases want.