### PR TITLE
Add wired devices to Solaar GUI

### DIFF
--- a/lib/hidapi/udev.py
+++ b/lib/hidapi/udev.py
@@ -55,6 +55,7 @@ DeviceInfo = namedtuple(
         'product',
         'interface',
         'driver',
+        'isDevice',
     ]
 )
 del namedtuple
@@ -89,6 +90,7 @@ def _match(action, device, filter):
     product_id = filter.get('product_id')
     interface_number = filter.get('usb_interface')
     hid_driver = filter.get('hid_driver')
+    isDevice = filter.get('isDevice')
 
     usb_device = device.find_parent('usb', 'usb_device')
     # print ("* parent", action, device, "usb:", usb_device)
@@ -134,7 +136,8 @@ def _match(action, device, filter):
             manufacturer=attrs.get('manufacturer'),
             product=attrs.get('product'),
             interface=usb_interface,
-            driver=hid_driver_name
+            driver=hid_driver_name,
+            isDevice=isDevice
         )
         return d_info
 
@@ -150,7 +153,8 @@ def _match(action, device, filter):
             manufacturer=None,
             product=None,
             interface=None,
-            driver=None
+            driver=None,
+            isDevice=isDevice
         )
         return d_info
 

--- a/lib/logitech_receiver/base.py
+++ b/lib/logitech_receiver/base.py
@@ -104,7 +104,7 @@ def wired_devices():
 
 def notify_on_receivers_glib(callback):
     """Watch for matching devices and notifies the callback on the GLib thread."""
-    _hid.monitor_glib(callback, *_RECEIVER_USB_IDS)
+    _hid.monitor_glib(callback, *_RECEIVER_USB_IDS, *_WIRED_DEVICE_IDS)
 
 
 #

--- a/lib/logitech_receiver/base_usb.py
+++ b/lib/logitech_receiver/base_usb.py
@@ -99,7 +99,7 @@ _ex100_receiver = lambda product_id: {
     'ex100_27mhz_wpid_fix': True
 }
 
-_wired_device = lambda product_id: {'vendor_id': 0x046d, 'product_id': product_id, 'usb_interface': 2}
+_wired_device = lambda product_id: {'vendor_id': 0x046d, 'product_id': product_id, 'usb_interface': 2, 'isDevice': True}
 
 # standard Unifying receivers (marked with the orange Unifying logo)
 UNIFYING_RECEIVER_C52B = _unifying_receiver(0xc52b)

--- a/lib/logitech_receiver/base_usb.py
+++ b/lib/logitech_receiver/base_usb.py
@@ -141,6 +141,7 @@ WIRED_DEVICE_C088 = _wired_device(0xc088)  # GPro
 WIRED_DEVICE_C090 = _wired_device(0xc090)  # G703 Hero
 WIRED_DEVICE_C091 = _wired_device(0xc091)  # G903 Hero
 WIRED_DEVICE_C08d = _wired_device(0xc08d)  # G502 Hero
+WIRED_DEVICE_C08a = _wired_device(0xc08a)  # MX Vertical
 
 del _DRIVER, _unifying_receiver, _nano_receiver, _lenovo_receiver, _lightspeed_receiver, _wired_device
 
@@ -177,6 +178,7 @@ WIRED_DEVICES = (
     WIRED_DEVICE_C090,
     WIRED_DEVICE_C091,
     WIRED_DEVICE_C08d,
+    WIRED_DEVICE_C08a,
 )
 
 

--- a/lib/logitech_receiver/base_usb.py
+++ b/lib/logitech_receiver/base_usb.py
@@ -140,6 +140,7 @@ WIRED_DEVICE_C087 = _wired_device(0xc087)  # G703
 WIRED_DEVICE_C088 = _wired_device(0xc088)  # GPro
 WIRED_DEVICE_C090 = _wired_device(0xc090)  # G703 Hero
 WIRED_DEVICE_C091 = _wired_device(0xc091)  # G903 Hero
+WIRED_DEVICE_C08d = _wired_device(0xc08d)  # G502 Hero
 
 del _DRIVER, _unifying_receiver, _nano_receiver, _lenovo_receiver, _lightspeed_receiver, _wired_device
 
