### PR TITLE
Apply uaccess rules on all actions other than remove

### DIFF
--- a/rules.d-uinput/42-logitech-unify-permissions.rules
+++ b/rules.d-uinput/42-logitech-unify-permissions.rules
@@ -5,7 +5,7 @@
 # because they could perform firmware updates.
 KERNEL=="uinput", SUBSYSTEM=="misc", TAG+="uaccess", OPTIONS+="static_node=uinput"
 
-ACTION != "add", GOTO="solaar_end"
+ACTION == "remove", GOTO="solaar_end"
 SUBSYSTEM != "hidraw", GOTO="solaar_end"
 
 # USB-connected Logitech receivers and devices

--- a/rules.d/42-logitech-unify-permissions.rules
+++ b/rules.d/42-logitech-unify-permissions.rules
@@ -4,7 +4,7 @@
 # Allowing users to write to the device is potentially dangerous
 # because they could perform firmware updates.
 
-ACTION != "add", GOTO="solaar_end"
+ACTION == "remove", GOTO="solaar_end"
 SUBSYSTEM != "hidraw", GOTO="solaar_end"
 
 # USB-connected Logitech receivers and devices


### PR DESCRIPTION
These actions now need to react to "change" uevents, not only "add" uevents. The recommendation from
https://github.com/systemd/systemd/blob/5a8b9fd49f7602c19b56deb8cc0efd23e0aa8e2a/NEWS#L22 is to apply them on all non-"remove" uevents, which is what is done here.

See also https://bugs.debian.org/1112660