### PR TITLE
GitHub CI: Disable latest Python tests on macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.13]
+        python-version: [3.8]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Related #2892