### PR TITLE
lower PyYAML and psutil version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,9 @@ For instructions on installing Solaar see https://pwr-solaar.github.io/Solaar/in
     python_requires='>=3.6',
     install_requires=[
         'pyudev (>= 0.13)',
-        'PyYAML (>= 5.1)',
+        'PyYAML (>= 3.12)',
         'python-xlib (>= 0.27)',
-        'psutil (>= 5.6.0)',
+        'psutil (>= 5.4.3)',
     ],
     package_dir={'': 'lib'},
     packages=['hidapi', 'logitech_receiver', 'solaar', 'solaar.ui', 'solaar.cli'],


### PR DESCRIPTION
RHEL8 and derivatives carry PyYAML 3.12 and psutil 5.4.3 built for the default python 3.6 in the base OS repository. Consequently, solaar is not installable without installing python38 or python39 stack (called module in RHEL/Fedora) that carry newer versions of these two.

solaar seems to work fine with these older versions as [confirmed](https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2022-f65a1a9d86) by @mefuller .

Fixes #1418 .