### PR TITLE
receiver: don't produce pop-up notifications at startup and power on

### DIFF
--- a/lib/logitech_receiver/notifications.py
+++ b/lib/logitech_receiver/notifications.py
@@ -296,8 +296,13 @@ def _process_feature_notification(device, status, n, feature):
         if n.address == 0x00:
             if _log.isEnabledFor(_DEBUG):
                 _log.debug('wireless status: %s', n)
-            if n.data[0:3] == b'\x01\x01\x01':
-                status.changed(active=True, alert=_ALERT.NOTIFICATION, reason='powered on')
+            reason = 'powered on' if n.data[2] == 1 else None
+            if n.data[1] == 1:  # device is asking for software reconfiguration so need to change status
+                # only show a user notification if the device can change hosts
+                # as we want to notify when a device changes to this host
+                # but the only indication we get is this notification
+                alert = _ALERT.NOTIFICATION if _F.CHANGE_HOST in device.features else _ALERT.NONE
+                status.changed(active=True, alert=alert, reason=reason)
             else:
                 _log.warn('%s: unknown WIRELESS %s', device, n)
         else:

--- a/lib/logitech_receiver/status.py
+++ b/lib/logitech_receiver/status.py
@@ -318,11 +318,16 @@ class DeviceStatus(dict):
                     if battery is not None:
                         self[KEYS.BATTERY_LEVEL] = battery
 
-        if self.updated == 0 and active is True:
-            # if the device is active on the very first status notification,
-            # (meaning just when the program started or a new receiver was just
-            # detected), pop-up a notification about it
-            alert |= ALERT.NOTIFICATION
+        # A device that is not active on the first status notification
+        # but becomes active afterwards does not produce a pop-up notification
+        # so don't produce one here.  This cuts off pop-ups when Solaar starts,
+        # which can be problematic if Solaar is autostarted.
+        ## if self.updated == 0 and active is True:
+        ## if the device is active on the very first status notification,
+        ## (meaning just when the program started or a new receiver was just
+        ## detected), pop up a notification about it
+        ##    alert |= ALERT.NOTIFICATION
+
         self.updated = timestamp
 
         # if _log.isEnabledFor(_DEBUG):


### PR DESCRIPTION
Fixes #194 