### PR TITLE
settings: add mouse gesture handling

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -3,7 +3,7 @@ title: Solaar Capabilities
 layout: page
 ---
 
-# Solaar capabilities
+# Solaar Capabilities
 
 [**Solaar**][solaar] reports on and controls [Logitech][logitech] devices
 (keyboards, mice, and trackballs) that connect to your computer via a
@@ -69,7 +69,7 @@ without the Unifying logo can probably only connect to the kind of receiver
 that they were bought with.
 
 
-## Supported features
+## Supported Features
 
 Solaar uses the HID++ protocol to pair devices to receivers and unpair
 devices from receivers, and also uses the HID++ protocol to display
@@ -121,16 +121,39 @@ WARNING: Updating firmware can cause a piece of hardware to become
 permanently non-functional if something goes wrong with the update or the
 update installs the wrong firmware.
 
-## Rule-based Processing of HID++ Feature Notifications
+## Other Solaar Capabilities
+
+Solaar has a few capabilities that go beyond simply changing device settings.
+
+### Rule-based Processing of HID++ Feature Notifications
 
 Solaar can process HID++ Feature Notifications from devices to, for example,
-change the speed of some thumb wheels.  For more information on this capability of Solaar see
+change the speed of some thumb wheels.  These notifications are only sent
+for actions that are set in Solaar to their HID++ setting (also known as diverted).
+For more information on this capability of Solaar see
 [the rules page](https://pwr-solaar.github.io/Solaar/rules).  As much of rule processing
 depends on X11, this capability is only when running under X11.
 
 Users can edit rules using a GUI by clicking on the `Edit Rule` button in the Solaar main window.
 
 Solaar rules is an experimental feature.  Significant changes might be made in response to problems.
+
+### Sliding DPI
+
+A few mice (such as the MX Vertical) have a button that can be used to change
+the sensitivity (DPI) of the mouse by pressing the button and moving the mouse left and right.
+This processing is only set up in Solaar when the DPI Sliding Adjustment setting is on and
+the DPI Switch button is diverted.
+
+### Mouse Gestures
+
+Some mice (such as the MX Master 3) have a button that can be used to
+create up/down/left/right gestures, which then are seen by the Solaar rules as
+MOUSE_GESTURE notifications.
+This processing is only set up in Solaar when the Mouse Gestures setting is on and
+the App Switch Gesture button or MultiPlatform Gesture Button is diverted.
+
+Mouse gestures is an experimental feature.  Significant changes might be made in response to problems.
 
 
 ## System Tray

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -89,6 +89,8 @@ A `thumb_wheel_up` test is the rotation amount of a `THUMB WHEEL` upward rotatio
 A `thumb_wheel_down` test is the rotation amount of a `THUMB WHEEL` downward rotation.
 `lowres_wheel_up`, `lowres_wheel_down`, `hires_wheel_up`, `hires_wheel_down` are the
 same but for `LOWRES WHEEL` and `HIRES WHEEL`.
+A 'mouse-down' test is true for a mouse gesture mostly in the downward direction.
+`mouse-up', 'mouse-left', and 'mouse-right' are the same but for gestures in the other directions.
 `True` and `False` tests return True and False, respectively.
 
 A `KeyPress` action takes a sequence of X11 key symbols and simulates a chorded keypress on the keyboard.

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -158,6 +158,20 @@ def signed(bytes):
     return int.from_bytes(bytes, 'big', signed=True)
 
 
+def xy_direction(d):
+    x, y = _unpack('!2h', d[:4])
+    if x > 0 and x >= abs(y):
+        return 'right'
+    elif x < 0 and abs(x) >= abs(y):
+        return 'left'
+    elif y > 0:
+        return 'down'
+    elif y < 0:
+        return 'up'
+    else:
+        return None
+
+
 TESTS = {
     'crown_right': lambda f, r, d: f == _F.CROWN and r == 0 and d[1] < 128 and d[1],
     'crown_left': lambda f, r, d: f == _F.CROWN and r == 0 and d[1] >= 128 and 256 - d[1],
@@ -173,6 +187,10 @@ TESTS = {
     'lowres_wheel_down': lambda f, r, d: f == _F.LOWRES_WHEEL and r == 0 and signed(d[0:1]) < 0 and signed(d[0:1]),
     'hires_wheel_up': lambda f, r, d: f == _F.HIRES_WHEEL and r == 0 and signed(d[1:3]) > 0 and signed(d[1:3]),
     'hires_wheel_down': lambda f, r, d: f == _F.HIRES_WHEEL and r == 0 and signed(d[1:3]) < 0 and signed(d[1:3]),
+    'mouse-down': lambda f, r, d: f == _F.MOUSE_GESTURE and xy_direction(d) == 'down',
+    'mouse-up': lambda f, r, d: f == _F.MOUSE_GESTURE and xy_direction(d) == 'up',
+    'mouse-left': lambda f, r, d: f == _F.MOUSE_GESTURE and xy_direction(d) == 'left',
+    'mouse-right': lambda f, r, d: f == _F.MOUSE_GESTURE and xy_direction(d) == 'right',
     'False': lambda f, r, d: False,
     'True': lambda f, r, d: True,
 }

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -164,6 +164,8 @@ FEATURE = _NamedInts(
     SIDETONE=0x8300,
     EQUALIZER=0x8310,
     HEADSET_OUT=0x8320,
+    # Fake features for Solaar internal use
+    MOUSE_GESTURE=0xFE00,
 )
 FEATURE._fallback = lambda x: 'unknown:%04X' % x
 
@@ -525,13 +527,12 @@ class ReprogrammableKeyV4(ReprogrammableKey):
         """
         flags = flags if flags else {}  # See flake8 B006
 
-        if special_keys.MAPPING_FLAG.raw_XY_diverted in flags and flags[special_keys.MAPPING_FLAG.raw_XY_diverted]:
-            # We need diversion to report raw XY, so divert temporarily
-            # (since XY reporting is also temporary)
-            flags[special_keys.MAPPING_FLAG.diverted] = True
-
-        if special_keys.MAPPING_FLAG.diverted in flags and not flags[special_keys.MAPPING_FLAG.diverted]:
-            flags[special_keys.MAPPING_FLAG.raw_XY_diverted] = False
+        # if special_keys.MAPPING_FLAG.raw_XY_diverted in flags and flags[special_keys.MAPPING_FLAG.raw_XY_diverted]:
+        # We need diversion to report raw XY, so divert temporarily
+        # (since XY reporting is also temporary)
+        # flags[special_keys.MAPPING_FLAG.diverted] = True
+        # if special_keys.MAPPING_FLAG.diverted in flags and not flags[special_keys.MAPPING_FLAG.diverted]:
+        # flags[special_keys.MAPPING_FLAG.raw_XY_diverted] = False
 
         # The capability required to set a given reporting flag.
         FLAG_TO_CAPABILITY = {


### PR DESCRIPTION
Addresses #1108 

Adds a Mouse Gestures setting.  When turned on, and the mouse's App Switch Gesture button is diverted, pressing and then releasing the App Switch Gesture button causes mouse x and y displacement while the button is down to be converted into a fake notification that can be used in Solaar rules.   The easiest way to build rules for these gestures is via mouse-left, mouse-right, mouse-down, and mouse-up tests.