### PR TITLE
Fix github workflow stopping all matrix jobs when one of them fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.13]
+      fail-fast: false
 
     steps:
     - name: Checkout
@@ -48,6 +49,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.13]
+      fail-fast: false
 
     steps:
     - name: Checkout


### PR DESCRIPTION
This avoids cancelling the python 3.8 test when the python 3.13 one has failed.