### PR TITLE
Add the <developer/> tag in the metainfo

### DIFF
--- a/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
+++ b/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
@@ -6,7 +6,7 @@
   <name>Solaar</name>
   <summary>Linux manager for Logitech keyboards, mice, and trackpads</summary>
   <developer id="pwr-solaar.github.io">
-    <name>Daniel Pavel</name>
+    <name>Peter F. Patel-Schneider</name>
   </developer>
   <url type="homepage">https://github.com/pwr-Solaar/Solaar</url>
   <content_rating type="oars-1.0" />

--- a/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
+++ b/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
@@ -6,7 +6,7 @@
   <name>Solaar</name>
   <summary>Linux manager for Logitech keyboards, mice, and trackpads</summary>
   <developer id="pwr-solaar.github.io">
-    <name>Peter F. Patel-Schneider</name>
+    <name>pwr-Solaar</name>
   </developer>
   <url type="homepage">https://github.com/pwr-Solaar/Solaar</url>
   <content_rating type="oars-1.0" />

--- a/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
+++ b/share/solaar/io.github.pwr_solaar.solaar.metainfo.xml
@@ -5,6 +5,9 @@
 
   <name>Solaar</name>
   <summary>Linux manager for Logitech keyboards, mice, and trackpads</summary>
+  <developer id="pwr-solaar.github.io">
+    <name>Daniel Pavel</name>
+  </developer>
   <url type="homepage">https://github.com/pwr-Solaar/Solaar</url>
   <content_rating type="oars-1.0" />
   <update_contact>pfpschneider_AT_gmail.com</update_contact>


### PR DESCRIPTION
Flathub requires this tag: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name.

The format of this tag is defined in https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer.