### PR TITLE
Fix changelog parsing in release.sh after conversion to markdown

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -119,8 +119,8 @@ echo 'Creating tag...'
     echo
     found=no
     while read -r line; do
-        if [[ "$line" == *: ]]; then
-            [ "$line" == "$version:" ] && found=yes || found=no
+        if [[ "$line" == "# "* ]]; then
+            [ "$line" == "# $version" ] && found=yes || found=no
         fi
         [ "$found" == 'yes' ] && [ "${line:0:1}" == '*' ] && echo "$line"
     done < ChangeLog.md


### PR DESCRIPTION
Fix changelog parsing in release.sh after conversion to markdown d57af51.
It used to be `Version :` but then it was changed to `# Version`, thus parsing was broken.

So now it actually uses info from `ChangeLog.md`, compare
https://github.com/antonsoroko/Solaar/releases/tag/1.1.10
with
https://github.com/antonsoroko/Solaar/releases/tag/1.1.11