### PR TITLE
setting: implement polling rate

### DIFF
--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -183,6 +183,8 @@ BATTERY_STATUS = _NamedInts(
     thermal_error=0x06
 )
 
+ONBOARD_MODES = _NamedInts(MODE_NO_CHANGE=0x00, MODE_ONBOARD=0x01, MODE_HOST=0x02)
+
 CHARGE_STATUS = _NamedInts(charging=0x00, full=0x01, not_charging=0x02, error=0x07)
 
 CHARGE_LEVEL = _NamedInts(average=50, full=90, critical=5)
@@ -1332,6 +1334,19 @@ def set_host_name(device, name):
             hn = name[:min(14, name.find('.'))] if name.find('.') >= 0 else name
             response = feature_request(device, FEATURE.HOSTS_INFO, 0x40, 0xff, 0, hn)
             return response
+
+
+def get_onboard_mode(device):
+    state = feature_request(device, FEATURE.ONBOARD_PROFILES, 0x20)
+
+    if state:
+        mode = _unpack('!B', state[:1])[0]
+        return mode
+
+
+def set_onboard_mode(device, mode):
+    state = feature_request(device, FEATURE.ONBOARD_PROFILES, 0x10, mode)
+    return state
 
 
 def get_polling_rate(device):

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -216,6 +216,12 @@ def _print_device(dev, num=None):
                 print('            Polling Rate (ms): %d' % _hidpp20.get_polling_rate(dev))
             elif feature == _hidpp20.FEATURE.REMAINING_PAIRING:
                 print('            Remaining Pairings: %d' % _hidpp20.get_remaining_pairing(dev))
+            elif feature == _hidpp20.FEATURE.ONBOARD_PROFILES:
+                if _hidpp20.get_onboard_mode(dev) == _hidpp20.ONBOARD_MODES.MODE_HOST:
+                    mode = 'Host'
+                else:
+                    mode = 'On-Board'
+                print('            Device Mode: %s' % mode)
             elif feature == _hidpp20.FEATURE.BATTERY_STATUS or feature == _hidpp20.FEATURE.BATTERY_VOLTAGE:
                 print('', end='       ')
                 _battery_line(dev)


### PR DESCRIPTION
Fixes #1040

As described in https://github.com/pwr-Solaar/Solaar/issues/1040,
this implements the ability to change report rates for HID++ 2.0+
devices by first sending the device into Host-mode before
modification.