### PR TITLE
Fix crash when reading notification flags.

### DIFF
--- a/lib/logitech_receiver/hidpp10.py
+++ b/lib/logitech_receiver/hidpp10.py
@@ -189,7 +189,9 @@ class Hidpp10:
         write_register(device, Registers.THREE_LEDS, v1, v2)
 
     def get_notification_flags(self, device: Device):
-        return NotificationFlag(self._get_register(device, Registers.NOTIFICATIONS))
+        flags = self._get_register(device, Registers.NOTIFICATIONS)
+        if flags is not None:
+            return NotificationFlag(flags)
 
     def set_notification_flags(self, device: Device, *flag_bits: NotificationFlag):
         assert device is not None

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -56,7 +56,7 @@ def _print_receiver(receiver):
     if notification_flags is not None:
         if notification_flags:
             notification_names = hidpp10_constants.NotificationFlag.flag_names(notification_flags)
-            print(f"  Notifications: {', '.join(notification_names)} (0x{notification_flags:06X})")
+            print(f"  Notifications: {', '.join(notification_names)} (0x{notification_flags.value:06X})")
         else:
             print("  Notifications: (none)")
 


### PR DESCRIPTION
`solaar show` is crashing for me on master:
```
❯ ./bin/solaar show 
rules cannot access modifier keys in Wayland, accessing process only works on GNOME with Solaar Gnome extension installed
cannot create uinput device: "/dev/uinput" cannot be opened for writing
solaar version 1.1.18

Receiver
  Device path  : /dev/hidraw3
  USB id       : 046d:C54D
  Serial       : CF596A34
  C Pending    : ff
    0          : 07.02.B0011
    1          : 02.11
    3          : 81.7F
  Has 1 paired device(s) out of a maximum of 2.
solaar: error: Traceback (most recent call last):
  File "/home/gebner/Solaar/lib/solaar/cli/__init__.py", line 216, in run
    m.run(c, args, _find_receiver, _find_device)
    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gebner/Solaar/lib/solaar/cli/show.py", line 324, in run
    _print_receiver(d)
    ~~~~~~~~~~~~~~~^^^
  File "/home/gebner/Solaar/lib/solaar/cli/show.py", line 59, in _print_receiver
    print(f"  Notifications: {', '.join(notification_names)} (0x{notification_flags:06X})")
                                                                ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/enum.py", line 1310, in __format__
    return str.__format__(str(self), format_spec)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Unknown format code 'X' for object of type 'str'
```

With this PR, I get a full output:
```
❯ ./bin/solaar show 
rules cannot access modifier keys in Wayland, accessing process only works on GNOME with Solaar Gnome extension installed
cannot create uinput device: "/dev/uinput" cannot be opened for writing
solaar version 1.1.18-1-gf5872095

Receiver
  Device path  : /dev/hidraw3
  USB id       : 046d:C54D
  Serial       : CF596A34
  C Pending    : ff
    0          : 07.02.B0011
    1          : 02.11
    3          : 81.7F
  Has 1 paired device(s) out of a maximum of 2.
  Notifications: software present, wireless (0x000900)
  Device activity counters: 1=178

  1: PRO X SUPERLIGHT 2c
     Device path  : None
     WPID         : 40B7
     Codename     : PRO X 2c
     Kind         : mouse
     Protocol     : HID++ 4.2
     Report Rate : 1ms
     Serial number: F1934960
     Model ID:      40B7C09F0000
     Unit ID:       F1934960
                 1: BL2 50.00.B0005
                 0: MPM 38.00.B0005
     The power switch is located on the unknown.
     Supports 33 HID++ 2.0 features:
         0: ROOT                   {0000} V0     
         1: FEATURE SET            {0001} V0     
         2: DEVICE FW VERSION      {0003} V7     
            Firmware: 1 BL2 50.00.B0005 AB35AD883B7E
            Firmware: 0 MPM 38.00.B0005 40B7AD883B7E
            Unit ID: F1934960  Model ID: 40B7C09F0000  Transport IDs: {'wpid': '40B7', 'usbid': 'C09F'}
         3: DEVICE NAME            {0005} V5     
            Name: PRO X SUPERLIGHT 2c
            Kind: mouse
         4: WIRELESS DEVICE STATUS {1D4B} V0     
         5: CONFIG CHANGE          {0020} V0     
            Configuration: 11000000000000000000000000000000
         6: UNIFIED BATTERY        {1004} V5     
            Battery: 51%, BatteryStatus.DISCHARGING.
         7: XY STATS               {2250} V1     
         8: WHEEL STATS            {2251} V0     
         9: EXTENDED ADJUSTABLE DPI {2202} V0     
            Sensitivity (DPI) (saved): {X:3000, Y:3000, LOD:HIGH}
            Sensitivity (DPI)        : {X:3000, Y:3000, LOD:HIGH}
        10: MODE STATUS            {8090} V3     
        11: unknown:80E0           {E080} V0     
        12: EXTENDED ADJUSTABLE REPORT RATE {8061} V0     
            Report Rate: 1ms
            Report Rate (saved): 1ms
            Report Rate        : 1ms
        13: ONBOARD PROFILES       {8100} V0     
            Device Mode: Host
            Onboard Profiles (saved): Disabled
            Onboard Profiles        : Disabled
        14: MOUSE BUTTON SPY       {8110} V0     
        15: FORCE PAIRING          {1500} V0     
        16: unknown:1801           {0118} V0    internal, hidden, unknown:000010 
        17: DEVICE RESET           {1802} V0     
        18: unknown:1803           {0318} V0    internal, hidden, unknown:000010 
        19: CONFIG DEVICE PROPS    {1806} V8     
        20: unknown:1817           {1718} V0    internal, hidden, unknown:000010 
        21: OOBSTATE               {1805} V0     
        22: unknown:1830           {3018} V0    internal, hidden, unknown:000010 
        23: unknown:1875           {7518} V0    internal, hidden, unknown:000010 
        24: unknown:1861           {6118} V0    internal, hidden, unknown:000010 
        25: unknown:1890           {9018} V0    internal, hidden, unknown:000008 
        26: unknown:18A1           {A118} V0    internal, hidden, unknown:000010 
        27: unknown:1E00           {001E} V0    hidden 
        28: unknown:1E02           {021E} V0    internal, hidden 
        29: unknown:1E22           {221E} V0    internal, hidden, unknown:000010 
        30: unknown:1602           {0216} V0     
        31: unknown:1EB0           {B01E} V0    internal, hidden, unknown:000010 
        32: unknown:18B1           {B118} V0    internal, hidden, unknown:000010 
     Battery: 51%, BatteryStatus.DISCHARGING.


```