@@ -175,6 +176,7 @@ WIRED_DEVICES = (
     WIRED_DEVICE_C088,
     WIRED_DEVICE_C090,
     WIRED_DEVICE_C091,
+    WIRED_DEVICE_C08d,
 )
 
 

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -31,6 +31,7 @@ class Device(object):
     def __init__(self, receiver, number, link_notification=None, info=None):
         assert receiver or info
         self.receiver = receiver
+        self.isDevice = True  # some devices act as receiver so we need a property to distinguish them
 
         if receiver:
             assert number > 0 and number <= receiver.max_devices

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -1050,6 +1050,21 @@ def get_firmware(device):
         return tuple(fw)
 
 
+def get_ids(device):
+    """Reads a device's ids (unit and model numbers)"""
+    ids = feature_request(device, FEATURE.DEVICE_FW_VERSION)
+    unitId = ids[1:5]
+    modelId = ids[7:13]
+    transport_bits = ord(ids[6:7])
+    offset = 0
+    tid_map = {}
+    for transport, flag in [('btid', 0x1), ('btleid', 0x02), ('wpid', 0x04), ('usbid', 0x08)]:
+        if transport_bits & flag:
+            tid_map[transport] = modelId[offset:offset + 2].hex().upper()
+            offset = offset + 2
+    return (unitId.hex().upper(), modelId.hex().upper(), tid_map)
+
+
 def get_kind(device):
     """Reads a device's type.
 

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -53,6 +53,7 @@ class Receiver(object):
         self.handle = handle
         assert device_info
         self.path = device_info.path
+        self.isDevice = False  # some devices act as receiver so we need a property to distinguish them
         # USB product id, used for some Nano receivers
         self.product_id = device_info.product_id
         product_info = _product_information(self.product_id)

--- a/lib/solaar/cli/__init__.py
+++ b/lib/solaar/cli/__init__.py
@@ -152,10 +152,13 @@ def _find_device(receivers, name):
                 number = None
 
     for r in receivers:
-        if number and number <= r.max_devices:
-            dev = r[number]
-            if dev:
-                return dev
+        if not r.isDevice:  # look for nth device of receiver
+            if number and number <= r.max_devices:
+                dev = r[number]
+                if dev:
+                    return dev
+        else:  # wired device, make a device list from it
+            r = [r]
 
         for dev in r:
             if (
@@ -185,7 +188,7 @@ def run(cli_args=None, hidraw_path=None):
 
     try:
         c = list(_receivers(hidraw_path))
-        if action == 'show':
+        if action == 'show' or action == 'probe' or action == 'config':
             c += list(_wired_devices(hidraw_path))
 
         if not c:

--- a/lib/solaar/cli/probe.py
+++ b/lib/solaar/cli/probe.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from logitech_receiver import base as _base
 from logitech_receiver import hidpp10 as _hidpp10
 from logitech_receiver.common import strhex as _strhex
-from solaar.cli.show import _print_receiver
+from solaar.cli.show import _print_device, _print_receiver
 
 _R = _hidpp10.REGISTERS
 
@@ -38,7 +38,11 @@ def run(receivers, args, find_receiver, _ignore):
     else:
         receiver = receivers[0]
 
-    assert receiver
+    assert receiver is not None
+
+    if receiver.isDevice:
+        _print_device(receiver, 1)
+        return
 
     _print_receiver(receiver)
 

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -91,7 +91,10 @@ def _print_device(dev, num=None):
 
     print('  %d: %s' % (num or dev.number, dev.name))
     print('     Device path  :', dev.path)
-    print('     USB id       : 046d:%s' % (dev.wpid or dev.product_id))
+    if dev.wpid:
+        print('     WPID         : %s' % dev.wpid)
+    if dev.product_id:
+        print('     USB id       : 046d:%s' % dev.product_id)
     print('     Codename     :', dev.codename)
     print('     Kind         :', dev.kind)
     if dev.protocol:
@@ -101,6 +104,10 @@ def _print_device(dev, num=None):
     if dev.polling_rate:
         print('     Polling rate :', dev.polling_rate, 'ms (%dHz)' % (1000 // dev.polling_rate))
     print('     Serial number:', dev.serial)
+    if dev.modelId:
+        print('     Model ID:     ', dev.modelId)
+    if dev.unitId:
+        print('     Unit ID:      ', dev.unitId)
     if dev.firmware:
         for fw in dev.firmware:
             print('       %11s:' % fw.kind, (fw.name + ' ' + fw.version).strip())
@@ -126,7 +133,6 @@ def _print_device(dev, num=None):
 
     if dev.online and dev.features:
         print('     Supports %d HID++ 2.0 features:' % len(dev.features))
-        dev.persister = None  # Give the device a fake persister
         dev_settings = []
         _settings_templates.check_feature_settings(dev, dev_settings)
         for index, feature in enumerate(dev.features):
@@ -202,6 +208,8 @@ def _print_device(dev, num=None):
                 for fw in _hidpp20.get_firmware(dev):
                     extras = _strhex(fw.extras) if fw.extras else ''
                     print('            Firmware: %s %s %s %s' % (fw.kind, fw.name, fw.version, extras))
+                unitId, modelId, tid_map = _hidpp20.get_ids(dev)
+                print('            Unit ID: %s  Model ID: %s  Transport IDs: %s' % (unitId, modelId, tid_map))
             elif feature == _hidpp20.FEATURE.REPORT_RATE:
                 print('            Polling Rate (ms): %d' % _hidpp20.get_polling_rate(dev))
             elif feature == _hidpp20.FEATURE.BATTERY_STATUS or feature == _hidpp20.FEATURE.BATTERY_VOLTAGE:

--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -509,7 +509,7 @@ def create():
 def update(device, is_online=None):
     assert _box is not None
     assert device
-    device_id = (device.receiver.path, device.number)
+    device_id = (device.receiver.path if device.receiver else device.path, device.number)
     if is_online is None:
         is_online = bool(device.online)
 
@@ -541,7 +541,7 @@ def clean(device):
     Needed after the device has been unpaired.
     """
     assert _box is not None
