### PR TITLE
Add support for MX Keys S Keyboard (Bluetooth)

### DIFF
--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -225,6 +225,7 @@ _D("Craft Advanced Keyboard", codename="Craft", protocol=4.5, wpid="4066", btid=
 _D("Wireless Illuminated Keyboard K800 new", codename="K800 new", protocol=4.5, wpid="406E")
 _D("Wireless Keyboard K470", codename="K470", protocol=4.5, wpid="4075")
 _D("MX Keys Keyboard", codename="MX Keys", protocol=4.5, wpid="408A", btid=0xB35B)
+_D("MX Keys S Keyboard", codename="MX Keys S", protocol=4.5, btid=0xB378)
 _D(
     "G915 TKL LIGHTSPEED Wireless RGB Mechanical Gaming Keyboard",
     codename="G915 TKL",


### PR DESCRIPTION
## Summary
Add support for Logitech MX Keys S keyboard connected via Bluetooth.

## Device Info
- **Product**: MX Keys S Keyboard
- **Bluetooth ID**: 0xB378
- **Protocol**: HID++ 4.5

## Testing
Tested on Ubuntu 24.04 with MX Keys S connected via Bluetooth:
- ✅ Device detection works
- ✅ Battery status reporting (UNIFIED BATTERY feature)
- ✅ Fn-swap configuration (K375S FN INVERSION feature)
- ✅ Backlight control (BACKLIGHT2 feature)
- ✅ Host switching (CHANGE HOST feature)
- ✅ All 34 HID++ 2.0 features detected and functional

## `solaar show` output
```
MX Keys S Keyboard
     Device path  : /dev/hidraw2
     USB id       : 046d:B378
     Codename     : MX Keys S
     Kind         : keyboard
     Protocol     : HID++ 4.5
     Model ID:      B37800000000
     Supports 34 HID++ 2.0 features
     Battery: 90%, BatteryStatus.DISCHARGING
```

## Notes
For Bluetooth HID devices, users may need udev rules that match on `KERNELS` pattern rather than `ATTRS{idVendor}`, e.g.:
```
KERNEL=="hidraw*", KERNELS=="*:046D:*", MODE="0660", GROUP="plugdev", TAG+="uaccess"
```