### PR TITLE
ui: add ability to ignore a Solaar setting

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -20,14 +20,6 @@ to your computer using a USB cable or via Bluetooth.
 Not all such devices supported in Solaar as information needs to be added to Solaar
 for each device type that directly connects.
 
-Most devices forget changed settings when the are turned off
-or go into a power-saving mode.
-Solaar keeps track of the settings that it has changed.
-The Solaar GUI application notices when devices reconnect and
-applies the remembered settings to the device.
-This is done independently on each computer that Solaar runs on.
-As a result if a device is switched between different computers
-Solaar can apply different settings on different computers.
 
 ## HID++
 
@@ -76,6 +68,7 @@ can connect only to the kind of devices they were bought with and devices
 without the Unifying logo can probably only connect to the kind of receiver
 that they were bought with.
 
+
 ## Supported features
 
 Solaar uses the HID++ protocol to pair devices to receivers and unpair
@@ -84,11 +77,40 @@ features of receivers and devices. Currently it only displays some
 features, and can modify even fewer. For a list of HID++ features
 and their support see [the features page](features).
 
-Solaar does not do anything beyond using the HID++ protocol to change the
-behavior of receivers and devices. In particular, it cannot change how
+Solaar does not do much beyond using the HID++ protocol to change the
+behavior of receivers and devices via changing their settings.
+In particular, Solaar cannot change how
 the operating system turns the keycodes that a keyboard produces into
 characters that are sent to programs. That is the province of HID device
 drivers and other software (such as X11).
+
+Settings can only be changed in the Solaar GUI when they are unlocked.
+To unlock a setting click on the icon at the right-hand edge of the setting
+until an unlocked lock appears (with tooltop "Changes allowed").
+
+Solaar keep tracks of the changeable settings of a device.
+Most devices forget changed settings when the are turned off
+or go into a power-saving mode.  When Solaar starts, it restores on-line
+devices to their previously-known state, and while running it restores
+devices to their previously-known state when the device itself comes on line.
+This information is stored in the file `~/.config/solaar/config.json`.
+
+Updating of settings can be turned off in the Solaar GUI by clicking on the icon
+at the right-hand edge of the setting until a red icon appears (with tooltip
+"Ignore this setting" ).
+
+Solaar keeps track of settings independently on each computer.
+As a result if a device is switched between different computers
+Solaar may apply different settings for it on the different computers
+
+Querying a device for its current state can require quite a few HID++
+interactions. These interactions can temporarily slow down the device, so
+Solaar tries to internally cache information about devices while it is
+running.  If the device
+state is changed by some other means, even sometimes by another invocation
+of the program, this cached information may become incorrect. Currently there is
+no way to force an update of the cached information besides restarting the
+program.
 
 Logitech receivers and devices have firmware in them. Some firmware
 can be updated using Logitech software in Windows. For example, there are
@@ -98,21 +120,6 @@ also be updated in Linux using `fwupdmgr`.
 WARNING: Updating firmware can cause a piece of hardware to become
 permanently non-functional if something goes wrong with the update or the
 update installs the wrong firmware.
-
-Solaar does keep track of some changeable settings of a device between
-invocations. When it starts, it restores on-line devices to their
-previously-known state, and while running it restores devices to
-their previously-known state when the device itself comes on line.
-This information is stored in the file `~/.config/solaar/config.json`.
-
-Querying a device for its current state can require quite a few HID++
-interactions. These interactions can temporarily slow down the device, so
-Solaar tries to internally cache information about devices. If the device
-state is changed by some other means, even sometimes by another invocation
-of the program, this cached information may become incorrect. Currently there is
-no way to force an update of the cached information besides restarting the
-program.
-
 
 ## Rule-based Processing of HID++ Feature Notifications
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -127,6 +127,12 @@ for the step-by-step procedure for manual installation.
   application is also running *may* occasionally cause either of them to become
   confused about the state of the devices.
 
+- Some Linux drivers view or modify the setting Scroll Wheel Resolution to
+  implement smooth scrolling.  If Solaar changes this setting after the driver is
+  set up scrolling can be either very fast or very slow.  To fix this problem
+  click on the icon at the right edge of the setting to set it to
+  "Ignore this setting".   Then turn your device off and on again.
+
 - There are several implementations of the system tray.   Some of these have problems
   that can result in missing or wrong-sized icons.
 

--- a/lib/logitech_receiver/settings.py
+++ b/lib/logitech_receiver/settings.py
@@ -37,6 +37,7 @@ del getLogger
 #
 #
 
+SENSITIVITY_IGNORE = 'ignore'
 KIND = _NamedInts(toggle=0x01, choice=0x02, range=0x04, map_choice=0x0A, multiple_toggle=0x10, multiple_range=0x40)
 
 
@@ -1029,3 +1030,12 @@ class MultipleRangeValidator:
                 raise ValueError(f'invalid choice for {item}.{sub_item}: {v} not in [{sub_item.minimum}..{sub_item.maximum}]')
             w += _int2bytes(v, sub_item.length)
         return w + b'\xFF'
