### PR TITLE
Filter and escape technical detail fields

### DIFF
--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -585,11 +585,18 @@ def _update_details(button):
             _details._text.set_markup(text)
 
         def _make_text(items):
-            text = '\n'.join('%-13s: %s' % i for i in items)
+            text = '\n'.join('%-13s: %s' % (name, value) for name, value in items)
             return '<small><tt>' + text + '</tt></small>'
+
+        def _displayable_items(items):
+            for name, value in items:
+                value = GLib.markup_escape_text(str(value).replace('\x00', '')).strip()
+                if value:
+                    yield name, value
 
         def _read_slow(device):
             items = _details_items(selected_device, True)
+            items = _displayable_items(items)
             text = _make_text(items)
             if device == _details._current_device:
                 GLib.idle_add(_set_details, text)


### PR DESCRIPTION
when running solaar with verbose logging I found the message was being emitted:
```
(solaar:64699): Gtk-WARNING **: 17:18:05.225: Failed to set text '<small><tt>Path         : /dev/hidraw5
Index        : 255
Product ID   : 046d:C092
Protocol     : HID++ 4.2
Polling rate : 1 ms (1000Hz)
Serial       : 
Unit ID      : 1D002800
  Bootloader : BL1 17.00.B0005
  Firmware   : U1  52.00.B0010
  Firmware   : ' from markup due to error parsing markup: Error on line 10 char 25: Element “markup” was closed, but the currently open element is “tt”
```

After investigation, I found this was because my G203 mouse was returning the following firmware values:
```
>>> device.firmware
(FirmwareInfo(kind=NamedInt(1, 'Bootloader'), name='BL1', version='17.00.B0005', extras=b'\xaa\xfd'),
 FirmwareInfo(kind=NamedInt(0, 'Firmware'), name='U1 ', version='52.00.B0010', extras=b'\xc0\x92'),
 FirmwareInfo(kind=NamedInt(0, 'Firmware'), name='\x00\x00\x00', version='00.00', extras=None),
 FirmwareInfo(kind=NamedInt(3, 'Other'), name='', version='', extras=None),
 FirmwareInfo(kind=NamedInt(3, 'Other'), name='', version='', extras=None))
```
Specifically the null characters in one of the firmware name fields was 'ending' the string early. Because of this the technical details are not fully filled out. After this fix the details were displayed. I also think that it makes sense to not display empty fields so I filtered those out to get the following:

(left to right: before, with null fix, with null fix + filtering)
![ui](https://user-images.githubusercontent.com/4923501/210273024-09141041-dd14-4fe6-987a-85ded0abea38.png)
