### PR TITLE
device: correctly determine whether to ping with a long HID++ message

### DIFF
--- a/docs/devices/G535 Wireless Gaming Headset 0AC4.txt
+++ b/docs/devices/G535 Wireless Gaming Headset 0AC4.txt
@@ -1,0 +1,29 @@
+solaar version 1.1.8
+
+USB and Bluetooth Devices
+
+  1: G535 Wireless Gaming Headset
+     Device path  : /dev/hidraw2
+     USB id       : 046d:0AC4
+     Codename     : G535
+     Kind         : ?
+     Protocol     : HID++ 4.2
+     Serial number:
+     Model ID:      000000000AC4
+     Unit ID:       FFFFFFFF
+          Firmware: U1  90.00.B0200
+     Supports 6 HID++ 2.0 features:
+         0: ROOT                   {0000} V0
+         1: FEATURE SET            {0001} V0
+         2: DEVICE FW VERSION      {0003} V2
+            Firmware: Firmware U1  90.00.B0200 0AC4
+            Unit ID: FFFFFFFF  Model ID: 000000000AC4  Transport IDs: {'btid': '0000', 'btleid': '0000'}
+         3: DEVICE NAME            {0005} V0
+            Name: G535 Wireless Gaming Headset
+            Kind: None
+         4: SIDETONE               {8300} V0
+            Sidetone (saved): 0
+            Sidetone        : 0
+         5: ADC MEASUREMENT        {1F20} V0
+            Battery: 60% 3920mV , discharging.
+     Battery: 60% 3920mV , discharging.

--- a/docs/devices/Number Pad N545 2006.txt
+++ b/docs/devices/Number Pad N545 2006.txt
@@ -1,0 +1,17 @@
+solaar version 1.1.8
+
+  3: Number Pad N545
+     Device path  : /dev/hidraw3
+     WPID         : 2006
+     Codename     : N545
+     Kind         : numpad
+     Protocol     : HID++ 1.0
+     Polling rate : 20 ms (50Hz)
+     Serial number: 900A4D98
+          Firmware: 13.00.B0037
+        Bootloader: 02.03
+             Other: 00.01
+     The power switch is located on the base.
+     Notifications: battery status (0x100000).
+     Features: (none)
+     Battery: full, discharging.

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -442,7 +442,7 @@ class Device:
 
     def ping(self):
         """Checks if the device is online, returns True of False"""
-        long = self.bluetooth or self._protocol is not None and self._protocol >= 2.0
+        long = self.bluetooth or self.hidpp_short is False or self._protocol is not None and self._protocol >= 2.0
         protocol = _base.ping(self.handle or self.receiver.handle, self.number, long_message=long)
         self.online = protocol is not None
         if protocol:


### PR DESCRIPTION
Fixes #1947 