### PR TITLE
use Settings interface in `solaar show`

### DIFF
--- a/lib/logitech_receiver/settings.py
+++ b/lib/logitech_receiver/settings.py
@@ -42,15 +42,16 @@ KIND = _NamedInts(toggle=0x01, choice=0x02, range=0x04)
 class Setting(object):
 	"""A setting descriptor.
 	Needs to be instantiated for each specific device."""
-	__slots__ = ('name', 'label', 'description', 'kind', 'device_kind',
+	__slots__ = ('name', 'label', 'description', 'kind', 'device_kind', 'feature', 
 					'_rw', '_validator', '_device', '_value')
 
-	def __init__(self, name, rw, validator, kind=None, label=None, description=None, device_kind=None):
+	def __init__(self, name, rw, validator, kind=None, label=None, description=None, device_kind=None, feature=None):
 		assert name
 		self.name = name
 		self.label = label or name
 		self.description = description
 		self.device_kind = device_kind
+		self.feature = feature
 
 		self._rw = rw
 		self._validator = validator

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -78,7 +78,7 @@ def feature_toggle(name, feature,
 					label=None, description=None, device_kind=None):
 	validator = _BooleanV(true_value=true_value, false_value=false_value, mask=mask)
 	rw = _FeatureRW(feature, read_function_id, write_function_id)
-	return _Setting(name, rw, validator, label=label, description=description, device_kind=device_kind)
+	return _Setting(name, rw, validator, feature=feature, label=label, description=description, device_kind=device_kind)
 
 def feature_choices(name, feature, choices,
 					read_function_id, write_function_id,
@@ -87,7 +87,7 @@ def feature_choices(name, feature, choices,
 	assert choices
 	validator = _ChoicesV(choices, bytes_count=bytes_count)
 	rw = _FeatureRW(feature, read_function_id, write_function_id)
-	return _Setting(name, rw, validator, kind=_KIND.choice, label=label, description=description, device_kind=device_kind)
+	return _Setting(name, rw, validator, feature=feature, kind=_KIND.choice, label=label, description=description, device_kind=device_kind)
 
 def feature_choices_dynamic(name, feature, choices_callback,
 					read_function_id, write_function_id,
@@ -113,7 +113,7 @@ def feature_range(name, feature, min_value, max_value,
 	validator = _RangeV(min_value, max_value, bytes_count=bytes_count)
 	if rw is None:
 		rw = _FeatureRW(feature, read_function_id, write_function_id)
-	return _Setting(name, rw, validator, kind=_KIND.range, label=label, description=description, device_kind=device_kind)
+	return _Setting(name, rw, validator, feature=feature, kind=_KIND.range, label=label, description=description, device_kind=device_kind)
 
 #
 # common strings for settings


### PR DESCRIPTION
`solaar show` uses Settings interface to show values for features if there is no built-in code to show feature.

Also comment out code for feature LOWRES_WHEEL as the Settings interface does a good job on this feature.

This means that new HID++ features do not need to be implemented in show.py or in hidpp20.py, only in settings_templates.py.

Fixes #687