### PR TITLE
device: Fix listing hidpp10 devices - bytes vs string concatenation

### DIFF
--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -533,7 +533,7 @@ class Ex100Receiver(Receiver):
         online = True
         encrypted = bool(notification.data[0] & 0x80)
         kind = extract_device_kind(_get_kind_from_index(self, number))
-        wpid = extract_wpid(notification.data[2:3])
+        wpid = "00" + extract_wpid(notification.data[2:3])
         return online, encrypted, wpid, kind
 
     def device_pairing_information(self, number: int) -> dict:

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -533,7 +533,7 @@ class Ex100Receiver(Receiver):
         online = True
         encrypted = bool(notification.data[0] & 0x80)
         kind = extract_device_kind(_get_kind_from_index(self, number))
-        wpid = extract_wpid("00" + notification.data[2:3])
+        wpid = extract_wpid(notification.data[2:3])
         return online, encrypted, wpid, kind
 
     def device_pairing_information(self, number: int) -> dict:


### PR DESCRIPTION
Fix error concatenating bytes with a string.

It seems that adding "00" to the bytes value has no more use, so I remove it.

Closes #2855.

Fixes: 5e0c85a6 receiver: Refactor extraction of serial and max. devices