### PR TITLE
fix BoltReceiver, Ex100Receiver __init__

### DIFF
--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -401,8 +401,8 @@ class Receiver:
 class BoltReceiver(Receiver):
     """Bolt receivers use a different pairing prototol and have different pairing registers"""
 
-    def __init__(self, receiver_kind, product_info, handle, path, product_id, setting_callback=None):
-        super().__init__(receiver_kind, product_info, handle, path, product_id, setting_callback)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def initialize(self, product_info: dict):
         serial_reply = self.read_register(Registers.BOLT_UNIQUE_ID)
@@ -466,8 +466,8 @@ class LightSpeedReceiver(Receiver):
 class Ex100Receiver(Receiver):
     """A very old style receiver, somewhat different from newer receivers"""
 
-    def __init__(self, receiver_kind, product_info, handle, path, product_id, setting_callback=None):
-        super().__init__(receiver_kind, product_info, handle, path, product_id, setting_callback)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def initialize(self, product_info: dict):
         self.serial = None


### PR DESCRIPTION
Fixes #2674 

Fix errors like during init:
```
Exception ignored in: <function Receiver.__del__ at 0x7fe4742a37e0>
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/logitech_receiver/receiver.py", line 146, in __del__
    self.close()
  File "/usr/lib/python3.12/site-packages/logitech_receiver/receiver.py", line 138, in close
    handle, self.handle = self.handle, None
                          ^^^^^^^^^^^
AttributeError: 'BoltReceiver' object has no attribute 'handle'
2024-11-06 09:55:24,035,035    ERROR [MainThread] logitech_receiver.receiver: open DeviceInfo(path='/dev/hidraw7', bus_id=3, vendor_id='046D', product_id='C548', interface=2, driver='hid-generic', manufacturer=None, product=None, serial='', release=None, isDevice=None, hidpp_short=True, hidpp_long=True)
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/logitech_receiver/receiver.py", line 536, in create_receiver
    return rclass(
           ^^^^^^^
TypeError: BoltReceiver.__init__() takes from 6 to 7 positional arguments but 8 were given
```