### PR TITLE
Add support for Logitech G933 Headset

### DIFF
--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -447,6 +447,7 @@ _D(
 
 _D("G533 Gaming Headset", codename="G533 Headset", protocol=2.0, interface=3, kind=DEVICE_KIND.headset, usbid=0x0A66)
 _D("G535 Gaming Headset", codename="G535 Headset", protocol=2.0, interface=3, kind=DEVICE_KIND.headset, usbid=0x0AC4)
+_D("G933 Gaming Headset", codename="G933 Headset", protocol=2.0, interface=3, kind=DEVICE_KIND.headset, usbid=0x0A5B)
 _D("G935 Gaming Headset", codename="G935 Headset", protocol=2.0, interface=3, kind=DEVICE_KIND.headset, usbid=0x0A87)
 _D("G733 Gaming Headset", codename="G733 Headset", protocol=2.0, interface=3, kind=DEVICE_KIND.headset, usbid=0x0AB5)
 _D(


### PR DESCRIPTION
Current version of Solaar shows the Logitech G933 as "ming" and sometimes "ming Wireless Headset", I suspect it is fetching this from the os and truncating it somehow.

In the logs I see:

```
Failed to set text '<b>ming Wireless Headset' from markup due to error parsing markup: Error on line 1 char 41: Element “markup” was closed, but the currently open element is “b”
```

Add the usb id and proper name to the Logitech descriptors list.

---

Before:

<img width="612" height="264" alt="image" src="https://github.com/user-attachments/assets/300764f8-8194-4018-90e3-d293ee9c09db" />

After:

<img width="637" height="287" alt="image" src="https://github.com/user-attachments/assets/45c32776-4089-44b8-869f-049fc6d6b171" />