### PR TITLE
dist: install .rules to correct place by default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def _data_files():
         yield _dirname(mo), [mo]
 
     yield 'share/applications', ['share/applications/solaar.desktop']
-    yield 'share/solaar/udev-rules.d', ['rules.d/42-logitech-unify-permissions.rules']
+    yield 'lib/udev/rules.d', ['rules.d/42-logitech-unify-permissions.rules']
     yield 'share/metainfo', ['share/solaar/io.github.pwr_solaar.solaar.metainfo.xml']
 
     del _dirname


### PR DESCRIPTION
these only have meaning when they end up in a directory scanned by udev, so $prefix/lib/udev/rules.d will be correct when installed to /usr. this changes it from /usr/share/solaar/udev-rules.d which is ignored. it does not affect installing as a user (e.g. pip install --user)  

closes #2142