### PR TITLE
Move the metainfo XML declaration to the top

### DIFF
--- a/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
+++ b/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
@@ -1,5 +1,5 @@
-<!-- Copyright 2020-2022 Peter F. Patel-Schneider -->
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2020-2022 Peter F. Patel-Schneider -->
 <component type="desktop-application">
   <id>io.github.pwr_solaar.solaar</id>
 


### PR DESCRIPTION
The metainfo file is no longer a valid XML file; the XML declaration
must be the first line in the file. The file can be checked with
appstreamcli validate.

This moves the declaration back to the top of the file.

Signed-off-by: Stephen Kitt <steve@sk2.org>