### PR TITLE
receiver: fix error when settings listed on descriptor.py return None

### DIFF
--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -250,6 +250,7 @@ class PairedDevice(object):
 		if self._settings is None:
 			if self.descriptor and self.descriptor.settings:
 				self._settings = [s(self) for s in self.descriptor.settings]
+				self._settings = [s for s in self._settings if s is not None]
 			else:
 				self._settings = []
 		if not self._feature_settings_checked:


### PR DESCRIPTION
The implementation of `feature_map_choices_dynamic` returns `None` when no choices are available. 

https://github.com/pwr-Solaar/Solaar/blob/c5ca2c2818fdd81647b2959a9433edf333e4af2b/lib/logitech_receiver/settings_templates.py#L158-L160

In that case, `None` should not be stored among real settings, otherwise several errors occur when the setting is listed on [descriptors.py](https://github.com/pwr-Solaar/Solaar/blob/master/lib/logitech_receiver/descriptors.py). Example of error:

```
File "…/Solaar/lib/solaar/ui/window.py", line 381, in _device_selected
    _update_info_panel(device, full=True)
  File "…/Solaar/lib/solaar/ui/window.py", line 721, in _update_info_panel
    _update_device_panel(device, _info._device, _info._buttons, full)
  File "…/Solaar/lib/solaar/ui/window.py", line 692, in _update_device_panel
    _config_panel.update(device, is_online)
  File "…/Solaar/lib/solaar/ui/config_panel.py", line 282, in update
    for s in device.settings:
  File "…/Solaar/lib/logitech_receiver/receiver.py", line 256, in settings
    self._feature_settings_checked =_check_feature_settings(self, self._settings)
  File "…/Solaar/lib/logitech_receiver/settings_templates.py", line 540, in check_feature_settings
    check_feature(_REPROGRAMMABLE_KEYS[0], _F.REPROG_CONTROLS_V4)
  File "…/Solaar/lib/logitech_receiver/settings_templates.py", line 513, in check_feature
    if any(s.name == name for s in already_known):
  File "…/Solaar/lib/logitech_receiver/settings_templates.py", line 513, in <genexpr>
    if any(s.name == name for s in already_known):
AttributeError: 'NoneType' object has no attribute 'name'
```

To fix that, we just have to remove the `None` values after this:
https://github.com/pwr-Solaar/Solaar/blob/c5ca2c2818fdd81647b2959a9433edf333e4af2b/lib/logitech_receiver/receiver.py#L252