+
+
+def apply_all_settings(device):
+    persister = getattr(device, 'persister', None)
+    sensitives = persister.get('_sensitive', {}) if persister else {}
+    for s in device.settings:
+        ignore = sensitives.get(s.name, False)
+        if ignore != SENSITIVITY_IGNORE:
+            s.apply()

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -772,7 +772,7 @@ _SETTINGS_TABLE = [
     _S(_HI_RES_SCROLL, _F.HI_RES_SCROLLING, _feature_hi_res_scroll),
     _S(_LOW_RES_SCROLL, _F.LOWRES_WHEEL, _feature_lowres_smooth_scroll),
     _S(_HIRES_INV, _F.HIRES_WHEEL, _feature_hires_smooth_invert),
-    #    _S(_HIRES_RES, _F.HIRES_WHEEL, _feature_hires_smooth_resolution),  # Recent Linux drivers depend on this not changing
+    _S(_HIRES_RES, _F.HIRES_WHEEL, _feature_hires_smooth_resolution),  # Recent Linux drivers depend on this not changing
     _S(_SMART_SHIFT, _F.SMART_SHIFT, _feature_smart_shift),
     _S(_SMART_SHIFT, _F.SMART_SHIFT_ENHANCED, _feature_smart_shift_enhanced, identifier='smart_shift_enhanced'),
     _S(_THUMB_SCROLL_MODE, _F.THUMB_WHEEL, _feature_thumb_mode),

--- a/lib/logitech_receiver/status.py
+++ b/lib/logitech_receiver/status.py
@@ -26,6 +26,7 @@ from time import time as _timestamp
 
 from . import hidpp10 as _hidpp10
 from . import hidpp20 as _hidpp20
+from . import settings as _settings
 from .common import BATTERY_APPROX as _BATTERY_APPROX
 from .common import NamedInt as _NamedInt
 from .common import NamedInts as _NamedInts
@@ -306,8 +307,7 @@ class DeviceStatus(dict):
                     # make sure they're up-to-date.
                     if _log.isEnabledFor(_INFO):
                         _log.info('%s pushing device settings %s', d, d.settings)
-                    for s in d.settings:
-                        s.apply()
+                    _settings.apply_all_settings(d)
 
                     # battery information may have changed so try to read it now
                     self.read_battery(timestamp)

--- a/lib/solaar/cli/config.py
+++ b/lib/solaar/cli/config.py
@@ -127,8 +127,7 @@ def run(receivers, args, find_receiver, find_device):
         if not dev.settings:
             raise Exception('no settings for %s' % dev.name)
         _configuration.attach_to(dev)
-        for s in dev.settings:
-            s.apply()
+        _settings.apply_all_settings(dev)
         print(dev.name, '(%s) [%s:%s]' % (dev.codename, dev.wpid, dev.serial))
         for s in dev.settings:
             print('')

--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -23,6 +23,7 @@ from threading import Timer as _Timer
 
 from gi.repository import Gdk, GLib, Gtk
 from logitech_receiver.settings import KIND as _SETTING_KIND
+from logitech_receiver.settings import SENSITIVITY_IGNORE as _SENSITIVITY_IGNORE
 from solaar.i18n import _, ngettext
 from solaar.ui import ui_async as _ui_async
 
@@ -352,22 +353,34 @@ def _create_multiple_range_control(setting, change):
 #
 #
 
+_allowables_icons = {True: 'changes-allow', False: 'changes-prevent', _SENSITIVITY_IGNORE: 'dialog-error'}
+_allowables_tooltips = {
+    True: _('Changes allowed'),
+    False: _('No changes allowed'),
+    _SENSITIVITY_IGNORE: _('Ignore this setting')
+}
+_next_allowable = {True: False, False: _SENSITIVITY_IGNORE, _SENSITIVITY_IGNORE: True}
+_icons_allowables = {v: k for k, v in _allowables_icons.items()}
 
-# clicking on the lock icon changes the sensitivity of the setting
+
+# clicking on the lock icon changes from changeable to unchangeable to ignore
 def _change_click(eb, button, arg):
     control, device, name = arg
-    sensitive = not control.get_sensitive()
-    control.set_sensitive(sensitive)
     icon = eb.get_children()[0]
-    _change_icon(sensitive, icon)
+    icon_name, _ = icon.get_icon_name()
+    allowed = _icons_allowables.get(icon_name, True)
+    new_allowed = _next_allowable[allowed]
+    control.set_sensitive(new_allowed is True)
+    _change_icon(new_allowed, icon)
     if device.persister:  # remember the new setting sensitivity
-        device.persister.set_sensitivity(name, sensitive)
+        device.persister.set_sensitivity(name, new_allowed)
     return True
 
 
 def _change_icon(allowed, icon):
-    icon.set_from_icon_name('changes-allow' if allowed else 'changes-prevent', Gtk.IconSize.LARGE_TOOLBAR)
-    icon.set_tooltip_text(_('Click to prevent changes.') if allowed else _('Click to allow changes.'))
+    allowed = allowed if allowed in _allowables_icons else True
+    icon.set_from_icon_name(_allowables_icons[allowed], Gtk.IconSize.LARGE_TOOLBAR)
+    icon.set_tooltip_text(_allowables_tooltips[allowed])
 
 
 def _create_sbox(s, device):

--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -374,6 +374,10 @@ def _change_click(eb, button, arg):
     _change_icon(new_allowed, icon)
     if device.persister:  # remember the new setting sensitivity
         device.persister.set_sensitivity(name, new_allowed)
+    if allowed == _SENSITIVITY_IGNORE:  # get current value of setting if it was being ignored
+        setting = next((s for s in device.settings if s.name == name), None)
+        if setting:
+            _read_async(setting, True, control.get_parent(), bool(device.online), control.get_sensitive())
     return True
 
 


### PR DESCRIPTION
This ability was added to permit Solaar to coexist with both old drivers - where users may need to set scroll wheel resolution to achieve good scrolling speed - and new drivers - where Solaar should not change the value for scroll wheel resolution.

Fixes  #1061 and #1112 and #1132.
