### PR TITLE
Comment-ify command suggestions in `bug_report.md`.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,10 +4,10 @@ about: Create a report to help us improve
 title: ''
 labels: bug
 assignees: ''
-
 ---
 
-**Information**
+#### Information
+
 <!-- Make sure that your issue is not one of the known issues in the
      Solaar documentation at https://pwr-solaar.github.io/Solaar/ -->
 <!-- Make sure that Solaar's udev rule is running by executing
@@ -19,50 +19,69 @@ assignees: ''
 <!-- Note that some distributions have very old versions of Solaar
      as their default version.  -->
 
-- Solaar version (`solaar --version` or `git describe --tags` if cloned from this repository):
-- Distribution:
-- Kernel version (ex. `uname -srmo`):
-- Output of `solaar show`:
-<!-- To run `solaar show` in 1.1.18 you have to clone Solaar from this repository
-  and `run bin/solaar show` from the download directory. -->
+- #### Solaar version
 
-<details>
+  <!-- `solaar --version` or `git describe --tags` if cloned from this repository -->
 
-```
-SOLAAR SHOW OUTPUT HERE
-```
-</details>
+- #### Distribution
 
-- Contents of `~/.config/solaar/config.yaml` (or `~/.config/solaar/config.json` if `~/.config/solaar/config.yaml` not present):
+  <!-- `cat /etc/os-release` -->
 
-<details>
+- #### Kernel version
 
-```
-CONTENTS HERE
-```
-</details>
+  <!-- `uname -srmo` -->
+
+- #### Output of `solaar show`
+
+  <!-- To run `solaar show`, in 1.1.18, you have to clone Solaar from this repository,
+       and `run bin/solaar show` from the download directory. -->
+
+  <details><blockquote>
+
+  ```yaml
+  SOLAAR SHOW OUTPUT HERE
+  ```
+
+  </blockquote></details>
+
+- #### Contents of `config.yaml` or `.json`
+
+  <!-- `~/.config/solaar/config.yaml` (or `~/.config/solaar/config.json` if `~/.config/solaar/config.yaml` is not present). -->
+
+  <details><blockquote>
+
+  ```yaml
+  CONTENTS HERE
+  ```
+
+  </blockquote></details>
 
 
-- Errors or warrnings from Solaar:
-<!-- Under normal operation Solaar keeps a log of warning and error messages
-in ~/.tmp while it is running, as a file starting with 'Solaar'.
-If this file is not available or does not have useful information you can
-run Solaar as `solaar -ddd`, after killing any running Solaar processes to
-have Solaar log debug, informational, warning, and error messages to stdout. -->
+- #### Errors or warrnings from Solaar
+
+  <!-- Under normal operation Solaar keeps a log of warning and error messages
+       in `~/.tmp`, while it is running, as a file starting with 'Solaar'. -->
+  <!-- If this file is not available or does not have useful information you can
+       run Solaar as `solaar -ddd`, after killing any running Solaar processes to
+       have Solaar log debug, informational, warning, and error messages to stdout. -->
 
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**A description of the bug**
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+<!-- A clear and concise description of what the bug is. -->
+
+**How to reproduce it**
+
+<!-- Steps to reproduce the behavior: -->
+<!-- 1. Go to '...'
+     2. Click on '....'
+     3. Scroll down to '....'
+     4. See error -->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 **Additional context**
-Add any other context about the problem here.
+
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
- Added advice for acquiring the distribution.

- All sections now support multi-line output.

- Section headings are consistently cased: “How To Reproduce” was title case, whereas sentence case was utilised elsewhere; this converts all headings back to sentence case, as intended.

- Code blocks have the YAML syntax highlighting applied, which is broadly applicable to their expected content.

- All solely-template-required suggestions are encapsulated in comments.

This should remediate [⪅ `#issuecomment-3765499022` of `issues/3103`](https://github.com/pwr-Solaar/Solaar/issues/3103#issuecomment-3765499022).