### PR TITLE
testing: upgrade desktop notifications tests to take notifications availability into account

### DIFF
--- a/lib/logitech_receiver/desktop_notifications.py
+++ b/lib/logitech_receiver/desktop_notifications.py
@@ -86,7 +86,7 @@ if available:
             n.set_urgency(Notify.Urgency.NORMAL)
             n.set_hint("desktop-entry", GLib.Variant("s", "solaar"))  # replace with better name late
             try:
-                n.show()
+                return n.show()
             except Exception:
                 logger.exception(f"showing {n}")
 

--- a/lib/solaar/ui/desktop_notifications.py
+++ b/lib/solaar/ui/desktop_notifications.py
@@ -122,7 +122,7 @@ if available:
                 n.set_hint("value", GLib.Variant("i", progress))
 
             try:
-                n.show()
+                return n.show()
             except Exception:
                 logger.exception(f"showing {n}")
 
@@ -139,4 +139,5 @@ else:
         return None
 
     def show(dev, reason=None):
+        return 1000
         return None

--- a/tests/logitech_receiver/test_desktop_notifications.py
+++ b/tests/logitech_receiver/test_desktop_notifications.py
@@ -2,22 +2,28 @@ from unittest import mock
 
 from logitech_receiver import desktop_notifications
 
-
-def test_notifications_available():
-    result = desktop_notifications.notifications_available()
-
-    assert not result
+# depends on external environment, so make some tests dependent on availability
 
 
 def test_init():
-    assert not desktop_notifications.init()
+    result = desktop_notifications.init()
+
+    assert result == desktop_notifications.available
 
 
 def test_uninit():
     assert desktop_notifications.uninit() is None
 
 
+class MockDevice(mock.Mock):
+    name = "MockDevice"
+
+    def close():
+        return True
+
+
 def test_show():
-    dev = mock.MagicMock()
+    dev = MockDevice()
     reason = "unknown"
-    assert desktop_notifications.show(dev, reason) is None
+    result = desktop_notifications.show(dev, reason)
+    assert result is not None if desktop_notifications.available else result is None

--- a/tests/solaar/ui/test_desktop_notifications.py
+++ b/tests/solaar/ui/test_desktop_notifications.py
@@ -2,15 +2,13 @@ from unittest import mock
 
 from solaar.ui import desktop_notifications
 
-
-def test_notifications_available():
-    result = desktop_notifications.notifications_available()
-
-    assert not result
+# depends on external environment, so make some tests dependent on availability
 
 
 def test_init():
-    assert not desktop_notifications.init()
+    result = desktop_notifications.init()
+
+    assert result == desktop_notifications.available
 
 
 def test_uninit():
@@ -22,7 +20,17 @@ def test_alert():
     assert desktop_notifications.alert(reason) is None
 
 
+class MockDevice(mock.Mock):
+    name = "MockDevice"
+
+    def close():
+        return True
+
+
 def test_show():
-    dev = mock.MagicMock()
+    dev = MockDevice()
     reason = "unknown"
-    assert desktop_notifications.show(dev, reason) is None
+    available = desktop_notifications.init()
+
+    result = desktop_notifications.show(dev, reason)
+    assert result is not None if available else result is None


### PR DESCRIPTION
@MattHag Some tests were failing when run in a setting where desktop notifications are available.