### PR TITLE
settings: add setting for HAPTIC feature

### DIFF
--- a/lib/logitech_receiver/hidpp20_constants.py
+++ b/lib/logitech_receiver/hidpp20_constants.py
@@ -66,6 +66,7 @@ class SupportedFeature(IntEnum):
     BACKLIGHT3 = 0x1983
     ILLUMINATION = 0x1990
     FORCE_SENSING_BUTTON = 0x19C0
+    HAPTIC = 0x19B0
     PRESENTER_CONTROL = 0x1A00
     SENSOR_3D = 0x1A01
     REPROG_CONTROLS = 0x1B00
@@ -277,3 +278,23 @@ class ParamId(IntEnum):
     PIXEL_ZONE = 2  # 4 2-byte integers, left, bottom, width, height; pixels
     RATIO_ZONE = 3  # 4 bytes, left, bottom, width, height; unit 1/240 pad size
     SCALE_FACTOR = 4  # 2-byte integer, with 256 as normal scale
+
+
+HapticWaveForms = NamedInts(
+    SHARP_STATE_CHANGE=0x00,
+    DAMP_STATE_CHANGE=0x01,
+    SHARP_COLLISION=0x02,
+    DAMP_COLLISION=0x03,
+    SUBTLE_COLLISION=0x04,
+    HAPPY_ALERT=0x05,
+    ANGRY_ALERT=0x06,
+    COMPLETED=0x07,
+    SQUARE=0x08,
+    WAVE=0x09,
+    FIREWORK=0x0A,
+    MAD=0x0B,
+    KNOCK=0x0C,
+    JINGLE=0x0D,
+    RINGING=0xE,
+    WHISPER_COLLISION=0x1B,
+)

--- a/lib/logitech_receiver/settings.py
+++ b/lib/logitech_receiver/settings.py
@@ -57,6 +57,7 @@ class Setting:
     rw_options = {}
     validator_class = None
     validator_options = {}
+    display = True  # display setting in UI
 
     def __init__(self, device, rw, validator):
         self._device = device

--- a/lib/logitech_receiver/settings_new.py
+++ b/lib/logitech_receiver/settings_new.py
@@ -40,6 +40,7 @@ class Setting:
     choices_universe = None  # All possible acceptable keys, for settings with keys
     kind = Kind.NONE  # What GUI interface to use
     persist = True  # Whether to remember the setting
+    display = True  # display setting in UI
     _device = None  # The device that this setting is for
     _device_object = None  # The object that interacts with the feature for the device
     _value = None  # Stored value as maintained by Solaar, used for persistence

--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -16,7 +16,6 @@
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import logging
-import traceback
 
 from enum import Enum
 from threading import Timer
@@ -70,7 +69,6 @@ def _write_async(setting, value, sbox, sensitive=True, key=None):
                 v = setting.write_key_value(key, v)
                 v = {key: v}
         except Exception:
-            traceback.print_exc()
             v = None
         if sb:
             GLib.idle_add(_update_setting_item, sb, v, True, sensitive, priority=99)
@@ -660,6 +658,8 @@ def _change_icon(allowed, icon):
 
 
 def _create_sbox(s, _device):
+    if not s.display:
+        return
     sbox = Gtk.HBox(homogeneous=False, spacing=6)
     sbox.setting = s
     sbox.kind = s.kind


### PR DESCRIPTION
Addresses #2964 

Adds a haptic-level setting to control how strong the haptic feedback is.

Adds a haptic-play "settting" to play a haptic form.  This setting is not shown in the UI.  Instead use `solaar config <device> haptic-play` to show the possible forms and `solaar config <device> haptic-play <form>` to play a form.