### PR TITLE
Refactor: Completely remove UnsortedNamedInts

### DIFF
--- a/lib/logitech_receiver/common.py
+++ b/lib/logitech_receiver/common.py
@@ -533,15 +533,6 @@ def flag_names(enum_class: Iterable, value: int) -> Generator[str]:
         yield f"unknown:{unknown_bits:06X}"
 
 
-class UnsortedNamedInts(NamedInts):
-    def _sort_values(self):
-        pass
-
-    def __or__(self, other):
-        c = UnsortedNamedInts if isinstance(other, UnsortedNamedInts) else NamedInts
-        return c(**self.__dict__, **other.__dict__)
-
-
 def strhex(x):
     assert x is not None
     """Produce a hex-string representation of a sequence of bytes."""

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -257,7 +257,7 @@ class ReprogrammableKeyV4(ReprogrammableKey):
     @property
     def remappable_to(self) -> common.NamedInts:
         self._device.keys._ensure_all_keys_queried()
-        ret = common.UnsortedNamedInts()
+        ret = common.NamedInts()
         if self.group_mask:  # only keys with a non-zero gmask are remappable
             ret[self.default_task] = self.default_task  # it should always be possible to map the key to itself
             for g in self.group_mask:

--- a/lib/logitech_receiver/special_keys.py
+++ b/lib/logitech_receiver/special_keys.py
@@ -24,7 +24,6 @@ from enum import IntEnum
 import yaml
 
 from .common import NamedInts
-from .common import UnsortedNamedInts
 
 _XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser(os.path.join("~", ".config"))
 _keys_file_path = os.path.join(_XDG_CONFIG_HOME, "solaar", "keys.yaml")
