### PR TITLE
Handle device open exceptions in hidapi and skip unsupported devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ __pycache__/
 /po/*.po~
 
 /.idea/
+
+.DS_Store
+._*
+
+Pipfile
+Pipfile.lock


### PR DESCRIPTION
If VID and PID are both zero, the device is highly unlikely to be HID++ capable. On an Apple Silicon Mac, there are a lot of internal HID class devices on bus ID 0x0, none of which are what we are looking for. In both cases we shouldn't even attempt to open the devices at all.

Not all HID class devices found on the system can be opened, `open_path()` will fail with an unhandled exception `IOHIDDeviceGetReport failed: (0xE00002C7) (iokit/common) unsupported function`. That has been fixed as well.

Update gitignore to include common junk files generated by macOS, and pipenv config which this project doesn't use.