### PR TITLE
Dpi

### DIFF
--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -408,9 +408,11 @@ def _feature_dpi_sliding():
 
             def displayNewDpi(self, newDpiIdx):
                 if _notify.available:
-                    reason = f'DPI {self.dpiChoices[newDpiIdx]} [min {self.dpiChoices[0]}, max {self.dpiChoices[-1]}]'
-                    asPercentage = int(float(newDpiIdx) / float(len(self.dpiChoices) - 1) * 100.)
-                    _notify.show(self.device, reason=reason, progress=asPercentage)
+                    reason = 'DPI %d [min %d, max %d]' % (self.dpiChoices[newDpiIdx], self.dpiChoices[0], self.dpiChoices[-1])
+                    # if there is a progress percentage then the reason isn't shown
+                    # asPercentage = int(float(newDpiIdx) / float(len(self.dpiChoices) - 1) * 100.)
+                    # _notify.show(self.device, reason=reason, progress=asPercentage)
+                    _notify.show(self.device, reason=reason)
 
             def handle_keys_event(self, cids):
                 if self.fsmState == 'idle':


### PR DESCRIPTION
Addresses comments at the end of PR #733 

Use regular DPI value as the other value for clicking on DPI switch
Save sliding DPI other value in persister for reuse when device starts up 

Display DPI value instead of low-high percentage.   Please say which display you prefer.