### PR TITLE
ui: do not override theme path when setting up AppIndicator

### DIFF
--- a/lib/solaar/ui/tray.py
+++ b/lib/solaar/ui/tray.py
@@ -177,10 +177,9 @@ try:
 
     def _create(menu):
         _icons._init_icon_paths()
-        theme_paths = Gtk.IconTheme.get_default().get_search_path()
 
-        ind = AppIndicator3.Indicator.new_with_path(
-            'indicator-solaar', _icon_file(_icons.TRAY_INIT), AppIndicator3.IndicatorCategory.HARDWARE, theme_paths[0]
+        ind = AppIndicator3.Indicator.new(
+            'indicator-solaar', _icon_file(_icons.TRAY_INIT), AppIndicator3.IndicatorCategory.HARDWARE
         )
         ind.set_title(NAME)
         ind.set_status(AppIndicator3.IndicatorStatus.ACTIVE)


### PR DESCRIPTION
Using /usr/share/solaar/icons as theme path will break the lookup of the icons within the AppIndicator based tray, resulting in:
```
Okt 10 14:54:08 pluto ubuntu-appindicators@ubuntu.com[2156]: indicator-solaar, Impossible to lookup icon for 'battery-good' in /usr/share/solaar/icons
```
Fix that by using the default theme path.

Fixes: #2156