### PR TITLE
rules: make rule processing conditional on X11 being available

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -109,7 +109,8 @@ program.
 
 Solaar can process HID++ Feature Notifications from devices to, for example,
 change the speed of some thumb wheels.  For more information on this capability of Solaar see
-[the rules page](https://pwr-solaar.github.io/Solaar/rules).
+[the rules page](https://pwr-solaar.github.io/Solaar/rules).  As much of rule processing
+depends on X11, this capability is only when running under X11.
 
 Users can edit rules using a GUI by clicking on the `Edit Rule` button in the Solaar main window.
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -3,6 +3,8 @@ title: Rule Processing of HID++ Notifications
 layout: page
 ---
 
+Note that rule processing is only available when running under X11.
+
 Logitech devices that use HID++ version 2.0 or greater produce feature-based
 notifications that Solaar can process using a simple rule language.  For
 example, using rules Solaar can emulate an `XF86_MonBrightnessDown` key tap

--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -330,7 +330,7 @@ _D(
     settings=[_FS.new_fn_swap()],
 )
 _D('Craft Advanced Keyboard', codename='Craft', protocol=4.5, wpid='4066', btid=0xB350)
-_D('MX Keys Keyboard', codename='MK Keys', protocol=4.5, wpid='408A', btid=0xB35B)
+_D('MX Keys Keyboard', codename='MX Keys', protocol=4.5, wpid='408A', btid=0xB35B)
 _D(
     'Wireless Keyboard S510',
     codename='S510',

--- a/lib/solaar/ui/diversion_rules.py
+++ b/lib/solaar/ui/diversion_rules.py
@@ -24,10 +24,9 @@ from contextlib import contextmanager as contextlib_contextmanager
 from logging import getLogger
 from shlex import quote as shlex_quote
 
-import Xlib.XK
-
 from gi.repository import Gdk, GObject, Gtk
 from logitech_receiver import diversion as _DIV
+from logitech_receiver.diversion import XK_KEYS as _XK_KEYS
 from logitech_receiver.diversion import buttons as _buttons
 from logitech_receiver.hidpp20 import FEATURE as _ALL_FEATURES
 from logitech_receiver.special_keys import CONTROL as _CONTROL
@@ -1086,7 +1085,7 @@ class ActionUI(RuleComponentUI):
 class KeyPressUI(ActionUI):
 
     CLASS = _DIV.KeyPress
-    KEY_NAMES = [k[3:] if k.startswith('XK_') else k for k, v in vars(Xlib.XK).items() if isinstance(v, int)]
+    KEY_NAMES = [k[3:] if k.startswith('XK_') else k for k, v in _XK_KEYS.items() if isinstance(v, int)]
 
     def create_widgets(self):
         self.widgets = {}


### PR DESCRIPTION
Fixes #1006 

Much of rule processing requires X11 so turn off rule processing if X11 is not available.