### PR TITLE
Remove udev-acl tag from udev rules

### DIFF
--- a/rules.d-uinput/42-logitech-unify-permissions.rules
+++ b/rules.d-uinput/42-logitech-unify-permissions.rules
@@ -23,8 +23,7 @@ LABEL="solaar_apply"
 
 # Allow any seated user to access the receiver.
 # uaccess: modern ACL-enabled udev
-# udev-acl: for Ubuntu 12.10 and older
-TAG+="uaccess", TAG+="udev-acl"
+TAG+="uaccess"
 
 # Grant members of the "plugdev" group access to receiver (useful for SSH users)
 #MODE="0660", GROUP="plugdev"

--- a/rules.d/42-logitech-unify-permissions.rules
+++ b/rules.d/42-logitech-unify-permissions.rules
@@ -22,8 +22,7 @@ LABEL="solaar_apply"
 
 # Allow any seated user to access the receiver.
 # uaccess: modern ACL-enabled udev
-# udev-acl: for Ubuntu 12.10 and older
-TAG+="uaccess", TAG+="udev-acl"
+TAG+="uaccess"
 
 # Grant members of the "plugdev" group access to receiver (useful for SSH users)
 #MODE="0660", GROUP="plugdev"


### PR DESCRIPTION
This was only needed for Ubuntu releases that are all now EOL.