### PR TITLE
Backlight2 update: True/False values for used 

### DIFF
--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -218,6 +218,9 @@ class Backlight2(_Setting):
     label = _('Backlight')
     description = _('Turn illumination on or off on keyboard.')
     feature = _F.BACKLIGHT2
+    # 0xFF stands for "Do not change the current effect", helps MX Mechanical backlight effect settings to be followed.
+    # according to https://drive.google.com/drive/u/2/folders/0BxbRzx7vEV7eWmgwazJ3NUFfQ28?resourcekey=0-dQ-Lx1FORQl0KAdOHQaE1A
+    validator_options = {'true_value': b'\xFF', 'false_value': b'\x01', 'read_skip_byte_count': 1}
 
 
 class Backlight3(_Setting):


### PR DESCRIPTION
Backlight2 is set to 0xFF when true. 0x01 when false to add some basic support for MX Mechanical backlight effects.

I cannot test in other devices.