### PR TITLE
ui: don't complain for receivers in other seats

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+New:
+  * Don't complain for receivers that are for other seats
+
 1.0.2rc2: 
   * Remove packaging directory tree as it is not maintained
   * Pip installs udev rule and solaar autostart when doing install without --user flag

--- a/lib/solaar/listener.py
+++ b/lib/solaar/listener.py
@@ -343,4 +343,13 @@ def _process_receiver_event(action, device_info):
 			_start(device_info)
 		except OSError:
 			# permission error, ignore this path for now
-			_error_callback('permissions', device_info.path)
+			# If receiver has extended ACL but not writable then it is for another seat.
+			# (It would be easier to use pylibacl but adding the pylibacl dependencies
+			# for this special case is not good.)
+			try: 
+				import subprocess, re
+				output = subprocess.check_output(['/usr/bin/getfacl', '-p', device_info.path])
+				if not re.search(b'user:.+:',output) :
+					_error_callback('permissions', device_info.path)
+			except:
+				_error_callback('permissions', device_info.path)


### PR DESCRIPTION
If a receiver is not writable but has an ACL it is for another seat so don't complain.
Using the python interface to ACL is nicer but has dependencies, which is not good for such an edge case.

Fixes #391 