### PR TITLE
delete tmpfile on close for cli

### DIFF
--- a/lib/solaar/gtk.py
+++ b/lib/solaar/gtk.py
@@ -154,6 +154,8 @@ def main():
 
     args = _parse_arguments()
     if not args:
+        # explicit close before return
+        temp.close()
         return
     if args.action:
         # explicit close before return

--- a/lib/solaar/gtk.py
+++ b/lib/solaar/gtk.py
@@ -156,6 +156,8 @@ def main():
     if not args:
         return
     if args.action:
+        # explicit close before return
+        temp.close()
         # if any argument, run comandline and exit
         return cli.run(args.action, args.hidraw_path)
 


### PR DESCRIPTION
solaar creates a tempfile. In cli-mode doesn't delete in on close.

This minimal patch fixes this so that the tempfile gets deleted on cli-mode too.