### PR TITLE
Drop some obsolete syntax

### DIFF
--- a/bin/solaar
+++ b/bin/solaar
@@ -18,8 +18,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, unicode_literals
-
 
 def init_paths():
     """Make the app work in the source tree."""
@@ -29,11 +27,8 @@ def init_paths():
     # Python 2 need conversion from utf-8 filenames
     # Python 3 might have problems converting back to UTF-8 in case of Unicode surrogates
     try:
-        if sys.version_info < (3, ):
-            decoded_path = sys.path[0].decode(sys.getfilesystemencoding())
-        else:
-            decoded_path = sys.path[0]
-            sys.path[0].encode(sys.getfilesystemencoding())
+        decoded_path = sys.path[0]
+        sys.path[0].encode(sys.getfilesystemencoding())
 
     except UnicodeError:
         sys.stderr.write(

--- a/lib/hidapi/__init__.py
+++ b/lib/hidapi/__init__.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/hidapi/__init__.py
+++ b/lib/hidapi/__init__.py
@@ -17,8 +17,6 @@
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """Generic Human Interface Device API."""
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from hidapi.udev import close  # noqa: F401
 from hidapi.udev import enumerate  # noqa: F401
 from hidapi.udev import find_paired_node  # noqa: F401

--- a/lib/hidapi/hidconsole.py
+++ b/lib/hidapi/hidconsole.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/hidapi/hidconsole.py
+++ b/lib/hidapi/hidconsole.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 import sys
 import time

--- a/lib/hidapi/udev.py
+++ b/lib/hidapi/udev.py
@@ -24,8 +24,6 @@ The docstrings are mostly copied from the hidapi API header, with changes where
 necessary.
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import errno as _errno
 import os as _os
 

--- a/lib/hidapi/udev.py
+++ b/lib/hidapi/udev.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/hidapi/udev.py
+++ b/lib/hidapi/udev.py
@@ -333,13 +333,13 @@ def write(device_handle, data):
         try:
             retrycount += 1
             bytes_written = _os.write(device_handle, data)
-        except IOError as e:
+        except OSError as e:
             if e.errno == _errno.EPIPE:
                 sleep(0.1)
         else:
             break
     if bytes_written != len(data):
-        raise IOError(_errno.EIO, 'written %d bytes out of expected %d' % (bytes_written, len(data)))
+        raise OSError(_errno.EIO, 'written %d bytes out of expected %d' % (bytes_written, len(data)))
 
 
 def read(device_handle, bytes_count, timeout_ms=-1):
@@ -364,7 +364,7 @@ def read(device_handle, bytes_count, timeout_ms=-1):
 
     if xlist:
         assert xlist == [device_handle]
-        raise IOError(_errno.EIO, 'exception on file descriptor %d' % device_handle)
+        raise OSError(_errno.EIO, 'exception on file descriptor %d' % device_handle)
 
     if rlist:
         assert rlist == [device_handle]

--- a/lib/logitech_receiver/__init__.py
+++ b/lib/logitech_receiver/__init__.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/logitech_receiver/__init__.py
+++ b/lib/logitech_receiver/__init__.py
@@ -28,8 +28,6 @@ http://julien.danjou.info/blog/2012/logitech-k750-linux-support
 http://6xq.net/git/lars/lshidpp.git/plain/doc/
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import logging
 
 from . import listener, status  # noqa: F401

--- a/lib/logitech_receiver/base.py
+++ b/lib/logitech_receiver/base.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/logitech_receiver/base.py
+++ b/lib/logitech_receiver/base.py
@@ -19,8 +19,6 @@
 # Base low-level functions used by the API proper.
 # Unlikely to be used directly unless you're expanding the API.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import threading as _threading
 
 from collections import namedtuple

--- a/lib/logitech_receiver/base.py
+++ b/lib/logitech_receiver/base.py
@@ -115,8 +115,7 @@ def filter_receivers(bus_id, vendor_id, product_id):
 
 def receivers():
     """Enumerate all the receivers attached to the machine."""
-    for dev in _hid.enumerate(filter_receivers):
-        yield dev
+    yield from _hid.enumerate(filter_receivers)
 
 
 def filter_devices(bus_id, vendor_id, product_id):
@@ -129,8 +128,7 @@ def filter_devices(bus_id, vendor_id, product_id):
 
 def wired_devices():
     """Enumerate all the USB-connected and Bluetooth devices attached to the machine."""
-    for dev in _hid.enumerate(filter_devices):
-        yield dev
+    yield from _hid.enumerate(filter_devices)
 
 
 def filter_either(bus_id, vendor_id, product_id):

--- a/lib/logitech_receiver/base_usb.py
+++ b/lib/logitech_receiver/base_usb.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/logitech_receiver/base_usb.py
+++ b/lib/logitech_receiver/base_usb.py
@@ -26,8 +26,6 @@
 # USB ids of Logitech wireless receivers.
 # Only receivers supporting the HID++ protocol can go in here.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from .descriptors import DEVICES as _DEVICES
 from .i18n import _
 

--- a/lib/logitech_receiver/common.py
+++ b/lib/logitech_receiver/common.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/logitech_receiver/common.py
+++ b/lib/logitech_receiver/common.py
@@ -18,8 +18,6 @@
 
 # Some common functions and types.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from binascii import hexlify as _hexlify
 from collections import namedtuple
 from struct import pack, unpack

--- a/lib/logitech_receiver/common.py
+++ b/lib/logitech_receiver/common.py
@@ -255,11 +255,11 @@ class KwException(Exception):
     They can be later accessed by simple member access.
     """
     def __init__(self, **kwargs):
-        super(KwException, self).__init__(kwargs)
+        super().__init__(kwargs)
 
     def __getattr__(self, k):
         try:
-            return super(KwException, self).__getattr__(k)
+            return super().__getattr__(k)
         except AttributeError:
             return self.args[0][k]
 

--- a/lib/logitech_receiver/common.py
+++ b/lib/logitech_receiver/common.py
@@ -204,8 +204,7 @@ class NamedInts:
             return value in self.__dict__ or value in self._values
 
     def __iter__(self):
-        for v in self._values:
-            yield v
+        yield from self._values
 
     def __len__(self):
         return len(self._values)

--- a/lib/logitech_receiver/common.py
+++ b/lib/logitech_receiver/common.py
@@ -86,7 +86,7 @@ class NamedInt(int):
         return 'NamedInt(%d, %r)' % (int(self), self.name)
 
 
-class NamedInts(object):
+class NamedInts:
     """An ordered set of NamedInt values.
 
     Indexing can be made by int or string, and will return the corresponding

--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from collections import namedtuple
 
 from .common import NamedInts as _NamedInts

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import errno as _errno
 
 from logging import INFO as _INFO

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -28,7 +28,7 @@ KIND_MAP = {kind: _hidpp10.DEVICE_KIND[str(kind)] for kind in _hidpp20.DEVICE_KI
 #
 
 
-class Device(object):
+class Device:
 
     read_register = _hidpp10.read_register
     write_register = _hidpp10.write_register

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -176,7 +176,7 @@ if x11:
     displayt = Display()
 
 
-class RuleComponent(object):
+class RuleComponent:
     def compile(self, c):
         if isinstance(c, RuleComponent):
             return c

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -851,7 +851,7 @@ def _load_config_rule_file():
     loaded_rules = []
     if _path.isfile(_file_path):
         try:
-            with open(_file_path, 'r') as config_file:
+            with open(_file_path) as config_file:
                 loaded_rules = []
                 for loaded_rule in _yaml_safe_load_all(config_file):
                     rule = Rule(loaded_rule, source=_file_path)

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -807,7 +807,7 @@ def _save_config_rule_file(file_name=_file_path):
         pass
 
     def blockseq_rep(dumper, data):
-        return dumper.represent_sequence(u'tag:yaml.org,2002:seq', data, flow_style=True)
+        return dumper.represent_sequence('tag:yaml.org,2002:seq', data, flow_style=True)
 
     _yaml_add_representer(inline_list, blockseq_rep)
 

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2020 Peter Patel-Schneider
 ##

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -832,7 +832,7 @@ def _save_config_rule_file(file_name=_file_path):
         # 'version': (1, 3),  # it would be printed for every rule
     }
     # Save only user-defined rules
-    rules_to_save = sum([r.data()['Rule'] for r in rules.components if r.source == file_name], [])
+    rules_to_save = sum((r.data()['Rule'] for r in rules.components if r.source == file_name), [])
     if rules_to_save:
         if _log.isEnabledFor(_INFO):
             _log.info('saving %d rule(s) to %s', len(rules_to_save), file_name)

--- a/lib/logitech_receiver/hidpp10.py
+++ b/lib/logitech_receiver/hidpp10.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from logging import getLogger  # , DEBUG as _DEBUG
 
 from .common import BATTERY_APPROX as _BATTERY_APPROX

--- a/lib/logitech_receiver/hidpp10.py
+++ b/lib/logitech_receiver/hidpp10.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -226,7 +226,7 @@ class FeatureCallError(_KwException):
 #
 
 
-class FeaturesArray(object):
+class FeaturesArray:
     """A sequence of features supported by a HID++ 2.0 device."""
     __slots__ = ('supported', 'device', 'features', 'non_features')
     assert FEATURE.ROOT == 0x0000
@@ -367,7 +367,7 @@ class FeaturesArray(object):
 #
 
 
-class ReprogrammableKey(object):
+class ReprogrammableKey:
     """Information about a control present on a device with the `REPROG_CONTROLS` feature.
     Ref: https://drive.google.com/file/d/0BxbRzx7vEV7eU3VfMnRuRXktZ3M/view
     Read-only properties:
@@ -578,7 +578,7 @@ class ReprogrammableKeyV4(ReprogrammableKey):
         self._getCidReporting()
 
 
-class KeysArray(object):
+class KeysArray:
     """A sequence of key mappings supported by a HID++ 2.0 device."""
 
     __slots__ = ('device', 'keys', 'keyversion', 'cid_to_tid', 'group_cids')
@@ -813,7 +813,7 @@ ACTION_ID = _NamedInts(
 ACTION_ID._fallback = lambda x: 'unknown:%04X' % x
 
 
-class Gesture(object):
+class Gesture:
 
     gesture_index = {}
 
@@ -869,7 +869,7 @@ class Gesture(object):
     write = set
 
 
-class Param(object):
+class Param:
     param_index = {}
 
     def __init__(self, device, low, high):
@@ -947,7 +947,7 @@ class Spec:
         return f'[{self.spec}={self.value}]'
 
 
-class Gestures(object):
+class Gestures:
     """Information about the gestures that a device supports.
     Right now only some information fields are supported.
     WARNING: Assumes that parameters are always global, which is not the case.

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -18,8 +18,6 @@
 
 # Logitech Unifying Receiver API.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from logging import DEBUG as _DEBUG
 from logging import ERROR as _ERROR
 from logging import INFO as _INFO

--- a/lib/logitech_receiver/i18n.py
+++ b/lib/logitech_receiver/i18n.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/logitech_receiver/i18n.py
+++ b/lib/logitech_receiver/i18n.py
@@ -18,8 +18,6 @@
 
 # Translation support for the Logitech receivers library
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import gettext as _gettext
 
 try:

--- a/lib/logitech_receiver/listener.py
+++ b/lib/logitech_receiver/listener.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import threading as _threading
 
 from logging import DEBUG as _DEBUG

--- a/lib/logitech_receiver/listener.py
+++ b/lib/logitech_receiver/listener.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/logitech_receiver/listener.py
+++ b/lib/logitech_receiver/listener.py
@@ -139,7 +139,7 @@ class EventsListener(_threading.Thread):
     Incoming packets will be passed to the callback function in sequence.
     """
     def __init__(self, receiver, notifications_callback):
-        super(EventsListener, self).__init__(name=self.__class__.__name__ + ':' + receiver.path.split('/')[2])
+        super().__init__(name=self.__class__.__name__ + ':' + receiver.path.split('/')[2])
 
         self.daemon = True
         self._active = False

--- a/lib/logitech_receiver/listener.py
+++ b/lib/logitech_receiver/listener.py
@@ -40,7 +40,7 @@ del getLogger
 #
 
 
-class _ThreadedHandle(object):
+class _ThreadedHandle:
     """A thread-local wrapper with different open handles for each thread.
 
     Closing a ThreadedHandle will close all handles.

--- a/lib/logitech_receiver/notifications.py
+++ b/lib/logitech_receiver/notifications.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/logitech_receiver/notifications.py
+++ b/lib/logitech_receiver/notifications.py
@@ -19,8 +19,6 @@
 # Handles incoming events from the receiver/devices, updating the related
 # status object as appropriate.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from logging import DEBUG as _DEBUG
 from logging import INFO as _INFO
 from logging import getLogger

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -38,7 +38,7 @@ _IR = _hidpp10.INFO_SUBREGISTERS
 #
 
 
-class Receiver(object):
+class Receiver:
     """A Unifying Receiver instance.
 
     The paired devices are available through the sequence interface.

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import errno as _errno
 
 from logging import INFO as _INFO

--- a/lib/logitech_receiver/settings.py
+++ b/lib/logitech_receiver/settings.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/logitech_receiver/settings.py
+++ b/lib/logitech_receiver/settings.py
@@ -42,7 +42,7 @@ SENSITIVITY_IGNORE = 'ignore'
 KIND = _NamedInts(toggle=0x01, choice=0x02, range=0x04, map_choice=0x0A, multiple_toggle=0x10, multiple_range=0x40)
 
 
-class Setting(object):
+class Setting:
     """A setting descriptor.
     Needs to be instantiated for each specific device."""
     __slots__ = (
@@ -514,7 +514,7 @@ class BitFieldWithOffsetAndMaskSetting(BitFieldSetting):
 #
 
 
-class RegisterRW(object):
+class RegisterRW:
     __slots__ = ('register', )
 
     kind = _NamedInt(0x01, _('register'))
@@ -530,7 +530,7 @@ class RegisterRW(object):
         return device.write_register(self.register, data_bytes)
 
 
-class FeatureRW(object):
+class FeatureRW:
     __slots__ = ('feature', 'read_fnid', 'write_fnid', 'prefix', 'no_reply')
 
     kind = _NamedInt(0x02, _('feature'))
@@ -597,7 +597,7 @@ class FeatureRWMap(FeatureRW):
 #
 
 
-class BooleanValidator(object):
+class BooleanValidator:
     __slots__ = ('true_value', 'false_value', 'read_offset', 'mask', 'needs_current_value')
 
     kind = KIND.toggle
@@ -710,7 +710,7 @@ class BooleanValidator(object):
         return to_write
 
 
-class BitFieldValidator(object):
+class BitFieldValidator:
     __slots__ = ('byte_count', 'options')
 
     kind = KIND.multiple_toggle
@@ -745,7 +745,7 @@ class BitFieldValidator(object):
         return self.options
 
 
-class BitFieldWithOffsetAndMaskValidator(object):
+class BitFieldWithOffsetAndMaskValidator:
     __slots__ = ('byte_count', 'options', '_option_from_key', '_mask_from_offset', '_option_from_offset_mask')
 
     kind = KIND.multiple_toggle
@@ -827,7 +827,7 @@ class BitFieldWithOffsetAndMaskValidator(object):
         return [int(opt) if isinstance(opt, int) else opt.as_int() for opt in self.options]
 
 
-class ChoicesValidator(object):
+class ChoicesValidator:
     kind = KIND.choice
     """Translates between NamedInts and a byte sequence.
     :param choices: a list of NamedInts
@@ -939,7 +939,7 @@ class ChoicesMapValidator(ChoicesValidator):
         return self._write_prefix_bytes + new_value.to_bytes(self._byte_count, 'big')
 
 
-class RangeValidator(object):
+class RangeValidator:
     __slots__ = ('min_value', 'max_value', 'flag', '_byte_count', 'needs_current_value')
 
     kind = KIND.range
@@ -1042,7 +1042,7 @@ class MultipleRangeValidator:
         return w + b'\xFF'
 
 
-class ActionSettingRW(object):
+class ActionSettingRW:
     """Special RW class for settings that turn on and off special processing when a key or button is depressed"""
     def __init__(self, name, divert_setting_name):
         self.name = name

--- a/lib/logitech_receiver/settings.py
+++ b/lib/logitech_receiver/settings.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import math
 
 from copy import copy as _copy

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from collections import namedtuple
 from logging import DEBUG as _DEBUG
 from logging import INFO as _INFO

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -672,7 +672,7 @@ def _feature_reprogrammable_keys():
     return _Settings(_REPROGRAMMABLE_KEYS, rw, callback=_feature_reprogrammable_keys_callback, device_kind=(_DK.keyboard, ))
 
 
-class DivertKeysRW(object):
+class DivertKeysRW:
     def __init__(self):
         self.kind = _FeatureRW.kind
 

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -327,10 +327,10 @@ class _SmartShiftRW(_FeatureRW):
     MAX_VALUE = 50
 
     def __init__(self, feature, read_fnid, write_fnid):
-        super(_SmartShiftRW, self).__init__(feature, read_fnid, write_fnid)
+        super().__init__(feature, read_fnid, write_fnid)
 
     def read(self, device):
-        value = super(_SmartShiftRW, self).read(device)
+        value = super().read(device)
         if _bytes2int(value[0:1]) == 1:
             # Mode = Freespin, map to minimum
             return _int2bytes(_SmartShiftRW.MIN_VALUE, count=1)
@@ -347,7 +347,7 @@ class _SmartShiftRW(_FeatureRW):
         if threshold == _SmartShiftRW.MAX_VALUE:
             threshold = 255
         data = _int2bytes(mode, count=1) + _int2bytes(threshold, count=1)
-        return super(_SmartShiftRW, self).write(device, data)
+        return super().write(device, data)
 
 
 def _feature_smart_shift():
@@ -845,7 +845,7 @@ def _feature_divert_crown():
 def _feature_divert_gkeys():
     class _DivertGkeysRW(_FeatureRW):
         def __init__(self, feature):
-            super(_DivertGkeysRW, self).__init__(feature, write_fnid=0x20)
+            super().__init__(feature, write_fnid=0x20)
 
         def read(self, device):  # no way to read, so just assume not diverted
             return b'\x00'

--- a/lib/logitech_receiver/special_keys.py
+++ b/lib/logitech_receiver/special_keys.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/logitech_receiver/special_keys.py
+++ b/lib/logitech_receiver/special_keys.py
@@ -19,8 +19,6 @@
 # Reprogrammable keys information
 # Mostly from Logitech documentation, but with some edits for better Lunix compatability
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from .common import NamedInts as _NamedInts
 
 # <controls.xml awk -F\" '/<Control /{sub(/^LD_FINFO_(CTRLID_)?/, "", $2);printf("\t%s=0x%04X,\n", $2, $4)}' | sort -t= -k2

--- a/lib/logitech_receiver/status.py
+++ b/lib/logitech_receiver/status.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/logitech_receiver/status.py
+++ b/lib/logitech_receiver/status.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from logging import DEBUG as _DEBUG
 from logging import INFO as _INFO
 from logging import getLogger

--- a/lib/solaar/__init__.py
+++ b/lib/solaar/__init__.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/__init__.py
+++ b/lib/solaar/__init__.py
@@ -16,7 +16,5 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 __version__ = '1.0.7'
 NAME = 'Solaar'

--- a/lib/solaar/cli/__init__.py
+++ b/lib/solaar/cli/__init__.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/cli/__init__.py
+++ b/lib/solaar/cli/__init__.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import argparse as _argparse
 import sys as _sys
 

--- a/lib/solaar/cli/config.py
+++ b/lib/solaar/cli/config.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/cli/config.py
+++ b/lib/solaar/cli/config.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from logitech_receiver import settings as _settings
 from logitech_receiver import settings_templates as _settings_templates
 from solaar import configuration as _configuration

--- a/lib/solaar/cli/pair.py
+++ b/lib/solaar/cli/pair.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/cli/pair.py
+++ b/lib/solaar/cli/pair.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from time import time as _timestamp
 
 from logitech_receiver import base as _base

--- a/lib/solaar/cli/probe.py
+++ b/lib/solaar/cli/probe.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2020
 ##

--- a/lib/solaar/cli/probe.py
+++ b/lib/solaar/cli/probe.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from logitech_receiver import base as _base
 from logitech_receiver import hidpp10 as _hidpp10
 from logitech_receiver.common import strhex as _strhex

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from logitech_receiver import hidpp10 as _hidpp10
 from logitech_receiver import hidpp20 as _hidpp20
 from logitech_receiver import receiver as _receiver

--- a/lib/solaar/cli/unpair.py
+++ b/lib/solaar/cli/unpair.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/cli/unpair.py
+++ b/lib/solaar/cli/unpair.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 
 def run(receivers, args, find_receiver, find_device):
     assert receivers

--- a/lib/solaar/configuration.py
+++ b/lib/solaar/configuration.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/configuration.py
+++ b/lib/solaar/configuration.py
@@ -111,13 +111,13 @@ def _cleanup_load(d):
 
 class _DeviceEntry(dict):
     def __init__(self, device, **kwargs):
-        super(_DeviceEntry, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if self.get(_KEY_NAME) != device.name:
             self[_KEY_NAME] = device.name
         self.update(device)
 
     def __setitem__(self, key, value):
-        super(_DeviceEntry, self).__setitem__(key, value)
+        super().__setitem__(key, value)
         save()
 
     def update(self, device):

--- a/lib/solaar/configuration.py
+++ b/lib/solaar/configuration.py
@@ -45,7 +45,7 @@ def _load():
     if _path.isfile(_file_path):
         loaded_configuration = {}
         try:
-            with open(_file_path, 'r') as config_file:
+            with open(_file_path) as config_file:
                 loaded_configuration = _json_load(config_file)
         except Exception:
             _log.error('failed to load from %s', _file_path)

--- a/lib/solaar/gtk.py
+++ b/lib/solaar/gtk.py
@@ -18,8 +18,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import importlib
 import os.path
 

--- a/lib/solaar/i18n.py
+++ b/lib/solaar/i18n.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/i18n.py
+++ b/lib/solaar/i18n.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import gettext as _gettext
 import locale
 

--- a/lib/solaar/listener.py
+++ b/lib/solaar/listener.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/listener.py
+++ b/lib/solaar/listener.py
@@ -70,7 +70,7 @@ class ReceiverListener(_listener.EventsListener):
     """Keeps the status of a Receiver.
     """
     def __init__(self, receiver, status_changed_callback):
-        super(ReceiverListener, self).__init__(receiver, self._notifications_handler)
+        super().__init__(receiver, self._notifications_handler)
         # no reason to enable polling yet
         # self.tick_period = _POLL_TICK
         # self._last_tick = 0

--- a/lib/solaar/listener.py
+++ b/lib/solaar/listener.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import time
 
 from collections import namedtuple

--- a/lib/solaar/tasks.py
+++ b/lib/solaar/tasks.py
@@ -18,8 +18,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from logging import DEBUG as _DEBUG
 from logging import getLogger
 from threading import Thread as _Thread

--- a/lib/solaar/tasks.py
+++ b/lib/solaar/tasks.py
@@ -37,7 +37,7 @@ except ImportError:
 
 class TaskRunner(_Thread):
     def __init__(self, name):
-        super(TaskRunner, self).__init__(name=name)
+        super().__init__(name=name)
         self.daemon = True
         self.queue = _Queue(16)
         self.alive = False

--- a/lib/solaar/ui/__init__.py
+++ b/lib/solaar/ui/__init__.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/ui/__init__.py
+++ b/lib/solaar/ui/__init__.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from logging import DEBUG as _DEBUG
 from logging import getLogger
 

--- a/lib/solaar/ui/about.py
+++ b/lib/solaar/ui/about.py
@@ -17,8 +17,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from gi.repository import Gtk
 from solaar import NAME, __version__
 from solaar.i18n import _

--- a/lib/solaar/ui/about.py
+++ b/lib/solaar/ui/about.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ## Revisions Copyright (C) Contributors to the Solaar project.

--- a/lib/solaar/ui/action.py
+++ b/lib/solaar/ui/action.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/ui/action.py
+++ b/lib/solaar/ui/action.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from gi.repository import Gdk, Gtk
 from solaar.i18n import _
 

--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from threading import Timer as _Timer
 
 from gi.repository import Gdk, GLib, Gtk

--- a/lib/solaar/ui/diversion_rules.py
+++ b/lib/solaar/ui/diversion_rules.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from collections import defaultdict
 from contextlib import contextmanager as contextlib_contextmanager
 from logging import getLogger

--- a/lib/solaar/ui/diversion_rules.py
+++ b/lib/solaar/ui/diversion_rules.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2020 Solaar
 ##

--- a/lib/solaar/ui/icons.py
+++ b/lib/solaar/ui/icons.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/ui/icons.py
+++ b/lib/solaar/ui/icons.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from logging import DEBUG as _DEBUG
 from logging import getLogger
 

--- a/lib/solaar/ui/notify.py
+++ b/lib/solaar/ui/notify.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/ui/notify.py
+++ b/lib/solaar/ui/notify.py
@@ -18,8 +18,6 @@
 
 # Optional desktop notifications.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from solaar.i18n import _
 
 #

--- a/lib/solaar/ui/pair_window.py
+++ b/lib/solaar/ui/pair_window.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/ui/pair_window.py
+++ b/lib/solaar/ui/pair_window.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from logging import DEBUG as _DEBUG
 from logging import getLogger
 

--- a/lib/solaar/ui/tray.py
+++ b/lib/solaar/ui/tray.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/ui/tray.py
+++ b/lib/solaar/ui/tray.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 
 from logging import DEBUG as _DEBUG

--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from logging import DEBUG as _DEBUG
 from logging import getLogger
 

--- a/lib/solaar/upower.py
+++ b/lib/solaar/upower.py
@@ -1,5 +1,4 @@
 # -*- python-mode -*-
-# -*- coding: UTF-8 -*-
 
 ## Copyright (C) 2012-2013  Daniel Pavel
 ##

--- a/lib/solaar/upower.py
+++ b/lib/solaar/upower.py
@@ -16,8 +16,6 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from logging import INFO as _INFO
 from logging import getLogger
 

--- a/tools/monitor.py
+++ b/tools/monitor.py
@@ -1,7 +1,6 @@
 #
 #
 #
-from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 


### PR DESCRIPTION
Most of this has no functional change and merely drops legacy code (most of it is python2-specific).

I used `pyupgrade` to generate the whole diff. See individual commits for details on each rule.