### PR TITLE
device: Fix listing of hidpp10 peripherals

### DIFF
--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -467,9 +467,7 @@ class Device:
             return False
 
         if enable:
-            set_flag_bits = (
-                NotificationFlag.BATTERY_STATUS | NotificationFlag.UI | NotificationFlag.CONFIGURATION_COMPLETE
-            ).value
+            set_flag_bits = NotificationFlag.BATTERY_STATUS | NotificationFlag.UI | NotificationFlag.CONFIGURATION_COMPLETE
         else:
             set_flag_bits = 0
         ok = _hidpp10.set_notification_flags(self, set_flag_bits)


### PR DESCRIPTION
The Flag enum was applied the value method twice. remove the value method call from the set_flag_bits in  device.py. There is no such value call in receiver.py set_flag_bits in the same commit so I believe this was a mistake.
With this fix the LX7 mouse is properly enumerated over a Logitech C-BT44 Receiver (seen as EX100, compatible 27MHz FastRF protocol)

Close #2850.

Fixes: 72c9dfc5 Remove NamedInts: Convert NotificationFlag to flag