### PR TITLE
support color feature for many devices

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -180,6 +180,8 @@ Some mice store one or more profiles, which control aspects of the behavior of t
 
 Profiles can control the rate at which the mouse reports movement, the resolution of the the movement reports, what the mouse buttons do, and its LED effects.  Solaar can dump the entire set of profiles into a YAML file can load an entire set of profiles from a file.  Users can edit the file to effect changes to the profiles.  Solaar has a setting that switches between profiles or disables all profiles.  When switching between profiles or using a button to change resolution Solaar keeps track of the changes in the settings for these features.
 
+When profiles are active changes cannot be made to the Report Rate setting.   Changes can be made to the Sensitivity setting and to LED settings.  To keep the profile values make these setting ignored.
+
 A profile file has some bookkeeping information, including profile version and the name of the device, and a sequence of profiles.
 
 Each profile has the following fields:

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -1172,8 +1172,8 @@ LEDParamSize = {
     LEDParam.form: 1
 }
 LEDEffects = {
-    0x0: [_NamedInt(0x0, _('Disable')), {}],
-    0x1: [_NamedInt(0x1, _('Fixed')), {
+    0x0: [_NamedInt(0x0, _('Disabled')), {}],
+    0x1: [_NamedInt(0x1, _('Static')), {
         LEDParam.color: 0,
         LEDParam.ramp: 3
     }],

--- a/lib/logitech_receiver/settings.py
+++ b/lib/logitech_receiver/settings.py
@@ -1229,8 +1229,7 @@ class HeteroValidator(Validator):
             return reply_value
 
     def prepare_write(self, new_value, current_value=None):
-        new_value.options = self.options
-        to_write = new_value.to_bytes()
+        to_write = new_value.to_bytes(options=self.options)
         return to_write
 
     def acceptable(self, args, current):  # should this actually do some checking?

--- a/lib/logitech_receiver/settings.py
+++ b/lib/logitech_receiver/settings.py
@@ -286,7 +286,7 @@ class Setting:
             reply = self._rw.read(self._device)
             if reply:
                 self._value = self._validator.validate_read(reply)
-            if self._device.persister and self.name not in self._device.persister:
+            if self._value is not None and self._device.persister and self.name not in self._device.persister:
                 # Don't update the persister if it already has a value,
                 # otherwise the first read might overwrite the value we wanted.
                 self._device.persister[self.name] = self._value if self.persist else None
@@ -1216,15 +1216,17 @@ class HeteroValidator(Validator):
     def build(cls, setting_class, device, **kwargs):
         return cls(**kwargs)
 
-    def __init__(self, data_class=None, options=None):
+    def __init__(self, data_class=None, options=None, readable=True):
         assert data_class is not None and options is not None
         self.data_class = data_class
         self.options = options
+        self.readable = readable
         self.needs_current_value = False
 
     def validate_read(self, reply_bytes):
-        reply_value = self.data_class.from_bytes(reply_bytes, options=self.options)
-        return reply_value
+        if self.readable:
+            reply_value = self.data_class.from_bytes(reply_bytes, options=self.options)
+            return reply_value
 
     def prepare_write(self, new_value, current_value=None):
         new_value.options = self.options

--- a/lib/logitech_receiver/settings.py
+++ b/lib/logitech_receiver/settings.py
@@ -1231,14 +1231,8 @@ class HeteroValidator(Validator):
         to_write = new_value.to_bytes()
         return to_write
 
-    def acceptable(self, args, current):  # FIXME
-        if len(args) != 2:
-            return None
-        item = self.items[args[0]] if args[0] in self.items else None
-        if item.kind == KIND.range:
-            return None if args[1] < item.min_value or args[1] > item.max_value else args
-        elif item.kind == KIND.choice:
-            return args if args[1] in item.choices else None
+    def acceptable(self, args, current):  # should this actually do some checking?
+        return True
 
 
 class PackedRangeValidator(Validator):

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1442,7 +1442,6 @@ _LEDP = _hidpp20.LEDParam
 
 
 # an LED Zone has an index, a set of possible LED effects, and an LED effect setting
-# reading the current setting for a zone returns zeros on some devices
 class LEDZoneSetting(_Setting):
     name = 'led_zone_'
     label = _('LED Zone Effects')
@@ -1458,12 +1457,12 @@ class LEDZoneSetting(_Setting):
 
     @classmethod
     def build(cls, device):
-        infos = _hidpp20.LEDEffectsInfo(device)
+        infos = device.led_effects
         settings = []
         for zone in infos.zones:
-            prefix = zone.index.to_bytes(1)
+            prefix = _int2bytes(zone.index, 1)
             rw = _FeatureRW(_F.COLOR_LED_EFFECTS, read_fnid=0xE0, write_fnid=0x30, prefix=prefix)
-            validator = _HeteroV(data_class=_hidpp20.LEDEffectIndexed, options=zone.effects, readable=infos.readable)
+            validator = _HeteroV(data_class=_hidpp20.LEDEffectSetting, options=zone.effects, readable=infos.readable)
             setting = cls(device, rw, validator)
             setting.name = cls.name + str(int(zone.location))
             setting.label = _('LEDs') + ' ' + str(_hidpp20.LEDZoneLocations[zone.location])

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1450,7 +1450,7 @@ class LEDZoneSetting(_Setting):
     feature = _F.COLOR_LED_EFFECTS
     color_field = {'name': _LEDP.color, 'kind': _KIND.choice, 'label': None, 'choices': colors}
     speed_field = {'name': _LEDP.speed, 'kind': _KIND.range, 'label': _('Speed'), 'min': 0, 'max': 255}
-    period_field = {'name': _LEDP.period, 'kind': _KIND.range, 'label': _('Period'), 'min': 0, 'max': 5000}
+    period_field = {'name': _LEDP.period, 'kind': _KIND.range, 'label': _('Period'), 'min': 100, 'max': 5000}
     intensity_field = {'name': _LEDP.intensity, 'kind': _KIND.range, 'label': _('Intensity'), 'min': 0, 'max': 100}
     ramp_field = {'name': _LEDP.ramp, 'kind': _KIND.choice, 'label': _('Ramp'), 'choices': _hidpp20.LEDRampChoices}
     #    form_field = { 'name': _LEDP.form, 'kind': _KIND.choice, 'label': _('Form'), 'choices': _hidpp20.LEDFormChoices }
@@ -1458,12 +1458,12 @@ class LEDZoneSetting(_Setting):
 
     @classmethod
     def build(cls, device):
-        zone_infos = _hidpp20.LEDEffectsInfo(device).zones
+        infos = _hidpp20.LEDEffectsInfo(device)
         settings = []
-        for zone in zone_infos:
+        for zone in infos.zones:
             prefix = zone.index.to_bytes(1)
             rw = _FeatureRW(_F.COLOR_LED_EFFECTS, read_fnid=0xE0, write_fnid=0x30, prefix=prefix)
-            validator = _HeteroV(data_class=_hidpp20.LEDEffectIndexed, options=zone.effects)
+            validator = _HeteroV(data_class=_hidpp20.LEDEffectIndexed, options=zone.effects, readable=infos.readable)
             setting = cls(device, rw, validator)
             setting.name = cls.name + str(int(zone.location))
             setting.label = _('LEDs') + ' ' + str(_hidpp20.LEDZoneLocations[zone.location])

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1418,6 +1418,17 @@ class ADCPower(_Setting):
     validator_options = {'byte_count': 1}
 
 
+class LEDControl(_Setting):
+    name = 'led_control'
+    label = _('LED Control')
+    description = _('Switch control of LEDs between device and Solaar')
+    feature = _F.COLOR_LED_EFFECTS
+    rw_options = {'read_fnid': 0x70, 'write_fnid': 0x80}
+    choices_universe = _NamedInts(Device=0, Solaar=1)
+    validator_class = _ChoicesV
+    validator_options = {'choices': choices_universe}
+
+
 SETTINGS = [
     RegisterHandDetection,  # simple
     RegisterSmoothScroll,  # simple
@@ -1447,6 +1458,7 @@ SETTINGS = [
     Backlight2DurationHandsIn,
     Backlight2DurationPowered,
     Backlight3,
+    LEDControl,
     FnSwap,  # simple
     NewFnSwap,  # simple
     K375sFnSwap,  # working

--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -24,7 +24,7 @@ from logging import getLogger
 from threading import Timer as _Timer
 
 from gi.repository import Gdk, GLib, Gtk
-from logitech_receiver.hidpp20 import LEDEffectIndexed as _LEDEffectIndexed
+from logitech_receiver.hidpp20 import LEDEffectSetting as _LEDEffectSetting
 from logitech_receiver.settings import KIND as _SETTING_KIND
 from logitech_receiver.settings import SENSITIVITY_IGNORE as _SENSITIVITY_IGNORE
 from solaar.i18n import _, ngettext
@@ -574,7 +574,7 @@ class HeteroKeyControl(Gtk.HBox, Control):
         result = {}
         for k, (_lblbox, box) in self._items.items():
             result[str(k)] = box.get_value()
-        result = _LEDEffectIndexed(**result)
+        result = _LEDEffectSetting(**result)
         return result
 
     def set_value(self, value):

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ For instructions on installing Solaar see https://pwr-solaar.github.io/Solaar/in
     python_requires='>=3.7',
     install_requires=[
         'evdev (>= 1.1.2) ; platform_system=="Linux"',
+        'webcolors',
         'pyudev (>= 0.13)',
         'PyYAML (>= 3.12)',
         'python-xlib (>= 0.27)',


### PR DESCRIPTION
This PR adds settings for feature x8070 COLOR LED EFFECTS.   

To set a color effect, edit `~/.config/solaar/config.yaml`, after first running this version of Solaar to have the possible color zones determined.  There will a line in the file with key `led_zone_n` for each color zone.  Unfortunately some mice do not report the current effect for the zones so the value is likely to be simple.  The information on effects is stored in a slightly different way than for profiles on devices - Solaar uses LEDEffectSetting in profiles and LEDEffectIndexed in config.yaml.