### PR TITLE
add MX Vertical mouse to the list of devices

### DIFF
--- a/docs/devices.md
+++ b/docs/devices.md
@@ -202,6 +202,7 @@ and are not being updated for new devices that are supported by Solaar.
 | MX Master        | 4041 | 2.0   |
 | MX Master 2S     | 4069 | 2.0   |
 | Cube             |      | 2.0   |
+| MX Vertical      | 407B | 2.0   |
 
 ### Mice (Nano)
 


### PR DESCRIPTION
When I read https://pwr-solaar.github.io/Solaar/devices to see whether MX Vertical is supported before I buy it, it confused me for a bit, until I find it being supported in the forums. This change adds the mouse to the list (verified it actually works by running `solaar show` in version 1.1.1).