-    device_id = (device.receiver.path, device.number)
+    device_id = (device.receiver.path if device.receiver else device.path, device.number)
     for k in list(_items.keys()):
         if k[0:2] == device_id:
             _box.remove(_items[k])

--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -433,6 +433,9 @@ def _device_row(receiver_path, device_number, device=None):
     assert device_number is not None
 
     receiver_row = _receiver_row(receiver_path, None if device is None else device.receiver)
+    if receiver_row and device_number == 0:  # wired device, receiver row is device row
+        return receiver_row
+
     item = _model.iter_children(receiver_row)
     new_child_index = 0
     while item:
@@ -450,9 +453,10 @@ def _device_row(receiver_path, device_number, device=None):
         icon_name = _icons.device_icon_name(device.name, device.kind)
         status_text = None
         status_icon = None
-        row_data = (
-            receiver_path, device_number, bool(device.online), device.codename, icon_name, status_text, status_icon, device
+        codename = device.codename if device.codename and device.codename[0] != '?' else (
+            device.name.split()[0] if device.name.split() else device.codename
         )
+        row_data = (receiver_path, device_number, bool(device.online), codename, icon_name, status_text, status_icon, device)
         assert len(row_data) == len(_TREE_SEPATATOR)
         if _log.isEnabledFor(_DEBUG):
             _log.debug('new device row %s at index %d', row_data, new_child_index)
@@ -533,7 +537,10 @@ def _update_details(button):
             else:
                 # yield ('Codename', device.codename)
                 yield (_('Index'), device.number)
-                yield (_('Wireless PID'), device.wpid)
+                if device.wpid:
+                    yield (_('Wireless PID'), device.wpid)
+                if device.product_id:
+                    yield (_('USB id'), '046d:' + device.product_id)
                 hid_version = device.protocol
                 yield (_('Protocol'), 'HID++ %1.1f' % hid_version if hid_version else _('Unknown'))
                 if read_all and device.polling_rate:
@@ -654,6 +661,9 @@ def _update_device_panel(device, panel, buttons, full=False):
     is_online = bool(device.online)
     panel.set_sensitive(is_online)
 
+    if device.status.get(_K.BATTERY_LEVEL) is None:
+        device.status.read_battery(device)
+
     battery_level = device.status.get(_K.BATTERY_LEVEL)
     battery_next_level = device.status.get(_K.BATTERY_NEXT_LEVEL)
     battery_voltage = device.status.get(_K.BATTERY_VOLTAGE)
@@ -736,7 +746,7 @@ def _update_device_panel(device, panel, buttons, full=False):
         panel._lux.set_visible(False)
 
     buttons._pair.set_visible(False)
-    buttons._unpair.set_sensitive(device.receiver.may_unpair)
+    buttons._unpair.set_sensitive(device.receiver.may_unpair if device.receiver else False)
     buttons._unpair.set_visible(True)
 
     panel.set_visible(True)
@@ -841,14 +851,14 @@ def update(device, need_popup=False):
 
     selected_device_id = _find_selected_device_id()
 
-    if device.kind is None:
+    if device.kind is None:  # receiver
         # receiver
         is_alive = bool(device)
         item = _receiver_row(device.path, device if is_alive else None)
 
         if is_alive and item:
             was_pairing = bool(_model.get_value(item, _COLUMN.STATUS_ICON))
-            is_pairing = bool(device.status.lock_open)
+            is_pairing = (not device.isDevice) and bool(device.status.lock_open)
             _model.set_value(item, _COLUMN.STATUS_ICON, 'network-wireless' if is_pairing else _CAN_SET_ROW_NONE)
 
             if selected_device_id == (device.path, 0):
@@ -862,44 +872,45 @@ def update(device, need_popup=False):
             _model.remove(item)
 
     else:
-        # peripheral
-        is_paired = bool(device)
-        assert device.receiver
-        assert device.number is not None and device.number > 0, 'invalid device number' + str(device.number)
-        item = _device_row(device.receiver.path, device.number, device if is_paired else None)
+        path = device.receiver.path if device.receiver else device.path
+        assert device.number is not None and device.number >= 0, 'invalid device number' + str(device.number)
+        item = _device_row(path, device.number, device if bool(device) else None)
 
-        if is_paired and item:
-            was_online = _model.get_value(item, _COLUMN.ACTIVE)
-            is_online = bool(device.online)
-            _model.set_value(item, _COLUMN.ACTIVE, is_online)
-
-            battery_level = device.status.get(_K.BATTERY_LEVEL)
-            battery_voltage = device.status.get(_K.BATTERY_VOLTAGE)
-            if battery_level is None:
-                _model.set_value(item, _COLUMN.STATUS_TEXT, _CAN_SET_ROW_NONE)
-                _model.set_value(item, _COLUMN.STATUS_ICON, _CAN_SET_ROW_NONE)
-            else:
-                if battery_voltage is not None:
-                    status_text = '%(battery_voltage)dmV' % {'battery_voltage': battery_voltage}
-                elif isinstance(battery_level, _NamedInt):
-                    status_text = _(str(battery_level))
-                else:
-                    status_text = '%(battery_percent)d%%' % {'battery_percent': battery_level}
-                _model.set_value(item, _COLUMN.STATUS_TEXT, status_text)
-
-                charging = device.status.get(_K.BATTERY_CHARGING)
-                icon_name = _icons.battery(battery_level, charging)
-                _model.set_value(item, _COLUMN.STATUS_ICON, icon_name)
-
-            if selected_device_id is None or need_popup:
-                select(device.receiver.path, device.number)
-            elif selected_device_id == (device.receiver.path, device.number):
-                full_update = need_popup or was_online != is_online
-                _update_info_panel(device, full=full_update)
-
+        if bool(device) and item:
+            update_device(device, item, selected_device_id, need_popup)
         elif item:
             _model.remove(item)
             _config_panel.clean(device)
 
     # make sure all rows are visible
     _tree.expand_all()
+
+
+def update_device(device, item, selected_device_id, need_popup):
+    was_online = _model.get_value(item, _COLUMN.ACTIVE)
+    is_online = bool(device.online)
+    _model.set_value(item, _COLUMN.ACTIVE, is_online)
+
+    battery_level = device.status.get(_K.BATTERY_LEVEL)
+    battery_voltage = device.status.get(_K.BATTERY_VOLTAGE)
+    if battery_level is None:
+        _model.set_value(item, _COLUMN.STATUS_TEXT, _CAN_SET_ROW_NONE)
+        _model.set_value(item, _COLUMN.STATUS_ICON, _CAN_SET_ROW_NONE)
+    else:
+        if battery_voltage is not None:
+            status_text = '%(battery_voltage)dmV' % {'battery_voltage': battery_voltage}
+        elif isinstance(battery_level, _NamedInt):
+            status_text = _(str(battery_level))
+        else:
+            status_text = '%(battery_percent)d%%' % {'battery_percent': battery_level}
+        _model.set_value(item, _COLUMN.STATUS_TEXT, status_text)
+
+        charging = device.status.get(_K.BATTERY_CHARGING)
+        icon_name = _icons.battery(battery_level, charging)
+        _model.set_value(item, _COLUMN.STATUS_ICON, icon_name)
+
+    if selected_device_id is None or need_popup:
+        select(device.receiver.path if device.receiver else device.path, device.number)
+    elif selected_device_id == (device.receiver.path if device.receiver else device.path, device.number):
+        full_update = need_popup or was_online != is_online
+        _update_info_panel(device, full=full_update)

--- a/rules.d/42-logitech-unify-permissions.rules
+++ b/rules.d/42-logitech-unify-permissions.rules
@@ -1,57 +1,14 @@
 # This rule was added by Solaar.
 #
-# Allows non-root users to have raw access the Logitech Unifying USB Receiver
-# device. For development purposes, allowing users to write to the receiver is
-# potentially dangerous (e.g. perform firmware updates).
+# Allows non-root users to have raw access to Logitech devices.
+# Allowing users to write to the device is potentially dangerous
+# because they could perform firmware updates.
 
 ACTION != "add", GOTO="solaar_end"
 SUBSYSTEM != "hidraw", GOTO="solaar_end"
 
-# official Unifying receivers
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c52b", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c532", GOTO="solaar_apply"
-
-# Nano receiver, "Unifying Ready"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c52f", GOTO="solaar_apply"
-
-# classic Nano receiver -- VX Nano mouse
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c526", GOTO="solaar_apply"
-
-# classic Nano receiver -- MK220/MK320 mouse and keyboard combo
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c52e", GOTO="solaar_apply"
-
-# classic? Nano receiver -- V220 wireless mouse
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c51b", GOTO="solaar_apply"
-
-# G-Series receiver -- G-Series mouse
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c531", GOTO="solaar_apply"
-
-# other Nano receivers known to Solaar
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c517", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c518", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c51a", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c521", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c525", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c534", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c537", GOTO="solaar_apply"
-
-# Lightspeed receivers
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c539", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c53a", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c53d", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c53f", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c545", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c541", GOTO="solaar_apply"
-
-# Logitech wired devices
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c081", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c082", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c086", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c087", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c088", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c090", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c091", GOTO="solaar_apply"
-ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c08d", GOTO="solaar_apply"
+# Logitech receivers and direct-connected devices
+ATTRS{idVendor}=="046d", GOTO="solaar_apply"
 
 # Lenovo nano receiver
 ATTRS{idVendor}=="17ef", ATTRS{idProduct}=="6042", GOTO="solaar_apply"

--- a/rules.d/42-logitech-unify-permissions.rules
+++ b/rules.d/42-logitech-unify-permissions.rules
@@ -51,6 +51,7 @@ ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c087", GOTO="solaar_apply"
 ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c088", GOTO="solaar_apply"
 ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c090", GOTO="solaar_apply"
 ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c091", GOTO="solaar_apply"
+ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c08d", GOTO="solaar_apply"
 
 # Lenovo nano receiver
 ATTRS{idVendor}=="17ef", ATTRS{idProduct}=="6042", GOTO="solaar_apply"


### PR DESCRIPTION
Adds wired devices that talk HID++ 2.0 to the Solaar GUI.
Also adds G502 Hero mouse USB information
Also lets config and probe work on wired devices
Also adds more information to show

Replaces #952 