### PR TITLE
Publish GitHub pages only on push to master

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - '*doc*'
 
 permissions:
   contents: read


### PR DESCRIPTION
Avoid draft documentation from being published.