### PR TITLE
appdata/metainfo fixes

### DIFF
--- a/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
+++ b/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
@@ -7,6 +7,7 @@
   <summary>Linux manager for Logitech keyboards, mice, and trackpads</summary>
   <url type="homepage">https://github.com/pwr-Solaar/Solaar</url>
   <content_rating type="oars-1.0" />
+  <update_contact>pfpschneider_AT_gmail.com</update_contact>
 
   <metadata_license>CC-BY-4.0</metadata_license>
   <project_license>GPL-2.0-only</project_license>

--- a/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
+++ b/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
@@ -1,3 +1,4 @@
+<!-- Copyright 2020-2022 Peter F. Patel-Schneider -->
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>io.github.pwr_solaar.solaar</id>

--- a/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
+++ b/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
@@ -41,6 +41,12 @@
     </screenshot>
   </screenshots>
 
+  <releases>
+    <release version="1.1.2" date="2022-03-26"/>
+    <release version="1.1.1" date="2021-12-25"/>
+    <release version="1.1.0" date="2021-12-20"/>
+  </releases>
+
   <provides>
     <binary>solaar</binary>
     <!-- USB Receivers - 27MHz, Unifying, Nano, Bolt -->

--- a/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
+++ b/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
@@ -3,7 +3,7 @@
   <id>io.github.pwr_solaar.solaar</id>
 
   <name>Solaar</name>
-  <summary>Solaar is a Linux manager for many Logitech keyboards, mice, and trackpads.</summary>
+  <summary>Linux manager for Logitech keyboards, mice, and trackpads</summary>
   <url type="homepage">https://github.com/pwr-Solaar/Solaar</url>
   <content_rating type="oars-1.0" />
 


### PR DESCRIPTION
The Flathub build was failing:
```
builddir/files/share/appdata/io.github.pwr_solaar.solaar.appdata.xml: FAILED:
• tag-missing           : <release> required
```