### PR TITLE
ui: add --battery-icons=symbolic option to prefer symbolic icons

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -102,23 +102,13 @@ For many devices, Solaar shows the approximate battery level via icons that
 show up in both main Solaar window and the system tray.  Solaar used to use
 several heuristics to determine which icon names to use for this purpose,
 but as more and more battery icon schemes have been developed this has
-become impossible to do well.  Solaar now only uses the eleven standard
+become impossible to do well.  Solaar now uses the eleven standard
 battery icon names `battery-{full,good,low,critical,empty}[-charging]` and
-`battery-missing`.  To use different icons from you have to change (part of)
-your GTK icon theme.
+`battery-missing`.  
 
-Solaar is not using the symbolic versions of these icons because of a bug
-external to Solaar that results in these icons not changing to the
-foreground colour in the system tray.  This can leave these icons nearly
-invisible in dark themes.  It would be useful to be able to switch to
-symbolic icons via GTK styling (using something like
-`.solaar * { -gtk-icon-style: symbolic; }` in the user's gtk.css)
-but most or all current system tray implementations do not allow for this.
-
-As a temporary hack setting the SOLAAR_TRAY_BATTERY_ICON_SYBOLIC environment
-variable will cause Solaar to use symbolic icons for battery levels in the
-system tray.
-
+Solaar will use the symbolic versions of these icons if started with the
+option `--battery-icons=symbolic`.  Because of bugs external to Solaar 
+these symbolic icons may be nearly invisible in dark themes.  
 
 [solaar]: https://github.com/pwr-Solaar/Solaar
 [logitech]: https://www.logitech.com

--- a/lib/solaar/gtk.py
+++ b/lib/solaar/gtk.py
@@ -40,6 +40,7 @@ def _require(module, os_package, gi=None, gi_package=None, gi_version=None):
 		import sys
 		sys.exit("%s: missing required system package %s" % (NAME, os_package))
 
+prefer_symbolic_battery_icons = False
 
 def _parse_arguments():
 	import argparse
@@ -51,6 +52,7 @@ def _parse_arguments():
 	arg_parser.add_argument('--restart-on-wake-up', action='store_true',
 							help='restart Solaar on sleep wake-up (experimental)')
 	arg_parser.add_argument('-w', '--window', choices=('show','hide','only'), help='start with window showing / hidden / only (no tray icon)')
+	arg_parser.add_argument('-b', '--battery-icons', choices=('regular','symbolic'), help='prefer regular / symbolic icons')
 	arg_parser.add_argument('-V', '--version', action='version', version='%(prog)s ' + __version__)
 	arg_parser.add_argument('--help-actions', action='store_true',
 							help='print help for the optional actions')
@@ -65,6 +67,9 @@ def _parse_arguments():
 
 	if args.window is None:
 		args.window = 'show' # default behaviour is to show main window
+
+	global prefer_symbolic_battery_icons
+	prefer_symbolic_battery_icons = True if args.battery_icons == 'symbolic' else False
 
 	import logging
 	if args.debug > 0:

--- a/lib/solaar/ui/icons.py
+++ b/lib/solaar/ui/icons.py
@@ -24,6 +24,7 @@ _log = getLogger(__name__)
 del getLogger
 
 from gi.repository import Gtk
+import solaar.gtk as gtk
 
 #
 #
@@ -73,6 +74,7 @@ def _look_for_application_icons():
 
 
 _default_theme = None
+_use_symbolic_icons = False
 
 def _init_icon_paths():
 	global _default_theme
@@ -85,6 +87,13 @@ def _init_icon_paths():
 	if _log.isEnabledFor(_DEBUG):
 		_log.debug("icon theme paths: %s", _default_theme.get_search_path())
 
+	if gtk.prefer_symbolic_battery_icons:
+		if _default_theme.has_icon('battery-good-symbolic'):
+			global _use_symbolic_icons
+			_use_symbolic_icons = True
+			return
+		else:
+			_log.warning("failed to detect symbolic icons")
 	if not _default_theme.has_icon('battery-good'):
 		_log.warning("failed to detect icons")
 
@@ -110,10 +119,10 @@ def _battery_icon_name(level, charging):
 	_init_icon_paths()
 
 	if level is None or level < 0:
-		return 'battery-missing'
+		return 'battery-missing' + ( '-symbolic' if _use_symbolic_icons else '' )
 
 	level_name = _first_res(level,((90,'full'), (50,'good'), (20,'low'), (5,'caution'), (0,'empty')))
-	return 'battery-%s%s' % (level_name, '-charging' if charging else '')
+	return 'battery-%s%s%s' % (level_name, '-charging' if charging else '', '-symbolic' if _use_symbolic_icons else '')
 
 #
 #

--- a/lib/solaar/ui/tray.py
+++ b/lib/solaar/ui/tray.py
@@ -203,9 +203,6 @@ try:
 			battery_charging = device_status.get(_K.BATTERY_CHARGING)
 			tray_icon_name = _icons.battery(battery_level, battery_charging)
 
-			# get around system tray icons not having styling and not having css class
-			tray_icon_name = tray_icon_name + ( "-symbolic" if "SOLAAR_TRAY_BATTERY_ICON_SYBOLIC" in os.environ else "" )
-
 			description =  '%s: %s' % (name, device_status.to_string())
 		else:
 			# there may be a receiver, but no peripherals
@@ -263,9 +260,6 @@ except ImportError:
 			battery_level = device_status.get(_K.BATTERY_LEVEL)
 			battery_charging = device_status.get(_K.BATTERY_CHARGING)
 			tray_icon_name = _icons.battery(battery_level, battery_charging)
-
-			# get around system tray icons not having styling and not having css class
-			tray_icon_name = tray_icon_name + ( "-symbolic" if "SOLAAR_TRAY_BATTERY_ICON_SYBOLIC" in os.environ else "" )
 		else:
 			# there may be a receiver, but no peripherals
 			tray_icon_name = _icons.TRAY_OKAY if _devices_info else _icons.TRAY_ATTENTION


### PR DESCRIPTION
This is a better solution than using an environment variable, although it probably means supporting the option for the forseeable future.

Fixes #768
Fixes #84