### PR TITLE
settings: ignore first mouse gestures movement event for feature version 5 (solves MX Master 3S problem)

### DIFF
--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -928,6 +928,9 @@ class MouseGesture(_Setting):
         def move_action(self, dx, dy):
             if self.fsmState == 'pressed':
                 now = _time() * 1000  # _time_ns() / 1e6
+                if self.device.features.get_feature_version(_F.REPROG_CONTROLS_V4) >= 5 and self.lastEv is None:
+                    self.lastEv = now  # hack to ignore strange first movement report from MX Master 3S
+                    return
                 if self.lastEv is not None and now - self.lastEv > 50.:
                     self.push_mouse_event()
                 dpi = self.dpiSetting.read() if self.dpiSetting else 1000


### PR DESCRIPTION
Fixes #1662 but is only a hack.  Waiting on information on updated feature to fix correctly.