### PR TITLE
Prefer symbolic battery icons on GNOME

### DIFF
--- a/lib/solaar/gtk.py
+++ b/lib/solaar/gtk.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import importlib
 import os.path
+import subprocess
 
 from logging import INFO as _INFO
 from logging import getLogger
@@ -96,7 +97,14 @@ def _parse_arguments():
         args.window = 'show'  # default behaviour is to show main window
 
     global battery_icons_style
-    battery_icons_style = args.battery_icons if args.battery_icons is not None else 'regular'
+    GNOME = b'GNOME' in subprocess.run(['echo $XDG_CURRENT_DESKTOP'], shell=True, capture_output=True).stdout
+
+    if args.battery_icons is not None:
+        battery_icons_style = args.battery_icons
+    elif GNOME:
+        battery_icons_style = 'symbolic'
+    else:
+        battery_icons_style = 'regular'
 
     import logging
     if args.debug > 0:


### PR DESCRIPTION
Fixes https://github.com/pwr-Solaar/Solaar/issues/1130.

I was trying to diagnose the above Issue based on the maintainer’s assertion that it was down to the indicator plugin, so I took the following steps.

I added the following to `icons.py`:
```
import sys
...
print('gtk.battery_icons_style returns', file=sys.stdout)
print(gtk.battery_icons_style, file=sys.stdout)
print('_default_theme.has_icon(\'battery-good-symbolic\') returns', file=sys.stdout)
print(_default_theme.has_icon('battery-good-symbolic'), file=sys.stdout)
```
and got the following output:
```
gtk.battery_icons_style returns
regular
_default_theme.has_icon('battery-good-symbolic') returns
True
```
As far as I can tell, the only place `gtk.battery_icons_style` is set is from the command line arguments, with the following line in `gtk.py`:
https://github.com/pwr-Solaar/Solaar/blob/69df28c15595363589c81fb0028bb140c9102057/lib/solaar/gtk.py#L99

In other words, Solaar does not actually check with the environment to see if the shell prefers symbolic icons. My guess is that this is based on a misunderstanding of how icon themes work (at least in GNOME): icon themes contain both symbolic and hicolor icons, with no preference either way, and it is up to application developers to choose.

If the preceding line were changed to:
```
battery_icons_style = args.battery_icons if args.battery_icons is not None
```
and the following lines in `icons.py` were changed from:
https://github.com/pwr-Solaar/Solaar/blob/69df28c15595363589c81fb0028bb140c9102057/lib/solaar/ui/icons.py#L95-L102
to:
```
if gtk.battery_icons_style is None:
    if _default_theme.has_icon('battery-good-symbolic'):
        _log.warning('detected symbolic icons')
        gtk.battery_icons_style = ’symbolic’
    elif _default_theme.has_icon('battery-good'):
        _log.warning('detected hicolor icons')
        gtk.battery_icons_style = ’regular’
    else:
        _log.warning('failed to detect icons')
        gtk.battery_icons_style = 'none'
```
then Solaar would choose the icon theme based on whether it contains the necessary symbolic icons. (i.e. Solaar would prefer symbolic icons by default.)

I looked at [`gtk.IconTheme`](https://developer.gnome.org/pygtk/stable/class-gtkicontheme.html), and it does not have any members indicating whether to prefer symbolic icons, aside from the ability to search to icons with the suffix `-symbolic`.

Regardless of what indicator plugin an end user is using, `gtk.IconTheme` is the API that Solaar itself uses to detect icon themes.

In [`enum Gtk::IconLookupFlags`](https://developer.gnome.org/gtkmm/stable/group__gtkmmEnums.html), I do see the following:
> Used to specify options for `Gtk::IconTheme::lookup_icon()`
>  `FORCE_REGULAR` | Try to always load regular icons, even when symbolic icon names are given.
> `FORCE_SYMBOLIC` | Try to always load symbolic icons, even when regular icon names are given.

But this flag is provided by the application, not the icon theme.

[ubuntu/gnome-shell-extension-appindicator](https://github.com/ubuntu/gnome-shell-extension-appindicator) does not contain any code for detecting a preference for symbolic icons.

[AyatanaIndicators/libayatana-indicator](https://github.com/AyatanaIndicators/libayatana-indicator) does not contain the string "symbolic" anywhere in its code, period.

I searched several Ayatana applets, and the only one I found with any reference to symbolic icons was [AyatanaIndicators/ayatana-indicator-power](https://github.com/AyatanaIndicators/ayatana-indicator-power)

Looking at [ayatana-indicator-power](https://github.com/AyatanaIndicators/ayatana-indicator-power/blob/6754015a5d4c23e700e8dd48a0de7c4646bb4e5e/tests/test-device.cc), we see the following:
```
EXPECT_ICON_NAMES_EQ("ac-adapter-symbolic;"
                       "ac-adapter",
                       device);
```
which is based on the function:
```
#define EXPECT_ICON_NAMES_EQ(expected_in,device_in)                          \
  do {                                                                       \
    const std::string tmp_expected {expected_in};                            \
    const std::string tmp_actual {get_icon_names_from_device(device_in)};    \
    EXPECT_EQ(tmp_expected, tmp_actual);                                     \
  } while(0)
```
It appears that the applet lists a preference for the symbolic icon, then falls back to the hicolor icon (though the syntax of the function definition is a bit opaque to me).

Anyway!

In deference to desktop shells other than GNOME, instead of defaulting to `symbolic` across the board, the code in this pull request defaults to `symbolic` only if `$XDG_CURRENT_DESKTOP` equals `GNOME`. (I used `in` rather than equality because `subprocess.run().stdout` includes newlines and other gobbledygook.) I have tested this code, and it functions as intended on my computer.

I would be happy to modify this pull request to default to symbolic icons across the board, if the maintainers so prefer, or I could add different shell-specific defaults. It would probably also be desirable to put an explanation of this behavior in the documentation, so I can add that, too.