### PR TITLE
settings: add back and forward mouseclick actions

### DIFF
--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -239,6 +239,8 @@ if evdev:
         "scroll_right": (7, evdev.ecodes.ecodes["BTN_7"]),
         "button8": (8, evdev.ecodes.ecodes["BTN_8"]),
         "button9": (9, evdev.ecodes.ecodes["BTN_9"]),
+        "back": (10, evdev.ecodes.ecodes["BTN_SIDE"]),
+        "forward": (11, evdev.ecodes.ecodes["BTN_EXTRA"]),
     }
 
     # uinput capability for keyboard keys, mouse buttons, and scrolling


### PR DESCRIPTION
Add BTN_SIDE and BTN_EXTRA to the mouseclick actions to support back and forward clicks. Not sure if this this applies to all Logitech devices; based it off the inputs that the mx master 2s supports.