### PR TITLE
Fix: handle `HIDError` in `hidapi.hidapi_impl._match()`

### DIFF
--- a/lib/hidapi/hidapi_impl.py
+++ b/lib/hidapi/hidapi_impl.py
@@ -257,18 +257,16 @@ def _match(
     device_handle = None
     try:
         device_handle = open_path(device["path"])
-        try:
-            report = _get_input_report(device_handle, 0x10, 32)
-            if len(report) == 1 + 6 and report[0] == 0x10:
-                device["hidpp_short"] = True
-        except HIDError as e:
-            logger.info(f"Error opening device {device['path']} ({bus_id}/{vid:04X}/{pid:04X}) for hidpp check: {e}")
-        try:
-            report = _get_input_report(device_handle, 0x11, 32)
-            if len(report) == 1 + 19 and report[0] == 0x11:
-                device["hidpp_long"] = True
-        except HIDError as e:
-            logger.info(f"Error opening device {device['path']} ({bus_id}/{vid:04X}/{pid:04X}) for hidpp check: {e}")
+        
+        report = _get_input_report(device_handle, 0x10, 32)
+        if len(report) == 1 + 6 and report[0] == 0x10:
+            device["hidpp_short"] = True
+
+        report = _get_input_report(device_handle, 0x11, 32)
+        if len(report) == 1 + 19 and report[0] == 0x11:
+            device["hidpp_long"] = True
+    except HIDError as e:
+        logger.info(f"Error opening device {device['path']} ({bus_id}/{vid:04X}/{pid:04X}) for hidpp check: {e}")
     finally:
         if device_handle:
             close(device_handle)


### PR DESCRIPTION
The `open_path()` function may raise `HIDError` but `_match()`, its caller, does not handle it, unlike other cases after opening the path. This affects to the device enumeration process in `hidapi.enumerate()`, causing some devices to be randomly undiscovered.

Below is the traceback in my Mac:
```
Traceback (most recent call last):
  File "/Users/geesecross/repo/Solaar/lib/solaar/ui/__init__.py", line 111, in <lambda>
    lambda app, startup_hook: _startup(app, startup_hook, use_tray, show_window),
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/geesecross/repo/Solaar/lib/solaar/ui/__init__.py", line 65, in _startup
    startup_hook()
  File "/Users/geesecross/repo/Solaar/lib/solaar/listener.py", line 287, in start_all
    for device_info in base.receivers_and_devices():
  File "/Users/geesecross/repo/Solaar/lib/logitech_receiver/base.py", line 244, in receivers_and_devices
    yield from hidapi.enumerate(filter_products_of_interest)
  File "/Users/geesecross/repo/Solaar/lib/hidapi/hidapi_impl.py", line 381, in enumerate
    d_info = _match(ACTION_ADD, device, filter_func)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/geesecross/repo/Solaar/lib/hidapi/hidapi_impl.py", line 259, in _match
    device_handle = open_path(device["path"])
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/geesecross/repo/Solaar/lib/hidapi/hidapi_impl.py", line 414, in open_path
    raise HIDError(_hidapi.hid_error(None))
hidapi.hidapi_impl.HIDError: hid_open_path: failed to open IOHIDDevice from mach entry: (0xE00002C5) (iokit/common) exclusive access and device already open
```