### PR TITLE
devices: pass arguments through in feature_choices_dynamic

### DIFF
--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -100,7 +100,7 @@ def feature_choices_dynamic(name, feature, choices_callback,
 		setting = feature_choices(name, feature, choices,
 						read_function_id, write_function_id,
 						bytes_count=bytes_count,
-						label=None, description=None, device_kind=None)
+						label=label, description=description, device_kind=device_kind)
 		return setting(device)
 	return instantiate
 


### PR DESCRIPTION
Fixes problem with displaying dpi in main window.
It would be good to also have a "tooltip" for _DPI and _POINTER_SPEED but I don't know what should be put there.
See #776 for an example of the suboptimal output.