### PR TITLE
Idle devices - exceptions caused by dynamic features

### DIFF
--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -271,11 +271,18 @@ class PairedDevice(object):
     @property
     def settings(self):
         if self._settings is None:
+            self._settings = []
             if self.descriptor and self.descriptor.settings:
-                self._settings = [s(self) for s in self.descriptor.settings]
-                self._settings = [s for s in self._settings if s is not None]
-            else:
                 self._settings = []
+                for s in self.descriptor.settings:
+                    try:
+                        setting = s(self)
+                    except Exception as e:
+                        # Do nothing if the device is offline
+                        if self.online:
+                            raise e
+                    if setting is not None:
+                        self._settings.append(setting)
         if not self._feature_settings_checked:
             self._feature_settings_checked = _check_feature_settings(self, self._settings)
         return self._settings


### PR DESCRIPTION
The implementation of dynamic features causes some exceptions when we click the name of an **idle** device. An example:
<details>

```
Traceback (most recent call last):
  File "…/Solaar/lib/solaar/ui/window.py", line 395, in _device_selected
    _update_info_panel(device, full=True)
  File "…/Solaar/lib/solaar/ui/window.py", line 759, in _update_info_panel
    _update_device_panel(device, _info._device, _info._buttons, full)
  File "…/Solaar/lib/solaar/ui/window.py", line 730, in _update_device_panel
    _config_panel.update(device, is_online)
  File "…/Solaar/lib/solaar/ui/config_panel.py", line 292, in update
    for s in device.settings:
  File "…/Solaar/lib/logitech_receiver/receiver.py", line 275, in settings
    self._settings = [s(self) for s in self.descriptor.settings]
  File "…/Solaar/lib/logitech_receiver/receiver.py", line 275, in <listcomp>
    self._settings = [s(self) for s in self.descriptor.settings]
  File "…/Solaar/lib/logitech_receiver/settings_templates.py", line 178, in instantiate
    choices = choices_callback(device)
  File "…/Solaar/lib/logitech_receiver/settings_templates.py", line 532, in _feature_reprogrammable_keys_choices
    assert count, 'Oops, reprogrammable key count cannot be retrieved!'
AssertionError: Oops, reprogrammable key count cannot be retrieved!
```
</details>


Solaar still works as expected and no errors are shown if we do that when the device is online, so this is not a big problem. I think it's worth fixing it anyway, especially because those meaningless error messages may be confusing to users and can make it harder to debug real problems.

This change catches the exceptions and raises them again only if the device is online. I'm not sure if this is the best approach, so ideas are welcome.