### PR TITLE
Add support for process condition under wayland using solaar-gnome-extension

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,7 +33,7 @@ The `udev` package must be installed and its daemon running.
 
 Solaar requires Python 3.7+ and requires several packages to be installed.
 If you are running the system version of Python you should have the
-`python3-pyudev`, `python3-psutil`, `python3-xlib`, `python3-evdev`, `python3-typing-extensions`,
+`python3-pyudev`, `python3-psutil`, `python3-xlib`, `python3-evdev`, `python3-typing-extensions`, `dbus-python`,
 and `python3-yaml` or `python3-pyyaml` packages installed.
 
 To run the GUI Solaar also requires Gtk3 and its GObject introspection bindings.

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -28,10 +28,10 @@ from logging import getLogger
 from math import sqrt as _sqrt
 from struct import unpack as _unpack
 
+import dbus
 import evdev
 import keysyms.keysymdef as _keysymdef
 import psutil
-import dbus
 
 from yaml import add_representer as _yaml_add_representer
 from yaml import dump_all as _yaml_dump_all
@@ -95,7 +95,9 @@ if _log.isEnabledFor(_INFO):
 
 wayland = _os.getenv('WAYLAND_DISPLAY')  # is this Wayland?
 if wayland:
-    _log.warn('rules cannot access modifier keys in Wayland, accessing process only works on GNOME with Solaar Gnome extension installed')
+    _log.warn(
+        'rules cannot access modifier keys in Wayland, accessing process only works on GNOME with Solaar Gnome extension installed'
+    )
 
 try:
     import Xlib
@@ -151,8 +153,8 @@ def gnome_dbus_interface_setup():
         return _dbus_interface
     try:
         bus = dbus.SessionBus()
-        remote_object = bus.get_object("org.gnome.Shell", "/io/github/pwr_solaar/solaar")
-        _dbus_interface = dbus.Interface(remote_object, "io.github.pwr_solaar.solaar")
+        remote_object = bus.get_object('org.gnome.Shell', '/io/github/pwr_solaar/solaar')
+        _dbus_interface = dbus.Interface(remote_object, 'io.github.pwr_solaar.solaar')
     except dbus.exceptions.DBusException:
         _log.warn('Solaar Gnome extension not installed - some rule capabilities inoperable', exc_info=_sys.exc_info())
         _dbus_interface = False
@@ -597,7 +599,10 @@ class Process(Condition):
         self.process = process
         if (not wayland and not x11_setup()) or (wayland and not gnome_dbus_interface_setup()):
             if warn:
-                _log.warn('rules can only access active process in X11 or in wayland under GNOME with Solaar Gnome extension - %s', self)
+                _log.warn(
+                    'rules can only access active process in X11 or in wayland under GNOME with Solaar Gnome extension - %s',
+                    self
+                )
         if not isinstance(process, str):
             if warn:
                 _log.warn('rule Process argument not a string: %s', process)
@@ -625,7 +630,10 @@ class MouseProcess(Condition):
         self.process = process
         if (not wayland and not x11_setup()) or (wayland and not gnome_dbus_interface_setup()):
             if warn:
-                _log.warn('rules cannot access active mouse process in X11 or in wayland under GNOME with Solaar Gnome extension - %s', self)
+                _log.warn(
+                    'rules cannot access active mouse process in X11 or in wayland under GNOME with Solaar Gnome extension - %s',
+                    self
+                )
         if not isinstance(process, str):
             if warn:
                 _log.warn('rule MouseProcess argument not a string: %s', process)

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -635,8 +635,7 @@ class MouseProcess(Condition):
             if warn:
                 _log.warn(
                     'rules cannot access active mouse process '
-                    'in X11 or in wayland under GNOME with Solaar Gnome extension - %s',
-                    self
+                    'in X11 or in wayland under GNOME with Solaar Gnome extension - %s', self
                 )
         if not isinstance(process, str):
             if warn:

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -109,6 +109,7 @@ Xkbdisplay = None  # xkb might be available
 modifier_keycodes = []
 XkbUseCoreKbd = 0x100
 
+_dbus_interface = None
 
 class XkbDisplay(_ctypes.Structure):
     """ opaque struct """
@@ -150,7 +151,7 @@ def gnome_dbus_interface_setup():
         return _dbus_interface
     try:
         bus = dbus.SessionBus()
