### PR TITLE
add keysyms to the packages list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ For instructions on installing Solaar see https://pwr-solaar.github.io/Solaar/in
         'psutil (>= 5.4.3)',
     ],
     package_dir={'': 'lib'},
-    packages=['hidapi', 'logitech_receiver', 'solaar', 'solaar.ui', 'solaar.cli'],
+    packages=['keysyms', 'hidapi', 'logitech_receiver', 'solaar', 'solaar.ui', 'solaar.cli'],
     data_files=list(_data_files()),
     scripts=_glob('bin/*'),
 )


### PR DESCRIPTION
`solaar` currently does not start because it can't find the `keysyms` library. This PR adds the library to the `packages` list of `setup.py` and creates a `__init__.py` file in the `keysyms` directory`.