### PR TITLE
Support for GESTURE_2 settings

### DIFF
--- a/docs/devices.md
+++ b/docs/devices.md
@@ -84,7 +84,7 @@ subset of HID++ 1.0 protocol. Only hardware pairing is supported.
 | K375s            | 4071 |       |         | FN swap                                 |
 | K400 Touch       | 400E | 2.0   | yes     | FN swap                                 |
 | K400 Touch       | 4024 | 2.0   | yes     | FN swap                                 |
-| K400 Plus        | 404D | 2.0   |         | FN swap                                 |
+| K400 Plus        | 404D | 2.0   |         | FN swap, disable keys, touchpad gestures|
 | K520             | 2011 | 1.0   | yes     | FN swap                                 |
 | K600 TV          | 4078 | 2.0   | yes     | FN swap                                 |
 | K750 Solar       | 4002 | 2.0   | yes     | FN swap, Lux reading, light button      |
@@ -106,38 +106,38 @@ subset of HID++ 1.0 protocol. Only hardware pairing is supported.
 
 ### Mice (Unifying)
 
-| Device           | WPID | HID++ | Battery | DPI   | Other supported features        |
-|------------------|------|-------|---------|-------|---------------------------------|
-| M150             | 4022 | 2.0   |         |       |                                 |
-| M185             | 4055 | 2.0   |         | R/W   | smooth scrolling                |
-| M310             | 4031 | 2.0   | yes     |       |                                 |
-| M310             | 4055 | 2.0   |         | R/W   | smooth scrolling                |
-| M317             |      |       |         |       |                                 |
-| M325             | 400A | 2.0   | yes     | 1000  | smooth scrolling                |
-| M330             |      | 2.0   | yes     | 1000  | smooth scrolling                |
-| M345             | 4017 | 2.0   | yes     | –     | smooth scrolling                |
-| M350             | 101C | 1.0   | yes     |       |                                 |
-| M350             | 4080 | 2.0   |         |       |                                 |
-| M505             | 101D | 1.0   | yes     |       | smooth scrolling, side scrolling|
-| M510             | 1025 | 1.0   | yes     |       | smooth scrolling, side scrolling|
-| M510             | 4051 | 2.0   | yes     |       | smooth scrolling                |
-| M515 Couch       | 4007 | 2.0   | yes     | –     | smooth scrolling                |
-| M525             | 4013 | 2.0   | yes     | –     | smooth scrolling                |
-| M560             |      | 2.0   | yes     | –     | smooth scrolling                |
-| M585             | 406B | 2.0   | yes     | R/W   | smooth scrolling                |
-| M590             | 406B | 2.0   | yes     | R/W   | smooth scrolling                |
-| M600 Touch       | 401A | 2.0   | yes     |       |                                 |
-| M705 Marathon    | 101B | 1.0   | yes     | –     | smooth scrolling, side scrolling|
-| M705 Marathon    | 406D | 2.0   | yes     | R/W   | smooth scrolling                |
-| M720 Triathlon   | 405E | 2.0   | yes     | –     |                                 |
-| T400 Zone Touch  |      | 2.0   | yes     |       | smooth scrolling                |
-| T620 Touch       |      | 2.0   | yes     |       |                                 |
-| Performance MX   | 101A | 1.0   | yes     | R/W   | smooth scrolling, side scrolling|
-| Anywhere MX      | 1017 | 1.0   | yes     | R/W   | smooth scrolling, side scrolling|
-| Anywhere MX 2    | 404A | 2.0   | yes     | R/W   | smooth scrolling                |
-| MX Master        | 4041 | 2.0   | yes     | R/W   | smooth scrolling, smart shift   |
-| MX Master 2S     | 4069 | 2.0   | yes     | R/W   | smooth scrolling, smart shift   |
-| Cube             |      | 2.0   | yes     |       |                                 |
+| Device           | WPID | HID++ | Battery | DPI   | Other supported features                |
+|------------------|------|-------|---------|-------|-----------------------------------------|
+| M150             | 4022 | 2.0   |         |       |                                         |
+| M185             | 4055 | 2.0   |         | R/W   | smooth scrolling                        |
+| M310             | 4031 | 2.0   | yes     |       |                                         |
+| M310             | 4055 | 2.0   |         | R/W   | smooth scrolling                        |
+| M317             |      |       |         |       |                                         |
+| M325             | 400A | 2.0   | yes     | 1000  | smooth scrolling                        |
+| M330             |      | 2.0   | yes     | 1000  | smooth scrolling                        |
+| M345             | 4017 | 2.0   | yes     | –     | smooth scrolling                        |
+| M350             | 101C | 1.0   | yes     |       |                                         |
+| M350             | 4080 | 2.0   |         |       |                                         |
+| M505             | 101D | 1.0   | yes     |       | smooth scrolling, side scrolling        |
+| M510             | 1025 | 1.0   | yes     |       | smooth scrolling, side scrolling        |
+| M510             | 4051 | 2.0   | yes     |       | smooth scrolling                        |
+| M515 Couch       | 4007 | 2.0   | yes     | –     | smooth scrolling                        |
+| M525             | 4013 | 2.0   | yes     | –     | smooth scrolling                        |
+| M560             |      | 2.0   | yes     | –     | smooth scrolling                        |
+| M585             | 406B | 2.0   | yes     | R/W   | smooth scrolling                        |
+| M590             | 406B | 2.0   | yes     | R/W   | smooth scrolling                        |
+| M600 Touch       | 401A | 2.0   | yes     |       |                                         |
+| M705 Marathon    | 101B | 1.0   | yes     | –     | smooth scrolling, side scrolling        |
+| M705 Marathon    | 406D | 2.0   | yes     | R/W   | smooth scrolling                        |
+| M720 Triathlon   | 405E | 2.0   | yes     | –     |                                         |
+| T400 Zone Touch  |      | 2.0   | yes     |       | smooth scrolling                        |
+| T620 Touch       |      | 2.0   | yes     |       |                                         |
+| Performance MX   | 101A | 1.0   | yes     | R/W   | smooth scrolling, side scrolling        |
+| Anywhere MX      | 1017 | 1.0   | yes     | R/W   | smooth scrolling, side scrolling        |
+| Anywhere MX 2    | 404A | 2.0   | yes     | R/W   | smooth scrolling                        |
+| MX Master        | 4041 | 2.0   | yes     | R/W   | smooth scrolling, smart shift           |
+| MX Master 2S     | 4069 | 2.0   | yes     | R/W   | smooth scrolling, smart shift, gestures |
+| Cube             |      | 2.0   | yes     |       |                                         |
 
 ### Mice (Nano)
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -93,7 +93,7 @@ Feature                                | ID       | Status             | Notes
 `TOUCHMOUSE_RAW_POINTS`                | `0x6110` | :x:                |
 `TOUCHMOUSE_6120`                      | `0x6120` | :x:                |
 `GESTURE`                              | `0x6500` | :x:                |
