### PR TITLE
Fix ubuntu github CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,15 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install Ubuntu dependencies
+    - name: Install Ubuntu dependencies for python 3.8
+      if: matrix.python-version == '3.8'
       run: |
         make install_apt
+
+    - name: Install Ubuntu dependencies for python 3.13
+      if: matrix.python-version == '3.13'
+      run: |
+        make install_apt_python3.13
 
     - name: Install Python dependencies
       run: |

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,12 @@ install_macos: install_brew install_pip
 install_apt:
 	@echo "Installing Solaar dependencies via apt"
 	sudo apt update
-	sudo apt install libdbus-1-dev libglib2.0-dev libgtk-3-dev libgirepository1.0-dev
+	sudo apt install libdbus-1-dev libglib2.0-dev libgtk-3-dev libgirepository-1.0-dev
+
+install_apt_python3.13:
+	@echo "Installing Solaar dependencies via apt"
+	sudo apt update
+	sudo apt install libdbus-1-dev libglib2.0-dev libgtk-3-dev libgirepository-2.0-dev gobject-introspection
 
 install_dnf:
 	@echo "Installing Solaar dependencies via dn"


### PR DESCRIPTION
python 3.13 brings pygobject >= 3.52.1 which requires libgirepository 2.0. Add gobject-introspection has libgirepository-2.0-dev does not depends on it and it is required by PyGObject.

Closes #2857.