### PR TITLE
release: fix up RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,11 +3,12 @@
 ###### Please read before making a release.
 
 We support two type of releases: normal releases (ex. `1.0.0`) and release
-candidates (ex. `1.0.0-rc1`). Release candidates must have a `-rcX` prefix.
+candidates (ex. `1.0.0rc1`). Release candidates must have a `rcX` suffix.
 
 Release routine:
-  - Update the ChangeLog and setup.py to the new version and create a commit
-    - Release commits must start with `release VERSION`
+  - Update ChangeLog, setup.py, lib/solaar/__init__.py, and docs/_config.yml to the new version
+  - Create a commit that starts with `release VERSION`
+  - Push commit to Solaar repository
   - Invoke `./release.sh`
     - Git tags are signed so you must have GPG set up
     - You are required to have a have a github token with `public_repo` access


### PR DESCRIPTION
It did not mention all the places where the release number needs to be changed.
It did not mention that the release commit needs to be pushed to the Solaar repository.
It had the old way to name release candidates.