### PR TITLE
Add stable branch to release.sh

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -137,7 +137,7 @@ echo 'Pushing tag...'
 
 # Point stable branch to latest version tag
 echo 'Updating stable branch...'
-if [ -z "$DRY_RUN" ]
+if [[ -z "$DRY_RUN" && $prerelease == "false" ]]
 then
     # Check if stable branch does not exist
     git rev-list --max-count=1 $stable_branch >/dev/null 2>/dev/null


### PR DESCRIPTION
To be used in PPA builds.

for https://github.com/pwr-Solaar/Solaar/issues/2186#issuecomment-1917541259

this will allow to make PPA build without manual changing of tag name in PPA recipe every time there is a release, instead we will use "stable" branch as branch name.

Tested by creating new releases:
from https://github.com/antonsoroko/Solaar/tree/version_1.1.11 i created
https://github.com/antonsoroko/Solaar/tree/1.1.11
and https://github.com/antonsoroko/Solaar/tree/stable used to point to that `1.1.11` tag.

then from https://github.com/antonsoroko/Solaar/tree/version_1.1.12 i created
https://github.com/antonsoroko/Solaar/tree/1.1.12
and https://github.com/antonsoroko/Solaar/tree/stable points to that new `1.1.12` tag.

see https://github.com/antonsoroko/Solaar/commits/stable/