### PR TITLE
ui: don't complain for receivers in other seats

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 1.0.2rc2:
   * Remove packaging directory tree as it is not maintained
   * Pip installs udev rule and solaar autostart when not doing --user install
+  * Don't complain for receivers that are for other seats
   * Use Solaar icon instead of a missing battery icon
   * Use only standard icons for battery levels.  Symbolic icons do not change to white in dark themes because of problems external to Solaar.
   * Better reporting of battery levels when charging for some devices.

--- a/lib/solaar/listener.py
+++ b/lib/solaar/listener.py
@@ -343,4 +343,13 @@ def _process_receiver_event(action, device_info):
 			_start(device_info)
 		except OSError:
 			# permission error, ignore this path for now
-			_error_callback('permissions', device_info.path)
+			# If receiver has extended ACL but not writable then it is for another seat.
+			# (It would be easier to use pylibacl but adding the pylibacl dependencies
+			# for this special case is not good.)
+			try: 
+				import subprocess, re
+				output = subprocess.check_output(['/usr/bin/getfacl', '-p', device_info.path])
+				if not re.search(b'user:.+:',output) :
+					_error_callback('permissions', device_info.path)
+			except:
+				_error_callback('permissions', device_info.path)


### PR DESCRIPTION
If a receiver is not writable but has ACL permissions is it for another seat so don't produce an error for it. 
This is done by calling getfacl instead of using pylibacl as pylibacl has dependencies and adding dependencies for this special case does not seem worthwhile.


Fixes #465