### PR TITLE
Update Arch repository name and link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -105,7 +105,7 @@ If a recent version of Solaar is not
 available from the standard repositories for your distribution you can try
 one of these packages.
 
-- Arch solaar package in the [community repository][arch]
+- Arch solaar package in the [extra repository][arch]
 - Ubuntu/Kubuntu stable packages: use the [Solaar stable ppa][ppa2], courtesy of [gogo][ppa4]
 - Ubuntu/Kubuntu git build packages: use the [Solaar git ppa][ppa1], courtesy of [gogo][ppa4]
 
@@ -122,7 +122,7 @@ Solaar uses a standard system tray implementation; solaar-gnome3 is no longer re
 [ppa2]: https://launchpad.net/~solaar-unifying/+archive/ubuntu/stable
 [ppa1]: https://launchpad.net/~solaar-unifying/+archive/ubuntu/ppa
 [ppa]: http://launchpad.net/~daniel.pavel/+archive/solaar
-[arch]: https://www.archlinux.org/packages/community/any/solaar/
+[arch]: https://www.archlinux.org/packages/extra/any/solaar/
 [gentoo]: https://packages.gentoo.org/packages/app-misc/solaar
 [mageia]: http://mageia.madb.org/package/show/release/cauldron/application/0/name/solaar
 [universe repository]: http://packages.ubuntu.com/search?keywords=solaar&searchon=names&suite=all&section=all


### PR DESCRIPTION
[`community` was merged into `extra`](https://archlinux.org/news/git-migration-announcement/).