### PR TITLE
git: add lib/solaar.egg-info/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 *.mo
 
 /lib/Solaar.egg-info/
+/lib/solaar.egg-info/
 /build/
 /sdist/
 /dist/


### PR DESCRIPTION
setup.py creates lib/solaar.egg-info/ so add it to .gitignore