### PR TITLE
macOS: Add support for Bluetooth devices

### DIFF
--- a/Release_Notes.md
+++ b/Release_Notes.md
@@ -1,5 +1,9 @@
 # Notes on Major Changes in Releases
 
+## Version 1.1.15
+
+* Solaar supports configuration of Bluetooth devices on macOS.
+
 ## Version 1.1.13
 
 * Solaar will drop support for Python 3.7 immediately after version 1.1.13.

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -366,7 +366,7 @@ def simulate_uinput(what, code, arg):
 def simulate_key(code, event):  # X11 keycode but Solaar event code
     if not wayland and simulate_xtest(code, event):
         return True
-    if simulate_uinput(evdev.ecodes.EV_KEY, code - 8, event):
+    if evdev and simulate_uinput(evdev.ecodes.EV_KEY, code - 8, event):
         return True
     logger.warning("no way to simulate key input")
 

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -151,8 +151,8 @@ def _print_device(dev, num=None):
             if isinstance(feature, str):
                 feature_bytes = bytes.fromhex(feature[-4:])
             else:
-                feature_bytes = feature.to_bytes(2, byteorder="big")
-            feature_int = int.from_bytes(feature_bytes, byteorder="big")
+                feature_bytes = feature.to_bytes(2, byteorder="little")
+            feature_int = int.from_bytes(feature_bytes, byteorder="little")
             flags = dev.request(0x0000, feature_bytes)
             flags = 0 if flags is None else ord(flags[1:2])
             flags = common.flag_names(hidpp20_constants.FeatureFlag, flags)

--- a/lib/solaar/gtk.py
+++ b/lib/solaar/gtk.py
@@ -178,7 +178,8 @@ def main():
 
     udev_file = "42-logitech-unify-permissions.rules"
     if (
-        logger.isEnabledFor(logging.WARNING)
+        platform.system() == "Linux"
+        and logger.isEnabledFor(logging.WARNING)
         and not os.path.isfile("/etc/udev/rules.d/" + udev_file)
         and not os.path.isfile("/usr/lib/udev/rules.d/" + udev_file)
         and not os.path.isfile("/usr/local/lib/udev/rules.d/" + udev_file)


### PR DESCRIPTION
Use hidapi on macOS to communicate with Logitech peripherals connected via Bluetooth. This brings macOS device support on the same level as Linux.

Tested with MX Keys and MX Master 3S.

Fixes #2729