### PR TITLE
device: use long messages for all 2.0 requests

### DIFF
--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -433,7 +433,7 @@ class Device(object):
             request_id,
             *params,
             no_reply=no_reply,
-            long_message=self.bluetooth
+            long_message=True  # use long messages for all requests - was self.bluetooth
         )
 
     def feature_request(self, feature, function=0x00, *params, no_reply=False):

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -562,8 +562,6 @@ def _feature_divert_keys_callback(device):
     for k in device.keys:
         if 'divertable' in k.flags:
             choices[k.key] = [_NamedInt(0x00, 'Regular'), _NamedInt(0x01, 'Diverted')]
-    if device.wpid == '4055':  # this device appears to lie about its diversion capabilities
-        return None
     if not choices:
         return None
     return _ChoicesMapV(choices, key_byte_count=2, byte_count=1, mask=0x01, activate=0x02)


### PR DESCRIPTION
Some devices signal errors if the message is short for a feature that expects more bytes.