### PR TITLE
docs: fix table rendering on GitHub Pages

### DIFF
--- a/docs/devices.md
+++ b/docs/devices.md
@@ -199,6 +199,7 @@ subset of HID++ 1.0 protocol. Only hardware pairing is supported.
 
 
 ### Mice (Lightspeed)
+
 | Device                       | WPID | HID++ |
 |------------------------------|------|-------|
 | PRO X Superlight Wireless    | 4093 | 4.2   |


### PR DESCRIPTION
Without any space between the heading and the table, the rendering on GitHub Pages breaks (see screenshot below).

![image](https://user-images.githubusercontent.com/3526562/144228769-34190130-95c9-4ef0-9155-d0d02283384f.png)
