### PR TITLE
Fix release date in io.github.pwr_solaar.solaar.metainfo.xml

### DIFF
--- a/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
+++ b/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
@@ -44,7 +44,7 @@
   </screenshots>
 
   <releases>
-    <release version="1.1.4" date="2022-77-04"/>
+    <release version="1.1.4" date="2022-07-04"/>
     <release version="1.1.3" date="2022-04-25"/>
     <release version="1.1.2" date="2022-03-26"/>
     <release version="1.1.1" date="2021-12-25"/>


### PR DESCRIPTION
Fix release date for 1.1.4: month should be "07" instead of "77".