### PR TITLE
only check device features once per device, not every time device settings are enumerated

### DIFF
--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -71,6 +71,7 @@ class PairedDevice(object):
 		self._keys = None
 		self._registers = None
 		self._settings = None
+		self._feature_settings_checked = False
 
 		# Misc stuff that's irrelevant to any functionality, but may be
 		# displayed in the UI and caching it here helps.
@@ -251,8 +252,8 @@ class PairedDevice(object):
 				self._settings = [s(self) for s in self.descriptor.settings]
 			else:
 				self._settings = []
-
-		_check_feature_settings(self, self._settings)
+		if not self._feature_settings_checked:
+			self._feature_settings_checked =_check_feature_settings(self, self._settings)
 		return self._settings
 
 	def enable_notifications(self, enable=True):

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -371,12 +371,13 @@ del _SETTINGS_LIST
 #
 #
 
+# Returns True if device was queried to find features, False otherwise
 def check_feature_settings(device, already_known):
 	"""Try to auto-detect device settings by the HID++ 2.0 features they have."""
 	if device.features is None or not device.online:
-		return
+		return False
 	if device.protocol and device.protocol < 2.0:
-		return
+		return False
 
 	def check_feature(name, featureId, field_name=None):
 		"""
@@ -414,3 +415,4 @@ def check_feature_settings(device, already_known):
 	check_feature(_POINTER_SPEED[0], _F.POINTER_SPEED)
 	check_feature(_SMART_SHIFT[0],   _F.SMART_SHIFT)
 	check_feature(_BACKLIGHT[0],   	 _F.BACKLIGHT2)
+	return True


### PR DESCRIPTION
This used to be checked when switching the shown device in the  main window, leading to slow response, as the UI had to wait for all the device features to be checked.  This change only checks for the device features when nothing is known about the device, on the plausible assumption that the features that a device implements doesn't change.