@@ -1233,7 +1232,7 @@ HORIZONTAL_SCROLL = NamedInts(
 HORIZONTAL_SCROLL._fallback = lambda x: f"unknown horizontal scroll:{x:04X}"
 
 # Construct universe for Persistent Remappable Keys setting (only for supported values)
-KEYS = UnsortedNamedInts()
+KEYS = NamedInts()
 KEYS_Default = 0x7FFFFFFF  # Special value to reset key to default - has to be different from all others
 KEYS[KEYS_Default] = "Default"  # Value to reset to default
 KEYS[0] = "None"  # Value for no output
@@ -1271,7 +1270,7 @@ for code in HORIZONTAL_SCROLL:
 
 # Construct subsets for known devices
 def persistent_keys(action_ids):
-    keys = UnsortedNamedInts()
+    keys = NamedInts()
     keys[KEYS_Default] = "Default"  # Value to reset to default
     keys[0] = "No Output (only as default)"
     for key in KEYS:
@@ -1283,7 +1282,7 @@ def persistent_keys(action_ids):
 KEYS_KEYS_CONSUMER = persistent_keys([ACTIONID.Key, ACTIONID.Consumer])
 KEYS_KEYS_MOUSE_HSCROLL = persistent_keys([ACTIONID.Key, ACTIONID.Mouse, ACTIONID.Hscroll])
 
-COLORS = UnsortedNamedInts(
+COLORS = NamedInts(
     {
         # from Xorg rgb.txt,v 1.3 2000/08/17
         "red": 0xFF0000,
@@ -1424,7 +1423,7 @@ COLORS = UnsortedNamedInts(
     }
 )
 
-COLORSPLUS = UnsortedNamedInts({"No change": -1})
+COLORSPLUS = NamedInts({"No change": -1})
 for i in COLORS:
     COLORSPLUS[int(i)] = str(i)
 

--- a/lib/solaar/ui/diversion_rules.py
+++ b/lib/solaar/ui/diversion_rules.py
@@ -38,7 +38,6 @@ from gi.repository import Gtk
 from logitech_receiver import diversion as _DIV
 from logitech_receiver.common import NamedInt
 from logitech_receiver.common import NamedInts
-from logitech_receiver.common import UnsortedNamedInts
 from logitech_receiver.settings import KIND as _SKIND
 from logitech_receiver.settings import Setting
 from logitech_receiver.settings_templates import SETTINGS
@@ -1538,7 +1537,7 @@ class _SettingWithValueUI:
         if isinstance(setting, Setting):
             setting = type(setting)
         if isinstance(setting, type) and issubclass(setting, Setting):
-            choices = UnsortedNamedInts()
+            choices = NamedInts()
             universe = getattr(setting, "choices_universe", None)
             if universe:
                 choices |= universe
@@ -1547,7 +1546,7 @@ class _SettingWithValueUI:
                 choices |= NamedInts(**{str(extra): int(extra)})
             return choices, extra
         settings = cls.ALL_SETTINGS.get(setting, [])
-        choices = UnsortedNamedInts()
+        choices = NamedInts()
         extra = None
         for s in settings:
             ch, ext = cls._all_choices(s)
@@ -1567,7 +1566,7 @@ class _SettingWithValueUI:
         val_class = setting.validator_class if setting else None
         kind = val_class.kind if val_class else None
         if kind in cls.MULTIPLE:
-            keys = UnsortedNamedInts()
+            keys = NamedInts()
             for s in settings:
                 universe = getattr(s, "keys_universe" if kind == _SKIND.map_choice else "choices_universe", None)
                 if universe:

--- a/tests/logitech_receiver/test_common.py
+++ b/tests/logitech_receiver/test_common.py
@@ -189,19 +189,6 @@ def test_named_ints_other():
     assert list(union) == [common.NamedInt(0, "empty"), common.NamedInt(5, "critical"), common.NamedInt(50, "good")]
 
 
-def test_unsorted_named_ints():
-    named_ints = common.UnsortedNamedInts(critical=5, empty=0)
-    named_ints_2 = common.UnsortedNamedInts(good=50)
-
-    union = named_ints.__or__(named_ints_2)
-    unionr = named_ints_2.__or__(named_ints)
-
-    assert len(union) == 3
-    assert list(union) == [common.NamedInt(5, "critical"), common.NamedInt(0, "empty"), common.NamedInt(50, "good")]
-    assert len(unionr) == 3
-    assert list(unionr) == [common.NamedInt(50, "good"), common.NamedInt(5, "critical"), common.NamedInt(0, "empty")]
-
-
 @pytest.mark.parametrize(
     "bytes_input, expected_output",
     [

--- a/tests/logitech_receiver/test_hidpp20_complex.py
+++ b/tests/logitech_receiver/test_hidpp20_complex.py
@@ -213,7 +213,7 @@ def test_reprogrammable_key_v4_key(device, index, cid, tid, flags, pos, group, g
 @pytest.mark.parametrize(
     "responses, index, mapped_to, remappable_to, mapping_flags",
     [
-        (fake_hidpp.responses_key, 1, "Right Click", common.UnsortedNamedInts(Right_Click=81, Left_Click=80), []),
+        (fake_hidpp.responses_key, 1, "Right Click", common.NamedInts(Right_Click=81, Left_Click=80), []),
         (fake_hidpp.responses_key, 2, "Left Click", None, ["diverted"]),
         (fake_hidpp.responses_key, 3, "Mouse Back Button", None, ["diverted", "persistently diverted"]),
         (fake_hidpp.responses_key, 4, "Mouse Forward Button", None, ["diverted", "raw XY diverted"]),
@@ -421,7 +421,7 @@ device_key = fake_hidpp.Device(
         (special_keys.CONTROL.Virtual_Gesture_Button, 7, common.NamedInt(0x51, "Right Click"), None),
     ],
 )
-def test_KeysArrayV4_key(key, expected_index, expected_mapped_to, expected_remappable_to):
+def test_keys_array_v4_key(key, expected_index, expected_mapped_to, expected_remappable_to):
     device_key._keys = _hidpp20.get_keys(device_key)
     device_key._keys._ensure_all_keys_queried()
 
@@ -432,7 +432,7 @@ def test_KeysArrayV4_key(key, expected_index, expected_mapped_to, expected_remap
     assert index == expected_index
     assert mapped_to == expected_mapped_to
     if expected_remappable_to is not None:
-        assert list(remappable_to) == expected_remappable_to
+        assert list(sorted(remappable_to)) == sorted(expected_remappable_to)
 
 
 @pytest.mark.parametrize(

--- a/tests/logitech_receiver/test_setting_templates.py
+++ b/tests/logitech_receiver/test_setting_templates.py
@@ -530,9 +530,9 @@ key_tests = [
     Setup(
         FeatureTest(settings_templates.ReprogrammableKeys, {0x50: 0x50, 0x51: 0x50, 0xC4: 0xC4}, {0x51: 0x51}, 4, offset=0x05),
         {
-            common.NamedInt(0x50, "Left Button"): common.UnsortedNamedInts(Left_Click=0x50, Right_Click=0x51),
-            common.NamedInt(0x51, "Right Button"): common.UnsortedNamedInts(Right_Click=0x51, Left_Click=0x50),
-            common.NamedInt(0xC4, "Smart Shift"): common.UnsortedNamedInts(Smart_Shift=0xC4, Left_Click=80, Right_Click=81),
+            common.NamedInt(0x50, "Left Button"): common.NamedInts(Left_Click=0x50, Right_Click=0x51),
+            common.NamedInt(0x51, "Right Button"): common.NamedInts(Right_Click=0x51, Left_Click=0x50),
+            common.NamedInt(0xC4, "Smart Shift"): common.NamedInts(Smart_Shift=0xC4, Left_Click=80, Right_Click=81),
         },
         *responses_reprog_controls,
         fake_hidpp.Response("0051000051", 0x0530, "0051000051"),  # right button set write


### PR DESCRIPTION
Simplify the code by removing this unnecessary class. Replace with default NamedInts implementation.

Related #2273