### PR TITLE
Fix PyGIWarning

### DIFF
--- a/lib/solaar/ui/__init__.py
+++ b/lib/solaar/ui/__init__.py
@@ -22,13 +22,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from logging import DEBUG as _DEBUG
 from logging import getLogger
 
-import gi
+import gi  # isort:skip
+gi.require_version('Gtk', '3.0')  # NOQA: E402
 
-from gi.repository import GLib, Gtk
-from logitech_receiver.status import ALERT
-from solaar.i18n import _
-
-gi.require_version('Gtk', '3.0')
+from gi.repository import GLib, Gtk  # NOQA: E402 # isort:skip
+from logitech_receiver.status import ALERT  # NOQA: E402 # isort:skip
+from solaar.i18n import _  # NOQA: E402 # isort:skip
 
 _log = getLogger(__name__)
 del getLogger


### PR DESCRIPTION
### Changes
* Fixes the following warning I was getting after every single call to `solaar`:
```
/usr/lib/python3.8/site-packages/solaar/ui/__init__.py:27: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.
```