### PR TITLE
Fix circular import

### DIFF
--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -33,7 +33,6 @@ import keysyms.keysymdef as _keysymdef
 import psutil
 
 from gi.repository import Gdk, GLib
-from solaar.ui.config_panel import change_setting as _change_setting
 from yaml import add_representer as _yaml_add_representer
 from yaml import dump_all as _yaml_dump_all
 from yaml import safe_load_all as _yaml_safe_load_all
@@ -998,6 +997,9 @@ class Set(Action):
         return 'Set: ' + ' '.join([str(a) for a in self.args])
 
     def evaluate(self, feature, notification, device, status, last_result):
+        # importing here to avoid circular imports
+        from solaar.ui.config_panel import change_setting as _change_setting
+
         if len(self.args) < 3:
             return None
         if _log.isEnabledFor(_INFO):


### PR DESCRIPTION
Fix this circular import error found while attempting to package Solaar in Fedora

```
Check import: logitech_receiver.diversion
/builddir/build/BUILDROOT/python-solaar-1.1.4-1.fc37.x86_64/usr/lib/python3.11/site-packages/logitech_receiver/diversion.py:35: PyGIWarning: Gdk was imported without specifying a version first. Use gi.require_version('Gdk', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gdk, GLib
Traceback (most recent call last):
  File "/usr/lib/rpm/redhat/import_all_modules.py", line 171, in <module>
    main()
  File "/usr/lib/rpm/redhat/import_all_modules.py", line 167, in main
    import_modules(modules)
  File "/usr/lib/rpm/redhat/import_all_modules.py", line 100, in import_modules
    importlib.import_module(module)
  File "/usr/lib64/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/builddir/build/BUILDROOT/python-solaar-1.1.4-1.fc37.x86_64/usr/lib/python3.11/site-packages/logitech_receiver/diversion.py", line 36, in <module>
    from solaar.ui.config_panel import change_setting as _change_setting
  File "/builddir/build/BUILDROOT/python-solaar-1.1.4-1.fc37.x86_64/usr/lib/python3.11/site-packages/solaar/ui/__init__.py", line 101, in <module>
    from . import diversion_rules, notify, tray, window  # isort:skip  # noqa: E402
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/builddir/build/BUILDROOT/python-solaar-1.1.4-1.fc37.x86_64/usr/lib/python3.11/site-packages/solaar/ui/diversion_rules.py", line 32, in <module>
    from logitech_receiver.diversion import XK_KEYS as _XK_KEYS
ImportError: cannot import name 'XK_KEYS' from partially initialized module 'logitech_receiver.diversion' (most likely due to a circular import) (/builddir/build/BUILDROOT/python-solaar-1.1.4-1.fc37.x86_64/usr/lib/python3.11/site-packages/logitech_receiver/diversion.py)
```