-        remote_object = bus.get_object("io.github.pwr_solaar.solaar", "/io/github/pwr_solaar/solaar")
+        remote_object = bus.get_object("org.gnome.Shell", "/io/github/pwr_solaar/solaar")
         _dbus_interface = dbus.Interface(remote_object, "io.github.pwr_solaar.solaar")
     except dbus.exceptions.DBusException:
         _log.warn('Solaar Gnome extension not installed - some rule capabilities inoperable', exc_info=_sys.exc_info())

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -31,6 +31,7 @@ from struct import unpack as _unpack
 import evdev
 import keysyms.keysymdef as _keysymdef
 import psutil
+import dbus
 
 from yaml import add_representer as _yaml_add_representer
 from yaml import dump_all as _yaml_dump_all
@@ -94,7 +95,7 @@ if _log.isEnabledFor(_INFO):
 
 wayland = _os.getenv('WAYLAND_DISPLAY')  # is this Wayland?
 if wayland:
-    _log.warn('rules cannot access active process or modifier keys in Wayland')
+    _log.warn('rules cannot access modifier keys in Wayland')
 
 try:
     import Xlib
@@ -141,6 +142,27 @@ def x11_setup():
         _x11 = False
         xtest_available = False
     return _x11
+
+
+def gnome_dbus_setup():
+    global _dbus_available
+    if _dbus_available is not None:
+        return _dbus_available
+
+    try:
+        bus = dbus.SessionBus()
+        remote_object = bus.get_object("io.github.pwr_solaar.solaar.gnome", "/io/github/pwr_solaar/solaar/gnome")
+        interface = dbus.Interface(remote_object, "io.github.pwr_solaar.solaar.gnome")
+
+        # Check if the interface is available by calling a method (e.g., ActiveWindow).
+        # You can use any method that you expect to exist in the D-Bus interface.
+        interface.ActiveWindow()
+
+        _dbus_available = True
+    except dbus.exceptions.DBusException:
+        _dbus_available = False
+
+    return _dbus_available
 
 
 def xkb_setup():
@@ -562,13 +584,34 @@ def x11_pointer_prog():
     return (wm_class[0], wm_class[1], name) if wm_class else (name, )
 
 
+def gnome_dbus_focus_prog():
+    if not gnome_dbus_setup():
+        return None
+    bus = dbus.SessionBus()
+    remote_object = bus.get_object("io.github.pwr_solaar.solaar.gnome", "/io/github/pwr_solaar/solaar/gnome")
+    interface = dbus.Interface(remote_object, "io.github.pwr_solaar.solaar.gnome")
+
+    wm_class = interface.ActiveWindow()
+    return (wm_class, ) if wm_class else None
+
+def gnome_dbus_pointer_prog():
+    if not gnome_dbus_setup():
+        return None
+    bus = dbus.SessionBus()
+    remote_object = bus.get_object("io.github.pwr_solaar.solaar.gnome", "/io/github/pwr_solaar/solaar/gnome")
+    interface = dbus.Interface(remote_object, "io.github.pwr_solaar.solaar.gnome")
+
+    wm_class = interface.PointerOverWindow()
+    return (wm_class, ) if wm_class else None
+
+
 class Process(Condition):
 
     def __init__(self, process, warn=True):
         self.process = process
-        if wayland or not x11_setup():
+        if (not wayland and not x11_setup()) or (wayland and not gnome_dbus_setup()):
             if warn:
-                _log.warn('rules can only access active process in X11 - %s', self)
+                _log.warn('rules can only access active process in X11 or in wayland under gnome with solaar-gnome-extension - %s', self)
         if not isinstance(process, str):
             if warn:
                 _log.warn('rule Process argument not a string: %s', process)
@@ -582,7 +625,7 @@ class Process(Condition):
             _log.debug('evaluate condition: %s', self)
         if not isinstance(self.process, str):
             return False
-        focus = x11_focus_prog()
+        focus = x11_focus_prog() if not wayland else gnome_db11_focus_prog()
         result = any(bool(s and s.startswith(self.process)) for s in focus) if focus else None
         return result
 
@@ -594,9 +637,9 @@ class MouseProcess(Condition):
 
     def __init__(self, process, warn=True):
         self.process = process
