### PR TITLE
Mention language pack for Gnome in i18n.md

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -5,7 +5,7 @@ layout: page
 
 # Translating Solaar
 
-First, make sure you have installed the `gettext` package.
+First, make sure you have installed the `gettext` package. Also, you would need to install language pack for Gnome for your language, e.g. `language-pack-gnome-XX-base` for Debian/Ubuntu.
 
 Here are the steps to add/update a translation (you should run all scripts from
 the source root):

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -22,7 +22,7 @@ the source root):
    the translation (msgstr); if you leave msgstr empty, the string will remain
    untranslated.
 
-   Alternatively, you can use the excellent `poedit`.
+   Alternatively, you can use the excellent [Poedit](https://poedit.net/) or [Lokalize](https://apps.kde.org/lokalize/).
 
 4. Run `./tools/po-compile.sh`. It will bring up-to-date all the compiled
    language files, necessary at runtime.


### PR DESCRIPTION
```
$ ./tools/po-update.sh ru
/usr/bin/msgunfmt: error while opening "/usr/share/locale-langpack/ru/LC_MESSAGES/gtk30.mo" for reading: No such file or directory
/usr/bin/msgunfmt: error while opening "/usr/share/locale-langpack/ru/LC_MESSAGES/gtk30-properties.mo" for reading: No such file ordirectory
/usr/bin/msgmerge: error while opening "" for reading: No such file or directory
```

```
$ ./tools/po-update.sh en
Created /home/antix/work/Solaar/po/en.po.
/usr/bin/msgunfmt: error while opening "/usr/share/locale-langpack/en/LC_MESSAGES/gtk30.mo" for reading: No such file or directory
/usr/bin/msgunfmt: error while opening "/usr/share/locale-langpack/en/LC_MESSAGES/gtk30-properties.mo" for reading: No such file ordirectory
/usr/bin/msgmerge: error while opening "" for reading: No such file or directory
```

```
$ apt-file search /usr/share/locale-langpack/ru/LC_MESSAGES/gtk30.mo
language-pack-gnome-ru-base: /usr/share/locale-langpack/ru/LC_MESSAGES/gtk30.mo

$ apt-file search /usr/share/locale-langpack/en/LC_MESSAGES/gtk30.mo
language-pack-gnome-en-base: /usr/share/locale-langpack/en/LC_MESSAGES/gtk30.mo
```

thus documentation must be updated.