### PR TITLE
device: add BT information for MX Keys

### DIFF
--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -330,7 +330,7 @@ _D(
     settings=[_FS.new_fn_swap()],
 )
 _D('Craft Advanced Keyboard', codename='Craft', protocol=4.5, wpid='4066', btid=0xB350)
-
+_D('MX Keys Keyboard', codename='MK Keys', protocol=4.5, wpid='408A', btid=0xB35B)
 _D(
     'Wireless Keyboard S510',
     codename='S510',


### PR DESCRIPTION
Hello!

Here is the device information for the MX Keys keyboard.

It works flawlessly with it. :-)

Thanks a lot for your awesome work!

Cheers,

Olivier