### PR TITLE
device: handle inaccessible devices when determining protocol

### DIFF
--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -216,7 +216,10 @@ class Device:
     @property
     def protocol(self):
         if not self._protocol:
-            self.ping()
+            try:
+                self.ping()
+            except exceptions.NoSuchDevice:
+                logger.warning("device %s inaccessible - no protocol set", self)
         return self._protocol or 0
 
     @property


### PR DESCRIPTION
Should fix #3094, but testing requires waiting until the required circumstances arise, probably a device becoming inaccessible at just the right time.