### PR TITLE
Docs: add translator GitHub profile links

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -43,30 +43,30 @@ a translation.
 Some of the languages Solaar has been translated to are listed below. A full list of available translations can be obtained by checking the `/po` folder for translation files.
 
 - Chinese (Simplified): [Rongrong][Rongronggg9]
-- Chinese (Taiwan): Peter Dave Hello
-- Czech: Marián Kyral
-- Croatian: gogo
-- Danish: John Erling Blad
-- Dutch: Heimen Stoffels
+- Chinese (Taiwan): [Peter Dave Hello][PeterDaveHello]
+- Czech: [Marián Kyral][mkyral]
+- Croatian: [gogo][muzena]
+- Danish: [John Erling Blad][jeblad]
+- Dutch: [Heimen Stoffels][vistaus]
 - Français: [Papoteur][papoteur], [David Geiger][david-geiger], [Damien Lallement][damsweb]
-- Finnish: Tomi Leppänen
-- German: Daniel Frost
-- Greek: Vangelis Skarmoutsos
+- Finnish: [Tomi Leppänen][Tomin1]
+- German: [Daniel Frost][danfro]
+- Greek: [Vangelis Skarmoutsos][skarmoutsosv]
 - Indonesia: [Ferdina Kusumah][feku]
 - Italiano: [Michele Olivo][micheleolivo], Lorenzo
-- Japanese: Ryunosuke Toda
+- Japanese: [Ryunosuke Toda][toda-ryunosuke]
 - Norsk (Bokmål): [John Erling Blad][jeblad]
 - Norsk (Nynorsk): [John Erling Blad][jeblad]
-- Polski: [Adrian Piotrowicz][nexces], Matthaiks
-- Portuguese: Américo Monteiro
-- Portuguese-BR: [Drovetto][drovetto], [Josenivaldo Benito Jr.][jrbenito], Vinícius
-- Română: Daniel Pavel
-- Russian: [Dimitriy Ryazantcev][DJm00n], Anton Soroko
+- Polski: [Adrian Piotrowicz][nexces], [Matthaiks][matthaiks]
+- Portuguese: [Américo Monteiro][Am-Monteiro]
+- Portuguese-BR: [Drovetto][drovetto], [Josenivaldo Benito Jr.][jrbenito], [Vinícius][viniciusbm]
+- Română: [Daniel Pavel][pwr]
+- Russian: [Dimitriy Ryazantcev][DJm00n], [Anton Soroko][antonsoroko]
 - Serbian: [Renato Kaurić][renatoka]
 - Slovak: [Jose Riha][jose1711]
-- Spanish, Castilian: Jose Luis Tirado
-- Swedish: John Erling Blad, [Daniel Zippert][zipperten], Emelie Snecker, Jonatan Nyberg
-- Turkish: Osman Karagöz
+- Spanish, Castilian: [Jose Luis Tirado][txelu]
+- Swedish: [John Erling Blad][jeblad], [Daniel Zippert][zipperten], Emelie Snecker, [Jonatan Nyberg][NickWick13]
+- Turkish: [Osman Karagöz][osmank3]
 - Ukrainian: Олександр Афанасьєв
 
 [Rongronggg9]: https://github.com/Rongronggg9
@@ -83,3 +83,19 @@ Some of the languages Solaar has been translated to are listed below. A full lis
 [jeblad]: https://github.com/jeblad
 [feku]: https://github.com/FerdinaKusumah
 [renatoka]: https://github.com/renatoka
+[PeterDaveHello]: https://github.com/PeterDaveHello
+[mkyral]: https://github.com/mkyral
+[muzena]: https://github.com/muzena
+[vistaus]: https://github.com/Vistaus
+[danfro]: https://github.com/Danfro
+[skarmoutsosv]: https://github.com/skarmoutsosv
+[toda-ryunosuke]: https://github.com/toda-ryunosuke
+[matthaiks]: https://github.com/Matthaiks
+[pwr]: https://github.com/pwr
+[antonsoroko]: https://github.com/antonsoroko
+[osmank3]: https://github.com/osmank3
+[Am-Monteiro]: https://github.com/Am-Monteiro
+[Tomin1]: https://github.com/Tomin1
+[viniciusbm]: https://github.com/viniciusbm
+[txelu]: https://github.com/txelu
+[NickWick13]: https://github.com/NickWick13


### PR DESCRIPTION
The doc docs/i18n.md lists current translation maintainers. Add those missing reference links to their GitHub profiles for consistency, easier contact and attribution.