### PR TITLE
Fix broken link to about website

### DIFF
--- a/lib/solaar/ui/about.py
+++ b/lib/solaar/ui/about.py
@@ -80,7 +80,7 @@ def _create():
         ))
     )
 
-    about.set_website('http://pwr-solaar.github.io/Solaar/')
+    about.set_website('https://pwr-solaar.github.io/Solaar')
     about.set_website_label(NAME)
 
     about.connect('response', lambda x, y: x.hide())


### PR DESCRIPTION
Just a small fix!

The link in the about was not working and I just put the link provided in the github page.