### PR TITLE
Include a systemd.service file

### DIFF
--- a/share/systemd/solaar.service
+++ b/share/systemd/solaar.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Manager for Logitech devices
+Documentation=https://pwr-solaar.github.io/Solaar/
+
+[Service]
+ExecStart=/usr/bin/solaar --window hide
+Slice=background.slice
+
+[Install]
+WantedBy=graphical-session.target


### PR DESCRIPTION
Solaar needs to (ideally) run permanently in the background.

This systemd.service(5) makes this easy. It should be installed into
either of:

    /usr/lib/systemd/user/solaar.service
    $XDG_CONFIG_HOME/systemd/user/solaar.service

It can then be enabled by a user to automatically be started when
logging in via:

    systemctl --user enable solaar.service

I've been running this for around a year without any inconveniences.