### PR TITLE
better handling of icon search paths and better icon handling

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -123,6 +123,9 @@ for the step-by-step procedure for manual installation.
   application is also running *may* occasionally cause either of them to become
   confused about the state of the devices.
 
+- There are several implementations of the system tray.   Some of these have problems
+  that can result in missing or wrong-sized icons.
+
 ## License
 
 This software is distributed under the terms of the

--- a/lib/solaar/ui/action.py
+++ b/lib/solaar/ui/action.py
@@ -67,7 +67,7 @@ def make_toggle(name, label, function, stock_id=None, *args):
 #     action.set_sensitive(notify.available)
 # toggle_notifications = make_toggle('notifications', 'Notifications', _toggle_notifications)
 
-about = make('help-about', _('About') + ' ' + NAME, _show_about_window, stock_id=Gtk.STOCK_ABOUT)
+about = make('help-about', _('About') + ' ' + NAME, _show_about_window, stock_id='help-about')
 
 #
 #
@@ -96,7 +96,7 @@ def unpair(window, device):
         _('Unpair') + ' ' + device.name + ' ?'
     )
     qdialog.set_icon_name('remove')
-    qdialog.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
+    qdialog.add_button(_('Cancel'), Gtk.ResponseType.CANCEL)
     qdialog.add_button(_('Unpair'), Gtk.ResponseType.ACCEPT)
     choice = qdialog.run()
     qdialog.destroy()

--- a/lib/solaar/ui/diversion_rules.py
+++ b/lib/solaar/ui/diversion_rules.py
@@ -136,11 +136,11 @@ class DiversionDialog:
             )
             dialog.set_default_size(400, 100)
             dialog.add_buttons(
-                Gtk.STOCK_YES,
+                _('Yes'),
                 Gtk.ResponseType.YES,
-                Gtk.STOCK_NO,
+                _('No'),
                 Gtk.ResponseType.NO,
-                Gtk.STOCK_CANCEL,
+                _('Cancel'),
                 Gtk.ResponseType.CANCEL,
             )
             dialog.set_markup(_('If you choose No, changes will be lost when Solaar is closed.'))

--- a/lib/solaar/ui/icons.py
+++ b/lib/solaar/ui/icons.py
@@ -88,8 +88,8 @@ def _init_icon_paths():
 
     _default_theme = Gtk.IconTheme.get_default()
     for p in _look_for_application_icons():
-        if p not in _default_theme.get_search_path():
-            _default_theme.prepend_search_path(p)
+        _default_theme.prepend_search_path(p)
+        break  # only prepend one path - that's sufficient
     if _log.isEnabledFor(_DEBUG):
         _log.debug('icon theme paths: %s', _default_theme.get_search_path())
 

--- a/lib/solaar/ui/icons.py
+++ b/lib/solaar/ui/icons.py
@@ -88,7 +88,8 @@ def _init_icon_paths():
 
     _default_theme = Gtk.IconTheme.get_default()
     for p in _look_for_application_icons():
-        _default_theme.prepend_search_path(p)
+        if p not in _default_theme.get_search_path():
+            _default_theme.prepend_search_path(p)
     if _log.isEnabledFor(_DEBUG):
         _log.debug('icon theme paths: %s', _default_theme.get_search_path())
 

--- a/lib/solaar/ui/tray.py
+++ b/lib/solaar/ui/tray.py
@@ -185,7 +185,7 @@ try:
         theme_paths = Gtk.IconTheme.get_default().get_search_path()
 
         ind = AppIndicator3.Indicator.new_with_path(
-            'indicator-solaar', _icon_file(_icons.TRAY_INIT), AppIndicator3.IndicatorCategory.HARDWARE, ':'.join(theme_paths)
+            'indicator-solaar', _icon_file(_icons.TRAY_INIT), AppIndicator3.IndicatorCategory.HARDWARE, theme_paths[0]
         )
         ind.set_title(NAME)
         ind.set_status(AppIndicator3.IndicatorStatus.ACTIVE)

--- a/lib/solaar/ui/tray.py
+++ b/lib/solaar/ui/tray.py
@@ -181,6 +181,7 @@ try:
         return icon_info.get_filename() if icon_info else icon_name
 
     def _create(menu):
+        _icons._init_icon_paths()
         theme_paths = Gtk.IconTheme.get_default().get_search_path()
 
         ind = AppIndicator3.Indicator.new_with_path(

--- a/lib/solaar/ui/tray.py
+++ b/lib/solaar/ui/tray.py
@@ -65,7 +65,7 @@ def _create_menu(quit_handler):
 
     from .action import about, make
     menu.append(about.create_menu_item())
-    menu.append(make('application-exit', _('Quit'), quit_handler, stock_id=Gtk.STOCK_QUIT).create_menu_item())
+    menu.append(make('application-exit', _('Quit'), quit_handler, stock_id='application-exit').create_menu_item())
     del about, make
 
     menu.show_all()

--- a/lib/solaar/ui/tray.py
+++ b/lib/solaar/ui/tray.py
@@ -189,7 +189,7 @@ try:
         )
         ind.set_title(NAME)
         ind.set_status(AppIndicator3.IndicatorStatus.ACTIVE)
-        ind.set_attention_icon_full(_icon_file(_icons.TRAY_ATTENTION), '')
+        # ind.set_attention_icon_full(_icon_file(_icons.TRAY_ATTENTION), '') # works poorly for XFCE 16
         # ind.set_label(NAME, NAME)
 
         ind.set_menu(menu)
@@ -226,7 +226,7 @@ try:
 
     def attention(reason=None):
         if _icon.get_status() != AppIndicator3.IndicatorStatus.ATTENTION:
-            _icon.set_attention_icon_full(_icon_file(_icons.TRAY_ATTENTION), reason or '')
+            # _icon.set_attention_icon_full(_icon_file(_icons.TRAY_ATTENTION), reason or '') # works poorly for XFCe 16
             _icon.set_status(AppIndicator3.IndicatorStatus.ATTENTION)
             GLib.timeout_add(10 * 1000, _icon.set_status, AppIndicator3.IndicatorStatus.ACTIVE)
 


### PR DESCRIPTION
Only add one path to theme paths because all the extra icons are in one directory.
Don't use a :-joined list of paths in appindicator.

Can be tested by anyone.  Check that icons show up correctly both in the main window and in the tray, particularly the solaar icons.