### PR TITLE
docs(i18n): mention Serbian translation

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -62,6 +62,7 @@ Some of the languages Solaar has been translated to are listed below. A full lis
 - Portuguese-BR: [Drovetto][drovetto], [Josenivaldo Benito Jr.][jrbenito], Vinícius
 - Română: Daniel Pavel
 - Russian: [Dimitriy Ryazantcev][DJm00n], Anton Soroko
+- Serbian: [Renato Kaurić][renatoka]
 - Slovak: [Jose Riha][jose1711]
 - Spanish, Castilian: Jose Luis Tirado
 - Swedish: John Erling Blad, [Daniel Zippert][zipperten], Emelie Snecker, Jonatan Nyberg
@@ -80,3 +81,4 @@ Some of the languages Solaar has been translated to are listed below. A full lis
 [jrbenito]: https://github.com/jrbenito
 [jeblad]: https://github.com/jeblad
 [feku]: https://github.com/FerdinaKusumah
+[renatoka]: https://github.com/renatoka


### PR DESCRIPTION
Serbian translation isn't mentioned in the docs even though it exists.
I checked the commit history and attributed correctly.