### PR TITLE
Use console_scripts entry point for pipx compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,5 +89,9 @@ setup(
     packages=find_packages(where="lib"),
     data_files=list(_data_files()),
     include_package_data=True,
-    scripts=glob("bin/*"),
+    entry_points={
+        "console_scripts": [
+            "solaar = solaar.gtk:main",
+        ],
+    },
 )


### PR DESCRIPTION
Fixes #3104

## Summary
Replace `scripts=glob("bin/*")` with `entry_points` containing `console_scripts` to make Solaar installable via pipx. pipx requires packages to define `console_scripts` entry points to detect command-line applications.

## Changes
- Modified `setup.py` to use `entry_points={"console_scripts": ["solaar = solaar.gtk:main"]}` instead of `scripts=glob("bin/*")`
- The `solaar` command will now be properly detected by pipx as an installable app

## Testing
- Verified setup.py syntax is correct
- Ran ruff linter - all checks passed
- Confirmed the entry point correctly references `solaar.gtk:main` which is the existing main function

## Diff stats
 setup.py | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)