### PR TITLE
Log real exception when can't use Xorg API

### DIFF
--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -20,6 +20,8 @@
 import os as _os
 import os.path as _path
 
+import sys as _sys
+
 from logging import INFO as _INFO
 from logging import getLogger
 
@@ -49,8 +51,8 @@ try:
     XK_KEYS = vars(_XK)
     disp_prog = Display()
     x11 = True
-except Exception:
-    _log.warn('X11 not available - rules will not be activated')
+except:
+    _log.warn('X11 not available - rules will not be activated', exc_info=_sys.exc_info())
     XK_KEYS = {}
     x11 = False
 

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -19,7 +19,6 @@
 
 import os as _os
 import os.path as _path
-
 import sys as _sys
 
 from logging import INFO as _INFO
@@ -51,7 +50,7 @@ try:
     XK_KEYS = vars(_XK)
     disp_prog = Display()
     x11 = True
-except:
+except Exception:
     _log.warn('X11 not available - rules will not be activated', exc_info=_sys.exc_info())
     XK_KEYS = {}
     x11 = False


### PR DESCRIPTION
The current version prints an obscure warning when it can't connect to xorg. As the result, troubleshooting requires modifying code even when maximum log verbosity is enabled (`-dd`).
This change adds the real exception to the logs.