### PR TITLE
Add PID of the K470 keyboard from the MK470 combo

### DIFF
--- a/docs/devices/Wireless Keyboard K470 4075.txt
+++ b/docs/devices/Wireless Keyboard K470 4075.txt
@@ -1,0 +1,61 @@
+Solaar version 1.1.7
+
+  1: Wireless Keyboard
+     Device path  : /dev/hidraw6
+     WPID         : 4075
+     Codename     :
+     Kind         : keyboard
+     Protocol     : HID++ 4.5
+     Polling rate : 20 ms (50Hz)
+     Serial number: 00000000
+     Model ID:      000000000000
+     Unit ID:       00000000
+          Firmware: RQK 71.00.B0002
+     Supports 20 HID++ 2.0 features:
+         0: ROOT                   {0000} V0
+         1: FEATURE SET            {0001} V0
+         2: DEVICE FW VERSION      {0003} V0
+            Firmware: Firmware RQK 71.00.B0002 4075
+            Unit ID: 00000000  Model ID: 000000000000  Transport IDs: {}
+         3: DEVICE NAME            {0005} V0
+            Name: Wireless Keyboard
+            Kind: keyboard
+         4: RESET                  {0020} V0
+         5: BATTERY STATUS         {1000} V0
+            Battery: 30%, discharging, next level 5%.
+         6: REPROG CONTROLS V4     {1B04} V2
+            Key/Button Diversion (saved): {Calculator:Regular, Mail:Regular, My Home:Regular, Search:Regular}
+            Key/Button Diversion        : {Calculator:Regular, Mail:Regular, My Home:Regular, Search:Regular}
+         7: WIRELESS DEVICE STATUS {1D4B} V0
+         8: NEW FN INVERSION       {40A2} V0
+            Fn-swap: disabled
+            Fn-swap default: disabled
+            Swap Fx function (saved): False
+            Swap Fx function        : False
+         9: ENCRYPTION             {4100} V0
+        10: LOCK KEY STATE         {4220} V0
+        11: KEYBOARD DISABLE KEYS  {4521} V0
+            Disable keys (saved): {Caps Lock:False, Num Lock:False, Scroll Lock:False, Insert:False, Win:False}
+            Disable keys        : {Caps Lock:False, Num Lock:False, Scroll Lock:False, Insert:False, Win:False}
+        12: unknown:1810           {1810} V0    internal, hidden
+        13: unknown:1830           {1830} V0    internal, hidden
+        14: unknown:1890           {1890} V0    internal, hidden
+        15: unknown:18A0           {18A0} V0    internal, hidden
+        16: unknown:18B0           {18B0} V0    internal, hidden
+        17: unknown:1DF3           {1DF3} V0    internal, hidden
+        18: unknown:1E00           {1E00} V0    hidden
+        19: unknown:1868           {1868} V0    internal, hidden
+     Has 4 reprogrammable keys:
+         0: My Home                   , default: HomePage                    => HomePage
+             is FN, FN sensitive, reprogrammable, divertable, pos:1, group:0, group mask:empty
+             reporting: default
+         1: Mail                      , default: Email                       => Email
+             is FN, FN sensitive, reprogrammable, divertable, pos:2, group:0, group mask:empty
+             reporting: default
+         2: Search                    , default: Search Files                => Search Files
+             is FN, FN sensitive, reprogrammable, divertable, pos:3, group:0, group mask:empty
+             reporting: default
+         3: Calculator                , default: Calculator                  => Calculator
+             is FN, FN sensitive, reprogrammable, divertable, pos:4, group:0, group mask:empty
+             reporting: default
+     Battery: 30%, discharging, next level 5%.

--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -202,6 +202,7 @@ _D('Wireless Multi-Device Keyboard K780', protocol=4.5, wpid='405B', settings=[_
 _D('Wireless Keyboard K375s', protocol=2.0, wpid='4061', settings=[_ST.K375sFnSwap])
 _D('Craft Advanced Keyboard', codename='Craft', protocol=4.5, wpid='4066', btid=0xB350)
 _D('Wireless Illuminated Keyboard K800 new', codename='K800 new', protocol=4.5, wpid='406E', settings=[_ST.FnSwap])
+_D('Wireless Keyboard K470', codename='K470', protocol=4.5, wpid='4075', settings=[_ST.FnSwap])
 _D('MX Keys Keyboard', codename='MX Keys', protocol=4.5, wpid='408A', btid=0xB35B)
 _D('G915 TKL LIGHTSPEED Wireless RGB Mechanical Gaming Keyboard', codename='G915 TKL', protocol=4.2, wpid='408E', usbid=0xC343)
 _D('G213 Prodigy Gaming Keyboard', codename='G213', usbid=0xc336, interface=1)


### PR DESCRIPTION
The K470 is the keyboard included in the MK470 Slim Wireless Keyboard and Mouse Combo: https://www.logitech.com/en-us/products/combos/mk470-slim-wireless-keyboard-mouse.html

The mouse in this combo is M340, with almost identical appearance of the Logitech Pebble M350 mouse, but has the same WPID of the M185 new (4054).