### PR TITLE
fix: destroy solaar-keyboard uinput device when no receiver is connected

### DIFF
--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -268,6 +268,20 @@ def setup_uinput():
         logger.warning("cannot create uinput device: %s", e)
 
 
+def teardown_uinput():
+    global udevice
+    if udevice is None:
+        return
+    try:
+        udevice.close()
+        if logger.isEnabledFor(logging.INFO):
+            logger.info("uinput device closed")
+    except Exception as e:
+        logger.warning("cannot close uinput device: %s", e)
+    finally:
+        udevice = None
+
+
 def kbdgroup():
     if xkb_setup():
         state = XkbStateRec()

--- a/lib/solaar/ui/__init__.py
+++ b/lib/solaar/ui/__init__.py
@@ -23,6 +23,7 @@ from typing import Callable
 import gi
 import yaml
 
+from logitech_receiver import diversion
 from logitech_receiver.common import Alert
 
 from solaar.i18n import _
@@ -130,6 +131,8 @@ def _status_changed(device, alert, reason, refresh=False):
         alert = Alert.NONE
 
     tray.update(device)
+    if device.kind is None and not tray._devices_info:
+        diversion.teardown_uinput()
     if alert & Alert.ATTENTION:
         tray.attention(reason)
 


### PR DESCRIPTION
## Summary

Closes #3176

The current master branch already fixes the OSK (on-screen keyboard) issue for users without rules configured, by making uinput device creation lazy (only when a rule is actually triggered). However, if rules are defined and have been triggered — causing `solaar-keyboard` to be created — the uinput device persists even after the receiver is disconnected. This means GNOME/mutter still detects a virtual pointer and keeps `touch_mode` disabled, blocking the OSK.

This PR adds a symmetric `teardown_uinput()` function and calls it when the last receiver is disconnected, mirroring the existing behavior of the system tray icon (which is also hidden on disconnect). The lazy re-creation on next rule trigger remains unchanged.

## Changes

- `lib/logitech_receiver/diversion.py`: Add `teardown_uinput()` to close and release the uinput device
- `lib/solaar/ui/__init__.py`: Call `teardown_uinput()` in `_status_changed()` when a receiver is removed and no receivers remain

## Behavior

| Scenario | Before | After |
|---|---|---|
| No rules defined | no uinput created (lazy fix) | no uinput created (lazy fix) |
| Rules triggered, receiver connected | uinput exists | uinput exists |
| Rules triggered, receiver **disconnected** | uinput persists — OSK blocked | uinput destroyed — OSK works |

## Notes

My own problem (OneXPlayer X1 Pro, GNOME Shell, OSK not appearing) is already solved by the lazy creation fix in master since I have no rules configured/triggered. I'm opening this PR because the dynamic lifecycle fix addresses a real remaining issue for users who do use rules.