-`GESTURE_2`                            | `0x6501` | :x:                |
+`GESTURE_2`                            | `0x6501` | :wrench:           | `_feature_gesture2_gestures`, `_feature_gesture2_params`
 `GKEY`                                 | `0x8010` | :x:                |
 `MKEYS`                                | `0x8020` | :x:                |
 `MR`                                   | `0x8030` | :x:                |

--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -219,6 +219,8 @@ _D(
         _FS.new_fn_swap(),
         _FS.reprogrammable_keys(),
         _FS.disable_keyboard_keys(),
+        _FS.gesture2_gestures(),
+        _FS.gesture2_params(),
     ],
 )
 _D(
@@ -476,6 +478,7 @@ _D(
     settings=[
         _FS.hires_smooth_invert(),
         _FS.hires_smooth_resolution(),
+        _FS.gesture2_gestures(),
     ],
 )
 

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -58,6 +58,7 @@ class Device(object):
 
         self._firmware = None
         self._keys = None
+        self._gestures = None
         self._registers = None
         self._settings = None
         self._feature_settings_checked = False
@@ -261,6 +262,13 @@ class Device(object):
             if self.online and self.protocol >= 2.0:
                 self._keys = _hidpp20.get_keys(self) or ()
         return self._keys
+
+    @property
+    def gestures(self):
+        if not self._gestures:
+            if self.online and self.protocol >= 2.0:
+                self._gestures = _hidpp20.get_gestures(self) or ()
+        return self._gestures
 
     @property
     def registers(self):

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -776,7 +776,7 @@ SUB_PARAM = {   # (byte count, minimum, maximum)
 # Spec Ids for feature GESTURE_2
 SPEC = _NamedInts(
     DVI_field_width=1,
-    field_widths=1,
+    field_widths=2,
     period_unit=3,
     resolution=4,
     multiplier=5,

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -664,6 +664,243 @@ class KeysArray(object):
         return len(self.keys)
 
 
+# Gesture Ids for feature GESTURE_2
+GESTURE = _NamedInts(
+    Tap1Finger=1,  # task Left_Click
+    Tap2Finger=2,  # task Right_Click
+    Tap3Finger=3,
+    Click1Finger=4,  # task Left_Click
+    Click2Finger=5,  # task Right_Click
+    Click3Finger=6,
+    DoubleTap1Finger=10,
+    DoubleTap2Finger=11,
+    DoubleTap3Finger=12,
+    Track1Finger=20,  # action MovePointer
+    TrackingAcceleration=21,
+    TapDrag1Finger=30,  # action Drag
+    TapDrag2Finger=31,  # action SecondaryDrag
+    Drag3Finger=32,
+    TapGestures=33,  # group all tap gestures under a single UI setting
+    FnClickGestureSuppression=34,  # suppresses Tap and Edge gestures, toggled by Fn+Click
+    Scroll1Finger=40,  # action ScrollOrPageXY / ScrollHorizontal
+    Scroll2Finger=41,  # action ScrollOrPageXY / ScrollHorizontal
+    Scroll2FingerHoriz=42,  # action ScrollHorizontal
+    Scroll2FingerVert=43,  # action WheelScrolling
+    Scroll2FingerStateless=44,
+    NaturalScrolling=45,  # affects native HID wheel reporting by gestures, not when diverted
+    Thumbwheel=46,  # action WheelScrolling
+    VScrollInertia=48,
+    VScrollBallistics=49,
+    Swipe2FingerHoriz=50,  # action PageScreen
+    Swipe3FingerHoriz=51,  # action PageScreen
+    Swipe4FingerHoriz=52,  # action PageScreen
+    Swipe3FingerVert=53,
+    Swipe4FingerVert=54,
+    LeftEdgeSwipe1Finger=60,
+    RightEdgeSwipe1Finger=61,
+    BottomEdgeSwipe1Finger=62,
+    TopEdgeSwipe1Finger=63,
+    LeftEdgeSwipe1Finger2=64,  # task HorzScrollNoRepeatSet
+    RightEdgeSwipe1Finger2=65,  # task 122 ??
+    BottomEdgeSwipe1Finger2=66,  #
+    TopEdgeSwipe1Finger2=67,  # task 121 ??
+    LeftEdgeSwipe2Finger=70,
+    RightEdgeSwipe2Finger=71,
+    BottomEdgeSwipe2Finger=72,
+    TopEdgeSwipe2Finger=73,
+    Zoom2Finger=80,  # action Zoom
+    Zoom2FingerPinch=81,  # ZoomBtnInSet
+    Zoom2FingerSpread=82,  # ZoomBtnOutSet
+    Zoom3Finger=83,
+    Zoom2FingerStateless=84,  # action Zoom
+    TwoFingersPresent=85,
+    Rotate2Finger=87,
+    Finger1=90,
+    Finger2=91,
+    Finger3=92,
+    Finger4=93,
+    Finger5=94,
+    Finger6=95,
+    Finger7=96,
+    Finger8=97,
+    Finger9=98,
+    Finger10=99,
+)
+GESTURE._fallback = lambda x: 'unknown:%04X' % x
+
+# Param Ids for feature GESTURE_2
+PARAM = _NamedInts(
+    ExtraCapabilities=1,  # not suitable for use
+    PixelZone=2,  # 4 2-byte integers, left, bottom, width, height; pixels
+    RatioZone=3,  # 4 bytes, left, bottom, width, height; unit 1/240 pad size
+    ScaleFactor=4,  # 2-byte integer, with 256 as normal scale
+)
+PARAM._fallback = lambda x: 'unknown:%04X' % x
+
+# Spec Ids for feature GESTURE_2
+SPEC = _NamedInts(
+    DVI_field_width=1,
+    field_widths=1,
+    period_unit=3,
+    resolution=4,
+    multiplier=5,
+    sensor_size=6,
+    finger_width_and_height=7,
+    finger_major_minor_axis=8,
+    finger_force=9,
+    zone=10
+)
+SPEC._fallback = lambda x: 'unknown:%04X' % x
+
+# Action Ids for feature GESTURE_2
+ACTION_ID = _NamedInts(
+    MovePointer=1,
+    ScrollHorizontal=2,
+    WheelScrolling=3,
+    ScrollVertial=4,
+    ScrollOrPageXY=5,
+    ScrollOrPageHorizontal=6,
+    PageScreen=7,
+    Drag=8,
+    SecondaryDrag=9,
+    Zoom=10,
+    ScrollHorizontalOnly=11,
+    ScrollVerticalOnly=12
+)
+ACTION_ID._fallback = lambda x: 'unknown:%04X' % x
+
+
+class Gesture(object):
+    enable_index = 0
+
+    def __init__(self, low, high):
+        self.id = low
+        self.gesture = GESTURE[low]
+        self.can_be_enabled = high & 0x01
+        self.can_be_diverted = high & 0x02
+        self.show_in_ui = high & 0x04
+        self.desired_software_default = high & 0x08
+        self.persistent = high & 0x10
+        self.default_enabled = high & 0x20
+        self.enable_index = None
+        if self.can_be_enabled or self.default_enabled:
+            self.enable_index = Gesture.enable_index
+            Gesture.enable_index += 1
+
+    def enable_offset_mask(self):  # offset and mask to enable or disable
+        if self.enable_index is not None:
+            offset = self.enable_index >> 3  # 8 gestures per byte
+            mask = 0x1 << (self.enable_index % 8)
+            return (offset, mask)
+        else:
+            return (None, None)
+
+    def enabled(self, device):  # is the gesture enabled?
+        offset, mask = self.enable_offset_mask()
+        if offset is not None:
+            result = feature_request(device, FEATURE.GESTURE_2, 0x10, offset, 0x01, mask)
+            return bool(result[0] & mask) if result else None
+
+    def set(self, device, enable):  # enable or disable the gesture
+        if not self.can_be_enabled:
+            return None
+        offset, mask = self.enable_offset_mask()
+        if offset is not None:
+            reply = feature_request(device, FEATURE.GESTURE_2, 0x20, offset, 0x01, mask, mask if enable else 0x00)
+            return reply
+
+    # allow a gesture to be used as a settings reader/writer to enable and disable the gesture
+    read = enabled
+    write = set
+
+
+class Param(object):
+    param_index = 0
+
+    def __init__(self, low, high):
+        self.id = low
+        self.param = PARAM(low)
+        self.size = high & 0x0F
+        self.show_in_ui = bool(high & 0x1F)
+        self._value = None
+        self.index = Param.param_index
+        Param.param_index += 1
+
+    def value(self, device):
+        return self._value if self._value is not None else self.read(device)
+
+    def read(self, device):  # returns the bytes for the parameter
+        result = feature_request(device, FEATURE.GESTURE_2, 0x70, self.index, 0xFF)
+        if result:
+            self._value = result[:self.size]
+            return self._value
+
+    def write(self, device, bytes):
+        self._value = bytes
+        return feature_request(device, FEATURE.GESTURE_2, 0x80, self.index, bytes, 0xFF)
+
+
+class Gestures(object):
+    """Information about the gestures that a device supports.
+    Right now only some information fields are supported.
+    WARNING: Assumes that parameters are always global, which is not the case.
+    """
+    def __init__(self, device):
+        self.device = device
+        self.gestures = {}
+        self.params = {}
+        index = 0
+        field_high = 0x00
+        while field_high != 0x01:  # end of fields
+            # retrieve the next eight fields
+            fields = feature_request(device, FEATURE.GESTURE_2, 0x00, index >> 8, index & 0xFF)
+            if not fields:
+                break
+            for offset in range(8):
+                field_high = fields[offset * 2]
+                field_low = fields[offset * 2 + 1]
+                if field_high == 0x1:  # end of fields
+                    break
+                elif field_high & 0x80:
+                    gesture = Gesture(field_low, field_high)
+                    self.gestures[gesture.gesture] = gesture
+                elif field_high & 0xF0 == 0x30 or field_high & 0xF0 == 0x20:
+                    param = Param(field_low, field_high)
+                    self.params[param.param] = param
+                elif field_high == 0x04:
+                    if field_low != 0x00:
+                        _log.error(f'Unimplemented GESTURE_2 grouping {field_low} {field_high} found.')
+                else:
+                    _log.warn(f'Unimplemented GESTURE_2 field {field_low} {field_high} found.')
+                index += 1
+
+    def gesture(self, gesture):
+        return self.gestures.get(gesture, None)
+
+    def gesture_enabled(self, gesture):  # is the gesture enabled?
+        g = self.gestures.get(gesture, None)
+        return g.enabled(self.device) if g else None
+
+    def enable_gesture(self, gesture):
+        g = self.gestures.get(gesture, None)
+        return g.set(self.device, True) if g else None
+
+    def disable_gesture(self, gesture):
+        g = self.gestures.get(gesture, None)
+        return g.set(self.device, False) if g else None
+
+    def param(self, param):
+        return self.params.get(param, None)
+
+    def get_param(self, param):
+        g = self.params.get(param, None)
+        return g.get(self.device) if g else None
+
+    def set_param(self, param, value):
+        g = self.params.get(param, None)
+        return g.set(self.device, value) if g else None
+
+
 #
 #
 #
@@ -807,6 +1044,11 @@ def get_keys(device):
         count = feature_request(device, FEATURE.REPROG_CONTROLS_V4)
     if count:
         return KeysArray(device, ord(count[:1]))
+
+
+def get_gestures(device):
+    if FEATURE.GESTURE_2 in device.features:
+        return Gestures(device)
 
 
 def get_mouse_pointer_info(device):

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -93,7 +93,7 @@ _THUMB_SCROLL_MODE = ('thumb-scroll-mode', _('HID++ Thumb Scrolling'),
                       _('HID++ mode for horizontal scroll with the thumb wheel.') + '\n' +
                       _('Effectively turns off thumb scrolling in Linux.'))
 _THUMB_SCROLL_INVERT = ('thumb-scroll-invert', _('Thumb Scroll Invert'), _('Invert thumb scroll direction.'))
-_GESTURE2_GESTURES = ('gesture2-gestures', _('Touchpad gestures'), _('Tweaks the touchpad behaviour.'))
+_GESTURE2_GESTURES = ('gesture2-gestures', _('Gestures'), _('Tweaks the mouse/touchpad behaviour.'))
 # yapf: enable
 
 # Setting template functions need to set up the setting itself, the validator, and the reader/writer.
@@ -412,7 +412,7 @@ def _feature_gesture2_gesture_callback(device):
 def _feature_gesture2_gesture():
     rw = _FeatureRW(_F.GESTURE_2, read_fnid=0x10, write_fnid=0x20)
     return _BitFieldOMSetting(
-        _GESTURE2_GESTURES, rw, callback=_feature_gesture2_gesture_callback, device_kind=(_DK.touchpad, )
+        _GESTURE2_GESTURES, rw, callback=_feature_gesture2_gesture_callback, device_kind=(_DK.touchpad, _DK.mouse)
     )
 
 

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -46,6 +46,7 @@ from .settings import RangeValidator as _RangeV
 from .settings import RegisterRW as _RegisterRW
 from .settings import Setting as _Setting
 from .settings import Settings as _Settings
+from .special_keys import DISABLE as _DKEY
 
 _log = getLogger(__name__)
 del getLogger
@@ -53,6 +54,9 @@ del getLogger
 _DK = _hidpp10.DEVICE_KIND
 _R = _hidpp10.REGISTERS
 _F = _hidpp20.FEATURE
+
+_GG = _hidpp20.GESTURE
+_GP = _hidpp20.PARAM
 
 #
 # common strings for settings - name, string to display in main window, tool tip for main window
@@ -97,6 +101,90 @@ _THUMB_SCROLL_MODE = ('thumb-scroll-mode', _('HID++ Thumb Scrolling'),
 _THUMB_SCROLL_INVERT = ('thumb-scroll-invert', _('Thumb Scroll Invert'), _('Invert thumb scroll direction.'))
 _GESTURE2_GESTURES = ('gesture2-gestures', _('Gestures'), _('Tweaks the mouse/touchpad behaviour.'))
 _GESTURE2_PARAMS = ('gesture2-params', _('Gesture params'), _('Changes numerical parameters of a mouse/touchpad.'))
+
+
+_GESTURE2_GESTURES_LABELS = {
+    _GG['Tap1Finger']: (_('Single tap'), _('Performs a left click.')),
+    _GG['Tap2Finger']: (_('Double tap'), _('Performs a right click.')),
+    _GG['Tap3Finger']: (_('Triple tap'), None),
+    _GG['Click1Finger']: (None, None),
+    _GG['Click2Finger']: (None, None),
+    _GG['Click3Finger']: (None, None),
+    _GG['DoubleTap1Finger']: (_('Double tap'), _('Performs a double click.')),
+    _GG['DoubleTap2Finger']: (_('Double tap with two fingers'), None),
+    _GG['DoubleTap3Finger']: (_('Double tap with three fingers'), None),
+    _GG['Track1Finger']: (None, None),
+    _GG['TrackingAcceleration']: (None, None),
+    _GG['TapDrag1Finger']: (_('Tap and drag'), _('Drags items by dragging the finger after double tapping.')),
+    _GG['TapDrag2Finger']: (_('Tap and drag with two fingers'),
+                            _('Drags items by dragging the fingers after double tapping.')),
+    _GG['Drag3Finger']: (_('Tap and drag with three fingers'), None),
+    _GG['TapGestures']: (None, None),
+    _GG['FnClickGestureSuppression']: (_('Suppress tap and edge gestures'),
+                                       _('Disables tap and edge gestures (equivalent to pressing Fn+LeftClick).')),
+    _GG['Scroll1Finger']: (_('Scroll with one finger'), _('Scrolls.')),
+    _GG['Scroll2Finger']: (_('Scroll with two fingers'), _('Scrolls.')),
+    _GG['Scroll2FingerHoriz']: (_('Scroll horizontally with two fingers'), _('Scrolls horizontally.')),
+    _GG['Scroll2FingerVert']: (_('Scroll vertically with two fingers'), _('Scrolls vertically.')),
+    _GG['Scroll2FingerStateless']: (_('Scroll with two fingers'), _('Scrolls.')),
+    _GG['NaturalScrolling']: (_('Natural scrolling'), _('Inverts the scrolling direction.')),
+    _GG['Thumbwheel']: (_('Thumbwheel'), _('Enables the thumbwheel.')),
+    _GG['VScrollInertia']: (None, None),
+    _GG['VScrollBallistics']: (None, None),
+    _GG['Swipe2FingerHoriz']: (None, None),
+    _GG['Swipe3FingerHoriz']: (None, None),
+    _GG['Swipe4FingerHoriz']: (None, None),
+    _GG['Swipe3FingerVert']: (None, None),
+    _GG['Swipe4FingerVert']: (None, None),
+    _GG['LeftEdgeSwipe1Finger']: (None, None),
+    _GG['RightEdgeSwipe1Finger']: (None, None),
+    _GG['BottomEdgeSwipe1Finger']: (None, None),
+    _GG['TopEdgeSwipe1Finger']: (_('Swipe from the top edge'), None),
+    _GG['LeftEdgeSwipe1Finger2']: (_('Swipe from the left edge'), None),
+    _GG['RightEdgeSwipe1Finger2']: (_('Swipe from the right edge'), None),
+    _GG['BottomEdgeSwipe1Finger2']: (_('Swipe from the bottom edge'), None),
+    _GG['TopEdgeSwipe1Finger2']: (_('Swipe from the top edge'), None),
+    _GG['LeftEdgeSwipe2Finger']: (_('Swipe two fingers from the left edge'), None),
+    _GG['RightEdgeSwipe2Finger']: (_('Swipe two fingers from the right edge'), None),
+    _GG['BottomEdgeSwipe2Finger']: (_('Swipe two fingers from the bottom edge'), None),
+    _GG['TopEdgeSwipe2Finger']: (_('Swipe two fingers from the top edge'), None),
+    _GG['Zoom2Finger']: (_('Zoom with two fingers.'), _('Pinch to zoom out; spread to zoom in.')),
+    _GG['Zoom2FingerPinch']: (_('Pinch to zoom out.'), _('Pinch to zoom out.')),
+    _GG['Zoom2FingerSpread']: (_('Spread to zoom in.'), _('Spread to zoom in.')),
+    _GG['Zoom3Finger']: (_('Zoom with three fingers.'), None),
+    _GG['Zoom2FingerStateless']: (_('Zoom with two fingers'), _('Pinch to zoom out; spread to zoom in.')),
+    _GG['TwoFingersPresent']: (None, None),
+    _GG['Rotate2Finger']: (None, None),
+    _GG['Finger1']: (None, None),
+    _GG['Finger2']: (None, None),
+    _GG['Finger3']: (None, None),
+    _GG['Finger4']: (None, None),
+    _GG['Finger5']: (None, None),
+    _GG['Finger6']: (None, None),
+    _GG['Finger7']: (None, None),
+    _GG['Finger8']: (None, None),
+    _GG['Finger9']: (None, None),
+    _GG['Finger10']: (None, None),
+    _GG['DeviceSpecificRawData']: (None, None),
+}
+
+_GESTURE2_PARAMS_LABELS = {
+    _GP['ExtraCapabilities']: (None, None),  # not supported
+    _GP['PixelZone']: ('Pixel zone', None),  # TO DO: replace None with a short description
+    _GP['RatioZone']: ('Ratio zone', None),  # TO DO: replace None with a short description
+    _GP['ScaleFactor']: ('Scale factor', 'Sets the cursor speed.'),
+}
+
+_GESTURE2_PARAMS_LABELS_SUB = {
+    'left': (_('Left'), _('Left-most coordinate.')),
+    'top': (_('top'), _('Top-most coordinate.')),
+    'width': (_('width'), _('Width.')),
+    'height': (_('height'), _('Height.')),
+    'scale': (_('Scale'), _('Cursor speed.')),
+}
+
+_DISABLE_KEYS_LABEL_SUB = _('Disables the %s key.')
+
 # yapf: enable
 
 # Setting template functions need to set up the setting itself, the validator, and the reader/writer.
@@ -319,7 +407,9 @@ def _feature_disable_keyboard_keys_callback(device):
 
 def _feature_disable_keyboard_keys():
     rw = _FeatureRW(_F.KEYBOARD_DISABLE_KEYS, read_fnid=0x10, write_fnid=0x20)
-    return _BitFieldSetting(_DISABLE_KEYS, rw, callback=_feature_disable_keyboard_keys_callback, device_kind=(_DK.keyboard, ))
+    s = _BitFieldSetting(_DISABLE_KEYS, rw, callback=_feature_disable_keyboard_keys_callback, device_kind=(_DK.keyboard, ))
+    s._labels = {k: (None, _DISABLE_KEYS_LABEL_SUB % k) for k in _DKEY}
+    return s
 
 
 # muultiplatform OS bits
@@ -414,9 +504,11 @@ def _feature_gesture2_gestures_callback(device):
 
 def _feature_gesture2_gestures():
     rw = _FeatureRW(_F.GESTURE_2, read_fnid=0x10, write_fnid=0x20)
-    return _BitFieldOMSetting(
+    s = _BitFieldOMSetting(
         _GESTURE2_GESTURES, rw, callback=_feature_gesture2_gestures_callback, device_kind=(_DK.touchpad, _DK.mouse)
     )
+    s._labels = _GESTURE2_GESTURES_LABELS
+    return s
 
 
 def _feature_gesture2_params_callback(device):
@@ -430,9 +522,15 @@ def _feature_gesture2_params_callback(device):
 
 def _feature_gesture2_params():
     rw = _FeatureRW(_F.GESTURE_2, read_fnid=0x70, write_fnid=0x80)
-    return _LongSettings(
-        _GESTURE2_PARAMS, rw, callback=_feature_gesture2_params_callback, device_kind=(_DK.touchpad, _DK.mouse)
-    )
+    s = _LongSettings(_GESTURE2_PARAMS, rw, callback=_feature_gesture2_params_callback, device_kind=(_DK.touchpad, _DK.mouse))
+
+    class ParamWrapper:
+        def get(self, name, default=None):
+            return _GESTURE2_PARAMS_LABELS.get(name.param, default)
+
+    s._labels = ParamWrapper()
+    s._labels_sub = _GESTURE2_PARAMS_LABELS_SUB
+    return s
 
 
 #

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -33,6 +33,8 @@ from .common import unpack as _unpack
 from .i18n import _
 from .settings import BitFieldSetting as _BitFieldSetting
 from .settings import BitFieldValidator as _BitFieldV
+from .settings import BitFieldWithOffsetAndMaskSetting as _BitFieldOMSetting
+from .settings import BitFieldWithOffsetAndMaskValidator as _BitFieldOMV
 from .settings import BooleanValidator as _BooleanV
 from .settings import ChoicesMapValidator as _ChoicesMapV
 from .settings import ChoicesValidator as _ChoicesV
@@ -91,6 +93,7 @@ _THUMB_SCROLL_MODE = ('thumb-scroll-mode', _('HID++ Thumb Scrolling'),
                       _('HID++ mode for horizontal scroll with the thumb wheel.') + '\n' +
                       _('Effectively turns off thumb scrolling in Linux.'))
 _THUMB_SCROLL_INVERT = ('thumb-scroll-invert', _('Thumb Scroll Invert'), _('Invert thumb scroll direction.'))
+_GESTURE2_GESTURES = ('gesture2-gestures', _('Touchpad gestures'), _('Tweaks the touchpad behaviour.'))
 # yapf: enable
 
 # Setting template functions need to set up the setting itself, the validator, and the reader/writer.
@@ -401,6 +404,18 @@ def _feature_thumb_invert():
     return _Setting(_THUMB_SCROLL_INVERT, rw, validator, device_kind=(_DK.mouse, _DK.trackball))
 
 
+def _feature_gesture2_gesture_callback(device):
+    options = [g for g in _hidpp20.get_gestures(device).gestures.values() if g.can_be_enabled or g.default_enabled]
+    return _BitFieldOMV(options) if options else None
+
+
+def _feature_gesture2_gesture():
+    rw = _FeatureRW(_F.GESTURE_2, read_fnid=0x10, write_fnid=0x20)
+    return _BitFieldOMSetting(
+        _GESTURE2_GESTURES, rw, callback=_feature_gesture2_gesture_callback, device_kind=(_DK.touchpad, )
+    )
+
+
 #
 #
 #
@@ -432,6 +447,7 @@ _SETTINGS_TABLE = [
     _S(_CHANGE_HOST, _F.CHANGE_HOST, _feature_change_host),
     _S(_THUMB_SCROLL_MODE, _F.THUMB_WHEEL, _feature_thumb_mode),
     _S(_THUMB_SCROLL_INVERT, _F.THUMB_WHEEL, _feature_thumb_invert),
+    _S(_GESTURE2_GESTURES, _F.GESTURE_2, _feature_gesture2_gesture),
 ]
 
 _SETTINGS_LIST = namedtuple('_SETTINGS_LIST', [s[4] for s in _SETTINGS_TABLE])

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -204,11 +204,16 @@ def _print_device(dev, num=None):
                 report_fmt = report_fmt if report_fmt else 'default'
                 print('             reporting: %s' % (report_fmt))
     if dev.online and dev.gestures:
-        print('     Has %d gestures and %d param:' % (len(dev.gestures.gestures), len(dev.gestures.params)))
+        print(
+            '     Has %d gesture(s), %d param(s) and %d spec(s):' %
+            (len(dev.gestures.gestures), len(dev.gestures.params), len(dev.gestures.specs))
+        )
         for k in dev.gestures.gestures.values():
             print('        %-26s Enabled (%4s): %s' % (k.gesture, k.index, k.enabled()))
         for k in dev.gestures.params.values():
             print('        %-26s Value   (%4s): %s' % (k.param, k.index, k.value()))
+        for k in dev.gestures.specs.values():
+            print('        %-26s Spec    (%4s): %s' % (k.spec, k.id, k.value))
     if dev.online:
         battery = _hidpp20.get_battery(dev)
         if battery is None:

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -203,6 +203,12 @@ def _print_device(dev, num=None):
                 report_fmt = ', '.join(k.mapping_flags)
                 report_fmt = report_fmt if report_fmt else 'default'
                 print('             reporting: %s' % (report_fmt))
+    if dev.online and dev.gestures:
+        print('     Has %d gestures and %d param:' % (len(dev.gestures.gestures), len(dev.gestures.params)))
+        for k in dev.gestures.gestures.values():
+            print('        %-26s Enabled (%4s): %s' % (k.gesture, k.enable_index, k.enabled(dev)))
+        for k in dev.gestures.params.values():
+            print('        %-26s Value (%4s): %s' % (k.param, k.index, k.value(dev)))
     if dev.online:
         battery = _hidpp20.get_battery(dev)
         if battery is None:

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -206,9 +206,9 @@ def _print_device(dev, num=None):
     if dev.online and dev.gestures:
         print('     Has %d gestures and %d param:' % (len(dev.gestures.gestures), len(dev.gestures.params)))
         for k in dev.gestures.gestures.values():
-            print('        %-26s Enabled (%4s): %s' % (k.gesture, k.enable_index, k.enabled(dev)))
+            print('        %-26s Enabled (%4s): %s' % (k.gesture, k.index, k.enabled()))
         for k in dev.gestures.params.values():
-            print('        %-26s Value (%4s): %s' % (k.param, k.index, k.value(dev)))
+            print('        %-26s Value   (%4s): %s' % (k.param, k.index, k.value()))
     if dev.online:
         battery = _hidpp20.get_battery(dev)
         if battery is None:

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -211,7 +211,7 @@ def _print_device(dev, num=None):
         for k in dev.gestures.gestures.values():
             print('        %-26s Enabled (%4s): %s' % (k.gesture, k.index, k.enabled()))
         for k in dev.gestures.params.values():
-            print('        %-26s Value   (%4s): %s' % (k.param, k.index, k.value()))
+            print('        %-26s Value   (%4s): %s [Default: %s]' % (k.param, k.index, k.value, k.default_value))
         for k in dev.gestures.specs.values():
             print('        %-26s Spec    (%4s): %s' % (k.spec, k.id, k.value))
     if dev.online:

--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -212,7 +212,16 @@ def _create_multiple_toggle_control(setting):
     btn = Gtk.Button('? / ?')
     for k in setting._validator.all_options():
         h = Gtk.HBox(homogeneous=False, spacing=0)
-        lbl = Gtk.Label(k)
+        lbl_text = str(k)
+        lbl_tooltip = None
+        if hasattr(setting, '_labels'):
+            l1, l2 = setting._labels.get(k, (None, None))
+            if l1:
+                lbl_text = l1
+            if l2:
+                lbl_tooltip = l2
+        lbl = Gtk.Label(lbl_text)
+        h.set_tooltip_text(lbl_tooltip or ' ')
         control = Gtk.Switch()
         control._setting_key = str(int(k))
         control.connect('notify::active', _toggle_notify, setting)
@@ -269,13 +278,31 @@ def _create_multiple_range_control(setting):
     btn = Gtk.Button('...')
     lb._showing = True
     for item in setting._validator.items:
-        item_lbl = Gtk.Label(item)
+        lbl_text = str(item)
+        lbl_tooltip = None
+        if hasattr(setting, '_labels'):
+            l1, l2 = setting._labels.get(item, (None, None))
+            if l1:
+                lbl_text = l1
+            if l2:
+                lbl_tooltip = l2
+        item_lbl = Gtk.Label(lbl_text)
         lb.add(item_lbl)
+        lb.set_tooltip_text(lbl_tooltip or ' ')
         item_lb = Gtk.ListBox()
         item_lb.set_selection_mode(Gtk.SelectionMode.NONE)
         for sub_item in setting._validator.sub_items[item]:
             h = Gtk.HBox(homogeneous=False, spacing=20)
-            sub_item_lbl = Gtk.Label(sub_item)
+            lbl_text = str(sub_item)
+            lbl_tooltip = None
+            if hasattr(setting, '_labels_sub'):
+                l1, l2 = setting._labels_sub.get(str(sub_item), (None, None))
+                if l1:
+                    lbl_text = l1
+                if l2:
+                    lbl_tooltip = l2
+            sub_item_lbl = Gtk.Label(lbl_text)
+            h.set_tooltip_text(lbl_tooltip or ' ')
             h.pack_start(sub_item_lbl, False, False, 0)
             sub_item_lbl.set_margin_left(30)
             sub_item_lbl.set_alignment(0.0, 0.5)

--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from threading import Timer as _Timer
 
-from gi.repository import GLib, Gtk
+from gi.repository import Gdk, GLib, Gtk
 from logitech_receiver.settings import KIND as _SETTING_KIND
 from solaar.i18n import _
 from solaar.ui import ui_async as _ui_async
@@ -230,6 +230,7 @@ def _create_multiple_toggle_control(setting):
         lbl.set_alignment(0.0, 0.5)
         lbl.set_margin_left(30)
         lb.add(h)
+    _disable_listbox_highlight_bg(lb)
     lb._toggle_display()
     btn.connect('clicked', lambda _: lb._toggle_display())
 
@@ -275,9 +276,9 @@ def _create_multiple_range_control(setting):
     lb = Gtk.ListBox()
     lb._toggle_display = (lambda l: (lambda: _toggle_display(l)))(lb)
     lb.set_selection_mode(Gtk.SelectionMode.NONE)
-    btn = Gtk.Button('...')
     lb._showing = True
     lb.set_no_show_all(True)
+    btn = Gtk.Button('...')
     for item in setting._validator.items:
         lbl_text = str(item)
         lbl_tooltip = None
@@ -322,7 +323,9 @@ def _create_multiple_range_control(setting):
             item_lb.add(h)
             h._setting_sub_item = sub_item
         item_lb._setting_item = item
+        _disable_listbox_highlight_bg(item_lb)
         lb.add(item_lb)
+    _disable_listbox_highlight_bg(lb)
     lb._toggle_display()
     btn.connect('clicked', lambda _: lb._toggle_display())
     btn.set_alignment(1.0, 0.5)
@@ -477,6 +480,13 @@ def _get_failed_spinner_control(sbox):
         failed = children[0].get_children()[0].get_children()[1]
         spinner = children[0].get_children()[0].get_children()[2]
     return failed, spinner, control
+
+
+def _disable_listbox_highlight_bg(lb):
+    colour = Gdk.RGBA()
+    colour.parse('rgba(0,0,0,0)')
+    for child in lb.get_children():
+        child.override_background_color(Gtk.StateFlags.PRELIGHT, colour)
 
 
 #

--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -197,18 +197,18 @@ def _create_multiple_toggle_control(setting):
         lb._showing = not lb._showing
         if not lb._showing:
             for c in lb.get_children():
-                lb._hidden_rows.append(c)
-                lb.remove(c)
+                c.hide()
+            lb.hide()
         else:
-            for c in lb._hidden_rows:
-                lb.add(c)
-            lb._hidden_rows = []
+            lb.show()
+            for c in lb.get_children():
+                c.show_all()
 
     lb = Gtk.ListBox()
-    lb._hidden_rows = []
     lb._toggle_display = (lambda l: (lambda: _toggle_display(l)))(lb)
     lb._showing = True
     lb.set_selection_mode(Gtk.SelectionMode.NONE)
+    lb.set_no_show_all(True)
     btn = Gtk.Button('? / ?')
     for k in setting._validator.all_options():
         h = Gtk.HBox(homogeneous=False, spacing=0)
@@ -230,6 +230,7 @@ def _create_multiple_toggle_control(setting):
         lbl.set_alignment(0.0, 0.5)
         lbl.set_margin_left(30)
         lb.add(h)
+    lb._toggle_display()
     btn.connect('clicked', lambda _: lb._toggle_display())
 
     hbox = Gtk.HBox(homogeneous=False, spacing=60)
@@ -264,19 +265,19 @@ def _create_multiple_range_control(setting):
         lb._showing = not lb._showing
         if not lb._showing:
             for c in lb.get_children():
-                lb._hidden_rows.append(c)
-                lb.remove(c)
+                c.hide()
+            lb.hide()
         else:
-            for c in lb._hidden_rows:
-                lb.add(c)
-            lb._hidden_rows = []
+            lb.show()
+            for c in lb.get_children():
+                c.show_all()
 
     lb = Gtk.ListBox()
-    lb._hidden_rows = []
     lb._toggle_display = (lambda l: (lambda: _toggle_display(l)))(lb)
     lb.set_selection_mode(Gtk.SelectionMode.NONE)
     btn = Gtk.Button('...')
     lb._showing = True
+    lb.set_no_show_all(True)
     for item in setting._validator.items:
         lbl_text = str(item)
         lbl_tooltip = None
@@ -322,6 +323,7 @@ def _create_multiple_range_control(setting):
             h._setting_sub_item = sub_item
         item_lb._setting_item = item
         lb.add(item_lb)
+    lb._toggle_display()
     btn.connect('clicked', lambda _: lb._toggle_display())
     btn.set_alignment(1.0, 0.5)
     hbox = Gtk.HBox(homogeneous=False, spacing=6)
@@ -421,11 +423,10 @@ def _update_setting_item(sbox, value, is_online=True):
             vbox.set_active_id(str(value.get(kbox.get_active_id())))
     elif isinstance(control, Gtk.ListBox):
         if control.kind == _SETTING_KIND.multiple_toggle:
-            hidden = getattr(control, '_hidden_rows', [])
-            total = len(control.get_children()) + len(hidden)
+            total = len(control.get_children())
             active = 0
             to_join = []
-            for ch in control.get_children() + hidden:
+            for ch in control.get_children():
                 elem = ch.get_children()[0].get_children()[-1]
                 v = value.get(elem._setting_key, None)
                 if v is not None:
@@ -438,10 +439,9 @@ def _update_setting_item(sbox, value, is_online=True):
             btn.set_label(f'{active} / {total}')
             btn.set_tooltip_text(b)
         elif control.kind == _SETTING_KIND.multiple_range:
-            hidden = getattr(control, '_hidden_rows', [])
             b = ''
             n = 0
-            for ch in control.get_children()[1:] + hidden:
+            for ch in control.get_children()[1:]:
                 # item
                 item = ch.get_children()[0]._setting_item
                 v = value.get(str(int(item)), None)

--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -207,22 +207,25 @@ def _create_multiple_toggle_control(setting):
     lb = Gtk.ListBox()
     lb._hidden_rows = []
     lb._toggle_display = (lambda l: (lambda: _toggle_display(l)))(lb)
+    lb._showing = True
     lb.set_selection_mode(Gtk.SelectionMode.NONE)
     btn = Gtk.Button('? / ?')
-    lb._showing = True
     for k in setting._validator.all_options():
-        h = Gtk.HBox(homogeneous=True, spacing=0)
+        h = Gtk.HBox(homogeneous=False, spacing=0)
         lbl = Gtk.Label(k)
         control = Gtk.Switch()
         control._setting_key = str(int(k))
         control.connect('notify::active', _toggle_notify, setting)
-        h.pack_start(lbl, True, True, 0)
-        h.pack_end(control, True, True, 0)
+        h.pack_start(lbl, False, False, 0)
+        h.pack_end(control, False, False, 0)
+        lbl.set_alignment(0.0, 0.5)
+        lbl.set_margin_left(30)
         lb.add(h)
     btn.connect('clicked', lambda _: lb._toggle_display())
 
-    hbox = Gtk.HBox(homogeneous=False, spacing=6)
-    hbox.pack_end(btn, True, True, 0)
+    hbox = Gtk.HBox(homogeneous=False, spacing=60)
+    hbox.pack_end(btn, False, False, 0)
+    btn.set_alignment(1.0, 0.5)
     vbox = Gtk.VBox(homogeneous=False, spacing=6)
     vbox.pack_start(hbox, True, True, 0)
     vbox.pack_end(lb, True, True, 0)
@@ -263,7 +266,7 @@ def _create_multiple_range_control(setting):
     lb._hidden_rows = []
     lb._toggle_display = (lambda l: (lambda: _toggle_display(l)))(lb)
     lb.set_selection_mode(Gtk.SelectionMode.NONE)
-    btn = Gtk.Button('???')
+    btn = Gtk.Button('...')
     lb._showing = True
     for item in setting._validator.items:
         item_lbl = Gtk.Label(item)
@@ -271,28 +274,31 @@ def _create_multiple_range_control(setting):
         item_lb = Gtk.ListBox()
         item_lb.set_selection_mode(Gtk.SelectionMode.NONE)
         for sub_item in setting._validator.sub_items[item]:
-            h = Gtk.HBox(homogeneous=True, spacing=0)
+            h = Gtk.HBox(homogeneous=False, spacing=20)
             sub_item_lbl = Gtk.Label(sub_item)
-            h.pack_start(sub_item_lbl, True, True, 0)
+            h.pack_start(sub_item_lbl, False, False, 0)
+            sub_item_lbl.set_margin_left(30)
+            sub_item_lbl.set_alignment(0.0, 0.5)
             if sub_item.widget == 'Scale':
                 control = Gtk.Scale.new_with_range(Gtk.Orientation.HORIZONTAL, sub_item.minimum, sub_item.maximum, 1)
                 control.set_round_digits(0)
                 control.set_digits(0)
+                h.pack_end(control, True, True, 0)
             elif sub_item.widget == 'SpinButton':
                 control = Gtk.SpinButton.new_with_range(sub_item.minimum, sub_item.maximum, 1)
                 control.set_digits(0)
+                h.pack_end(control, False, False, 0)
             else:
                 raise NotImplementedError
-            h.pack_end(control, True, True, 0)
             control.connect('value-changed', _changed, setting, item, sub_item)
             item_lb.add(h)
             h._setting_sub_item = sub_item
         item_lb._setting_item = item
         lb.add(item_lb)
     btn.connect('clicked', lambda _: lb._toggle_display())
-
+    btn.set_alignment(1.0, 0.5)
     hbox = Gtk.HBox(homogeneous=False, spacing=6)
-    hbox.pack_end(btn, True, True, 0)
+    hbox.pack_end(btn, False, False, 0)
     vbox = Gtk.VBox(homogeneous=False, spacing=6)
     vbox.pack_start(hbox, True, True, 0)
     vbox.pack_end(lb, True, True, 0)
@@ -331,13 +337,15 @@ def _create_sbox(s):
         vbox = _create_multiple_toggle_control(s)
         control = vbox.get_children()[1]
         sbox.remove(label)
-        vbox.get_children()[0].pack_start(label, True, True, 0)
+        vbox.get_children()[0].pack_start(label, False, False, 0)
+        label.set_alignment(0.0, 0.5)
         sbox.pack_start(vbox, True, True, 0)
     elif s.kind == _SETTING_KIND.multiple_range:
         vbox = _create_multiple_range_control(s)
         control = vbox.get_children()[1]
         sbox.remove(label)
-        vbox.get_children()[0].pack_start(label, True, True, 0)
+        vbox.get_children()[0].pack_start(label, False, False, 0)
+        label.set_alignment(0.0, 0.5)
         sbox.pack_start(vbox, True, True, 0)
     else:
         raise Exception('NotImplemented')

--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -559,13 +559,6 @@ def _update_details(button):
                 flag_names = ('(%s)' % _('none'), ) if flag_bits == 0 else _hidpp10.NOTIFICATION_FLAG.flag_names(flag_bits)
                 yield (_('Notifications'), ('\n%15s' % ' ').join(flag_names))
 
-            if hasattr(device, 'gestures'):
-                specs = device.gestures.specs
-                if specs:
-                    yield ('Gesture specs', '')
-                    for s in specs.values():
-                        yield ('  %s' % s.spec, s.value)
-
         def _set_details(text):
             _details._text.set_markup(text)
 

--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -559,6 +559,13 @@ def _update_details(button):
                 flag_names = ('(%s)' % _('none'), ) if flag_bits == 0 else _hidpp10.NOTIFICATION_FLAG.flag_names(flag_bits)
                 yield (_('Notifications'), ('\n%15s' % ' ').join(flag_names))
 
+            if hasattr(device, 'gestures'):
+                specs = device.gestures.specs
+                if specs:
+                    yield ('Gesture specs', '')
+                    for s in specs.values():
+                        yield ('  %s' % s.spec, s.value)
+
         def _set_details(text):
             _details._text.set_markup(text)
 

--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -144,7 +144,7 @@ def _create_device_panel():
     p.pack_start(p._lux, False, False, 0)
 
     p._config = _config_panel.create()
-    p.pack_end(p._config, False, False, 4)
+    p.pack_end(p._config, True, True, 4)
 
     return p
 


### PR DESCRIPTION
Closes #411.
Closes #788.

This is a follow-up to #934 and #788.

I didn't use the set and get methods directly from Gesture because I tried to avoid unnecessary requests, which is possible because we can read and write options that share an offset in a single request. 

@pfps, thank you for writing the code of #934 (upon which this PR is based). I retained your old commit, as I didn't know a good way to replace it with your updates after I made a lot of changes.

So far, I've only implemented the boolean settings. I tried to make the UI look better than that ugly hack I had written (#818), but it still has some alignment issues. The UI changes also apply to KEYBOARD_DISABLE_KEYS. 

Of course, corrections and ideas are welcome. 