### PR TITLE
device: add K845 keyboard

### DIFF
--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -209,6 +209,7 @@ _D('G213 Prodigy Gaming Keyboard', codename='G213', usbid=0xc336, interface=1)
 _D('G512 RGB Mechanical Gaming Keyboard', codename='G512', usbid=0xc33c, interface=1)
 _D('G815 Mechanical Keyboard', codename='G815', usbid=0xc33f, interface=1)
 _D('diNovo Edge Keyboard', codename='diNovo', protocol=1.0, wpid='C714', settings=[_ST.RegisterFnSwap])
+_D('K845 Mechanical Keyboard', codename='K845', usbid=0xc341, interface=3)
 
 # Mice
 


### PR DESCRIPTION
Fixes #2196 

Test:
"solaar show" no longer breaks.