### PR TITLE
Fix issue with G keys

### DIFF
--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -762,7 +762,7 @@ if x11:
     ])
 
 keys_down = []
-g_keys_down = 0x00000000
+g_keys_down = [0, 0, 0, 0]
 
 
 # process a notification


### PR DESCRIPTION
When I was trying to define rules for the G keys of a G613, I got the error message "'int' object is not subscriptable". With this fix it works.