-        if wayland or not x11_setup():
+        if (not wayland and not x11_setup()) or (wayland and not gnome_dbus_setup()):
             if warn:
-                _log.warn('rules cannot access active mouse process in X11 - %s', self)
+                _log.warn('rules cannot access active mouse process in X11 or in wayland under gnome with solaar-gnome-extension - %s', self)
         if not isinstance(process, str):
             if warn:
                 _log.warn('rule MouseProcess argument not a string: %s', process)
@@ -610,7 +653,7 @@ class MouseProcess(Condition):
             _log.debug('evaluate condition: %s', self)
         if not isinstance(self.process, str):
             return False
-        pointer_focus = x11_pointer_prog()
+        pointer_focus = x11_pointer_prog() if not wayland else gnome_dbus_pointer_prog()
         result = any(bool(s and s.startswith(self.process)) for s in pointer_focus) if pointer_focus else None
         return result
 

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -150,8 +150,8 @@ def gnome_dbus_interface_setup():
         return _dbus_interface
     try:
         bus = dbus.SessionBus()
-        remote_object = bus.get_object("io.github.pwr_solaar.solaar.gnome", "/io/github/pwr_solaar/solaar/gnome")
-        _dbus_interface = dbus.Interface(remote_object, "io.github.pwr_solaar.solaar.gnome")
+        remote_object = bus.get_object("io.github.pwr_solaar.solaar", "/io/github/pwr_solaar/solaar")
+        _dbus_interface = dbus.Interface(remote_object, "io.github.pwr_solaar.solaar")
     except dbus.exceptions.DBusException:
         _log.warn('Solaar Gnome extension not installed - some rule capabilities inoperable', exc_info=_sys.exc_info())
         _dbus_interface = False

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -625,7 +625,7 @@ class Process(Condition):
             _log.debug('evaluate condition: %s', self)
         if not isinstance(self.process, str):
             return False
-        focus = x11_focus_prog() if not wayland else gnome_db11_focus_prog()
+        focus = x11_focus_prog() if not wayland else gnome_dbus_focus_prog()
         result = any(bool(s and s.startswith(self.process)) for s in focus) if focus else None
         return result
 

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -113,6 +113,7 @@ XkbUseCoreKbd = 0x100
 
 _dbus_interface = None
 
+
 class XkbDisplay(_ctypes.Structure):
     """ opaque struct """
 
@@ -585,6 +586,7 @@ def gnome_dbus_focus_prog():
         return None
     wm_class = _dbus_interface.ActiveWindow()
     return (wm_class, ) if wm_class else None
+
 
 def gnome_dbus_pointer_prog():
     if not gnome_dbus_interface_setup():

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -96,7 +96,8 @@ if _log.isEnabledFor(_INFO):
 wayland = _os.getenv('WAYLAND_DISPLAY')  # is this Wayland?
 if wayland:
     _log.warn(
-        'rules cannot access modifier keys in Wayland, accessing process only works on GNOME with Solaar Gnome extension installed'
+        'rules cannot access modifier keys in Wayland, '
+        'accessing process only works on GNOME with Solaar Gnome extension installed'
     )
 
 try:
@@ -633,7 +634,8 @@ class MouseProcess(Condition):
         if (not wayland and not x11_setup()) or (wayland and not gnome_dbus_interface_setup()):
             if warn:
                 _log.warn(
-                    'rules cannot access active mouse process in X11 or in wayland under GNOME with Solaar Gnome extension - %s',
+                    'rules cannot access active mouse process '
+                    'in X11 or in wayland under GNOME with Solaar Gnome extension - %s',
                     self
                 )
         if not isinstance(process, str):

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ For instructions on installing Solaar see https://pwr-solaar.github.io/Solaar/in
         'PyYAML (>= 3.12)',
         'python-xlib (>= 0.27)',
         'psutil (>= 5.4.3)',
+        'dbus-python (>=1.3.2)',
     ],
     extras_require={
         'report-descriptor': ['hid-parser'],


### PR DESCRIPTION
This utilises https://github.com/sidevesh/solaar-gnome-extension gnome extension to get wm_class of focus and pointer focus window under wayland in gnome-shell.
Also, let me know if @pfps you would want to include the source of the gnome extension in this repo or org.
Closes #1747