### PR TITLE
Make APP_ID match real application ID

### DIFF
--- a/lib/solaar/cli/config.py
+++ b/lib/solaar/cli/config.py
@@ -187,7 +187,7 @@ def run(receivers, args, find_receiver, find_device):
         _print_setting(setting)
         return
 
-    APP_ID = 'io.github.pwr.solaar'
+    APP_ID = 'io.github.pwr_solaar.solaar'
     application = Gtk.Application.new(APP_ID, Gio.ApplicationFlags.HANDLES_COMMAND_LINE)
     application.register()
 

--- a/lib/solaar/ui/__init__.py
+++ b/lib/solaar/ui/__init__.py
@@ -163,7 +163,7 @@ def _shutdown(app, shutdown_hook):
 def run_loop(startup_hook, shutdown_hook, use_tray, show_window):
     assert use_tray or show_window, 'need either tray or visible window'
     # from gi.repository.Gio import ApplicationFlags as _ApplicationFlags
-    APP_ID = 'io.github.pwr.solaar'
+    APP_ID = 'io.github.pwr_solaar.solaar'
     application = Gtk.Application.new(APP_ID, Gio.ApplicationFlags.HANDLES_COMMAND_LINE)
 
     application.connect('startup', lambda app, startup_hook: _startup(app, startup_hook, use_tray, show_window), startup_hook)


### PR DESCRIPTION
The application advertises itself as io.github.pwr_solaar.solaar through
its appdata file, so name the application this way too.

This fixes this warning in Flatpak:
```
Failed to register: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: org.freedesktop.DBus.Error.ServiceUnknown
```

I went with `io.github.pwr_solaar.solaar` as `io.github.pwr.solaar` doesn't seem like a correct reverse DNS name.