### PR TITLE
Links to usage, capabilities, devices and installation pages broken in the project's main README.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,8 +25,8 @@ Solaar is able to pair and unpair devices with
 receivers as supported by the receiver. Solaar can also control
 some changeable features of devices, such as smooth scrolling or
 function key behavior. For more information on how to use Solaar see
-[the usage page](usage), and for more information on the capabilities see
-[the capabilities page](capabilities).
+[the usage page](./docs/usage.md), and for more information on the capabilities see
+[the capabilities page](./docs/capabilities.md).
 
 Solaar does not process normal input from the devices. It is thus unable
 to fix problems that arise from incorrect handling of mouse movements or keycodes
@@ -56,7 +56,7 @@ generally cannot be paired with Unifying receivers.
 
 For some devices, extra settings (usually not available through the standard
 Linux system configuration) are supported. For a list of supported devices
-and their features, see [the devices page](devices).
+and their features, see [the devices page](./docs/devices.md).
 
 [logo]: assets/solaar.svg
 
@@ -95,7 +95,7 @@ Solaar uses a standard system tray implementation; solaar-gnome3 is no longer re
 
 ## Manual installation
 
-See [the installation page](installation) for the step-by-step procedure for manual installation.
+See [the installation page](./docs/installation.md) for the step-by-step procedure for manual installation.
 
 ## Known Issues
 


### PR DESCRIPTION
Fixed broken links to usage, capabilities, devices and installation pages. These pages seem to be located under `/docs` folder. Have added proper paths in README.md
