### PR TITLE
udev: Add "static_node=uinput" option

### DIFF
--- a/rules.d/42-logitech-unify-permissions.rules
+++ b/rules.d/42-logitech-unify-permissions.rules
@@ -23,7 +23,7 @@ LABEL="solaar_apply"
 # Allow any seated user to access the receiver.
 # uaccess: modern ACL-enabled udev
 # udev-acl: for Ubuntu 12.10 and older
-TAG+="uaccess", TAG+="udev-acl"
+TAG+="uaccess", TAG+="udev-acl", OPTIONS+="static_node=uinput"
 
 # Grant members of the "plugdev" group access to receiver (useful for SSH users)
 #MODE="0660", GROUP="plugdev"


### PR DESCRIPTION
I noticed that on every boot `/dev/uinput` is recreated without ACL set. `setfacl -m u:${USER}:rw /dev/uinput` helps but only till the next boot (I'm on Fedora 36 with Wayland).

I've found that the Steam client was suffering the similar issue (ValveSoftware/steam-for-linux#4794, especially this comment explains in detail: https://github.com/ValveSoftware/steam-for-linux/issues/4794#issuecomment-327006061) and they fixed it by adding the `OPTIONS+="static_node=uinput"` to udev rules.
I tried that on my system and it works fine (no need to run `facl` on every boot any more).

