### PR TITLE
docs: swap commands

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,12 +31,12 @@ brew install hidapi gtk+3 pygobject3
 * Option A (recommended): Configure a LaunchAgent to automatically start Solaar and keep it running in the background.
 It will also automatically restart Solaar if it crashed or closed.
 ```
-bash <(curl -fsSL https://raw.githubusercontent.com/pwr-Solaar/Solaar/refs/heads/master/tools/create-macos-app.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/pwr-Solaar/Solaar/refs/heads/master/tools/create-macos-launchagent.sh)
 ```
 * Option B: Create Solaar.app launcher in /Applications.
 It can be added to Login Items to start on login, but it will not automatically recover on crashes.
 ```
-bash <(curl -fsSL https://raw.githubusercontent.com/pwr-Solaar/Solaar/refs/heads/master/tools/create-macos-launchagent.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/pwr-Solaar/Solaar/refs/heads/master/tools/create-macos-app.sh)
 ```
 
 # Installating from GitHub


### PR DESCRIPTION
The commands were probably meant to be the other way around. 

And I also think there is something missing or wrong here:

> and then run `pip install --user solaar` or `pipx install --system-site-packages solaar` or If you are using pipx add the `` flag.

but I was not sure.