### PR TITLE
cli: don't select paired but not connected device for config command

### DIFF
--- a/lib/solaar/cli/__init__.py
+++ b/lib/solaar/cli/__init__.py
@@ -156,7 +156,7 @@ def _find_device(receivers, name):
             if number and number <= r.max_devices:
                 dev = r[number]
                 if dev:
-                    return dev
+                    yield dev
         else:  # wired device, make a device list from it
             r = [r]
 
@@ -165,9 +165,10 @@ def _find_device(receivers, name):
                 name == dev.serial.lower() or name == dev.codename.lower() or name == str(dev.kind).lower()
                 or name in dev.name.lower()
             ):
-                return dev
+                yield dev
 
-    raise Exception("no device found matching '%s'" % name)
+
+#    raise Exception("no device found matching '%s'" % name)
 
 
 def run(cli_args=None, hidraw_path=None):

--- a/lib/solaar/cli/config.py
+++ b/lib/solaar/cli/config.py
@@ -90,7 +90,7 @@ def run(receivers, args, find_receiver, find_device):
                 value = False
             else:
                 raise Exception("%s: don't know how to interpret '%s' as boolean" % (setting.name, value))
-        print('Setting %s to %s' % (setting.name, value))
+        print('Setting %s of %s to %s' % (setting.name, dev.name, value))
 
     elif setting.kind == _settings.KIND.range:
         try:
@@ -100,7 +100,7 @@ def run(receivers, args, find_receiver, find_device):
         min, max = setting.range
         if value < min or value > max:
             raise Exception("%s: value '%s' out of bounds" % (setting.name, args.value))
-        print('Setting %s to %s' % (setting.name, value))
+        print('Setting %s of %s to %s' % (setting.name, dev.name, value))
 
     elif setting.kind == _settings.KIND.choice:
         value = args.value
@@ -129,7 +129,7 @@ def run(receivers, args, find_receiver, find_device):
             value = setting.choices[:][0]
         else:
             raise Exception('%s: possible values are [%s]' % (setting.name, ', '.join(str(v) for v in setting.choices)))
-        print('Setting %s to %r' % (setting.name, value))
+        print('Setting %s of %s to %s' % (setting.name, dev.name, value))
 
     else:
         raise Exception('NotImplemented')

--- a/lib/solaar/cli/config.py
+++ b/lib/solaar/cli/config.py
@@ -51,10 +51,15 @@ def run(receivers, args, find_receiver, find_device):
     assert args.device
 
     device_name = args.device.lower()
-    dev = find_device(receivers, device_name)
 
-    if not dev.ping():
-        raise Exception('%s is offline' % dev.name)
+    dev = None
+    for dev in find_device(receivers, device_name):
+        if dev.ping():
+            break
+        dev = None
+
+    if not dev:
+        raise Exception("no online device found matching '%s'" % device_name)
 
     if not args.setting:  # print all settings, so first set them all up
         if not dev.settings:

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -287,6 +287,8 @@ def run(devices, args, find_receiver, find_device):
         _print_receiver(dev)
         return
 
-    dev = find_device(devices, device_name)
-    assert dev
+    dev = next(find_device(devices, device_name), None)
+    if not dev:
+        raise Exception("no device found matching '%s'" % device_name)
+
     _print_device(dev)

--- a/lib/solaar/cli/unpair.py
+++ b/lib/solaar/cli/unpair.py
@@ -25,7 +25,9 @@ def run(receivers, args, find_receiver, find_device):
     assert args.device
 
     device_name = args.device.lower()
-    dev = find_device(receivers, device_name)
+    dev = next(find_device(receivers, device_name), None)
+    if not dev:
+        raise Exception("no device found matching '%s'" % device_name)
 
     if not dev.receiver.may_unpair:
         print(


### PR DESCRIPTION
Fixes an issue when trying to configure a device that is connected via BT or USB but is also paired with a connected receiver.