### PR TITLE
NamedInt: return False on comparison with None

### DIFF
--- a/lib/logitech_receiver/common.py
+++ b/lib/logitech_receiver/common.py
@@ -44,6 +44,8 @@ class NamedInt(int):
         return int2bytes(self, count)
 
     def __eq__(self, other):
+        if other is None:
+            return False
         if isinstance(other, NamedInt):
             return int(self) == int(other) and self.name == other.name
         if isinstance(other, int):


### PR DESCRIPTION
The equality test of `NamedInt` returns None when it is compared to a None, it should return False instead. This is problematic because the equality test of `Device` (`lib/logitech_receiver/device.py`) depends on it.

```python
def __eq__(self, other):
    return other is not None and self._kind == other._kind and self.wpid == other.wpid
```
So that if one of the devices' `_kind` is None, this equality test would return None.

And that, in turn, makes the Device condition (`lib/logitech_receiver/diversion.py`) return None, which stops the processing of the remaining rules.

That means, if a connected device has a `_kind` of None and it sends a HID++ notification, then a failure of a Device condition in an earlier rule would prevent later rules from being processed.

This commit fixes that.