### PR TITLE
ui: use Solaar icon instead of missing battery icons

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 1.0.2rc2:
   * Remove packaging directory tree as it is not maintained
   * Pip installs udev rule and solaar autostart when not doing --user install
+  * Use Solaar icon instead of a missing battery icon
   * Use only standard icons for battery levels.  Symbolic icons do not change to white in dark themes because of problems external to Solaar.
   * Better reporting of battery levels when charging for some devices.
   * Add information on K600 TV, M350 WIPD 4080, and MX Keys

--- a/lib/solaar/ui/icons.py
+++ b/lib/solaar/ui/icons.py
@@ -95,7 +95,8 @@ def _init_icon_paths():
 def battery(level=None, charging=False):
 	icon_name = _battery_icon_name(level, charging)
 	if not _default_theme.has_icon(icon_name):
-		_log.warning("icon %s not found in current theme", icon_name);
+		_log.warning("icon %s not found in current theme", icon_name)
+		return TRAY_OKAY # use Solaar icon if battery icon not available
 	elif _log.isEnabledFor(_DEBUG):
 		_log.debug("battery icon for %s:%s = %s", level, charging, icon_name)
 	return icon_name


### PR DESCRIPTION
It's silly to check and warn about a missing icon but then try to use it.