### PR TITLE
ui: increase entry size for ChoiceControlBig

### DIFF
--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -173,7 +173,7 @@ class ChoiceControlBig(Gtk.Entry, Control):
         self.init(sbox, delegate)
         self.choices = choices if choices is not None else sbox.setting.choices
         self.value = None
-        self.set_width_chars(max([len(str(x)) for x in self.choices]) + 2)
+        self.set_width_chars(max([len(str(x)) for x in self.choices]) + 5)
         liststore = Gtk.ListStore(int, str)
         for v in self.choices:
             liststore.append((int(v), str(v)))


### PR DESCRIPTION
The `ChoiceControlBig` text entry widget, used for AdjustableDpi setting, fails to display the full content, possibly due to the icon:

![image](https://user-images.githubusercontent.com/529520/177835098-f93fe825-f342-41d1-9219-3c1c823be24e.png)
_(actual value is 2200)_

This patch proposes to increase its width to improve readability:

![image](https://user-images.githubusercontent.com/529520/177835498-148e2461-042a-4144-a5ce-ed43e6734168.png)
![image](https://user-images.githubusercontent.com/529520/177835724-58199eaa-2a69-424e-b91b-b1781f1bce9b.png)

