### PR TITLE
diversion: implement pressed and released action on Key condition

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -58,7 +58,9 @@ can only be `Shift`, `Control`, `Alt`, and `Super`.
 Modifiers conditions are true if their argument is the current keyboard
 modifiers.
 `Key` conditions are true if the Logitech name of the last diverted key or button down is their
-string argument.  Logitech key and button names are shown in the `Key/Button Diversion`
+string argument.  Alternatively, if the argument is a list `[name, action]` where `action`
+is either `'pressed'` or `'released'`, the key down or key up events of `name` argument are
+matched, respectively.  Logitech key and button names are shown in the `Key/Button Diversion`
 setting.  Some keyboards have Gn keys, which are diverted using the 'Divert G Keys' setting.
 `Test` conditions are true if their test evaluates to true on the feature,
 report, and data of the current notification.

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -154,6 +154,7 @@ if x11:
 # See docs/rules.md for documentation
 
 key_down = None
+key_up = None
 
 
 def signed(bytes):
@@ -406,21 +407,50 @@ class Modifiers(Condition):
 
 
 class Key(Condition):
-    def __init__(self, key):
+    DOWN = 'pressed'
+    UP = 'released'
+
+    def __init__(self, args):
+        default_key = 0
+        default_action = self.DOWN
+
+        key, action = None, None
+
+        if not args or not isinstance(args, (list, str)):
+            _log.warn('rule Key arguments unknown: %s' % args)
+            key = default_key
+            action = default_action
+        elif isinstance(args, str):
+            _log.debug('rule Key assuming action "%s" for "%s"' % (default_action, args))
+            key = args
+            action = default_action
+        elif isinstance(args, list):
+            if len(args) == 1:
+                _log.debug('rule Key assuming action "%s" for "%s"' % (default_action, args))
+                key, action = args[0], default_action
+            elif len(args) >= 2:
+                key, action = args[:2]
+
         if isinstance(key, str) and key in _CONTROL:
             self.key = _CONTROL[key]
         else:
-            _log.warn('rule Key argument not name of a Logitech key: %s', key)
-            self.key = 0
+            _log.warn('rule Key key name not name of a Logitech key: %s' % key)
+            self.key = default_key
+
+        if isinstance(action, str) and action in (self.DOWN, self.UP):
+            self.action = action
+        else:
+            _log.warn('rule Key action unknown: %s, assuming %s' % (action, default_action))
+            self.action = default_action
 
     def __str__(self):
-        return 'Key: ' + (str(self.key) if self.key else 'None')
+        return 'Key: %s (%s)' % ((str(self.key) if self.key else 'None'), self.action)
 
     def evaluate(self, feature, notification, device, status, last_result):
-        return self.key and self.key == key_down
+        return self.key and self.key == (key_down if self.action == self.DOWN else key_up)
 
     def data(self):
-        return {'Key': str(self.key)}
+        return {'Key': [str(self.key), self.action]}
 
 
 def bit_test(start, end, bits):
@@ -735,14 +765,17 @@ g_keys_down = 0x00
 def process_notification(device, status, notification, feature):
     if not x11:
         return
-    global keys_down, g_keys_down, key_down
-    key_down = None
+    global keys_down, g_keys_down, key_down, key_up
+    key_down, key_up = None, None
     # need to keep track of keys that are down to find a new key down
     if feature == _F.REPROG_CONTROLS_V4 and notification.address == 0x00:
         new_keys_down = _unpack('!4H', notification.data[:8])
         for key in new_keys_down:
             if key and key not in keys_down:
                 key_down = key
+        for key in keys_down:
+            if key and key not in new_keys_down:
+                key_up = key
         keys_down = new_keys_down
     # and also G keys down
     elif feature == _F.GKEY and notification.address == 0x00:
@@ -750,6 +783,8 @@ def process_notification(device, status, notification, feature):
         for i in range(1, 9):
             if new_g_keys_down & (0x01 << (i - 1)) and not g_keys_down & (0x01 << (i - 1)):
                 key_down = _CONTROL['G' + str(i)]
+            if g_keys_down & (0x01 << (i - 1)) and not new_g_keys_down & (0x01 << (i - 1)):
+                key_up = _CONTROL['G' + str(i)]
         g_keys_down = new_g_keys_down
     rules.evaluate(feature, notification, device, status, True)
 

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -447,7 +447,7 @@ class Key(Condition):
         return 'Key: %s (%s)' % ((str(self.key) if self.key else 'None'), self.action)
 
     def evaluate(self, feature, notification, device, status, last_result):
-        return self.key and self.key == (key_down if self.action == self.DOWN else key_up)
+        return bool(self.key and self.key == (key_down if self.action == self.DOWN else key_up))
 
     def data(self):
         return {'Key': [str(self.key), self.action]}

--- a/lib/logitech_receiver/special_keys.py
+++ b/lib/logitech_receiver/special_keys.py
@@ -272,7 +272,7 @@ CONTROL = _NamedInts(
     LED_Toggle=0x013B,  #
 )
 
-for i in range(1, 7):  # add in G keys - these are not really Logitech Controls
+for i in range(1, 33):  # add in G keys - these are not really Logitech Controls
     CONTROL[0x1000 + i] = 'G' + str(i)
 
 CONTROL._fallback = lambda x: 'unknown:%04X' % x


### PR DESCRIPTION
- Track `key_up` key in addition to `key_down`
- Support `pressed` or `released` action in `Key` condition
- Add radio button to KeyUI to represent `pressed` or `released`

#### Use case

Push to talk with a mouse button: Bind `pressed` and `released` events to microphone unmute and mute commands respectively

Implements #1186 