### PR TITLE
G522 LIGHTSPEED headphones support

### DIFF
--- a/lib/hidapi/common.py
+++ b/lib/hidapi/common.py
@@ -19,3 +19,4 @@ class DeviceInfo:
     hidpp_short: str | None
     hidpp_long: str | None
     centurion: bool = False
+    centurion_report_id: int | None = None  # 0x50 or 0x51 when centurion=True

--- a/lib/hidapi/udev_impl.py
+++ b/lib/hidapi/udev_impl.py
@@ -102,6 +102,7 @@ def _match(action: str, device, filter_func: typing.Callable[[int, int, int, boo
         from hid_parser import ReportDescriptor
 
         hidpp_short = hidpp_long = centurion = False
+        centurion_report_id = None
         devfile = "/sys" + hid_device.properties.get("DEVPATH") + "/report_descriptor"
         with fileopen(devfile, "rb") as fd:
             with warnings.catch_warnings():
@@ -111,16 +112,22 @@ def _match(action: str, device, filter_func: typing.Callable[[int, int, int, boo
             # and _Usage(0xFF00, 0x0001) in rd.get_input_items(0x10)[0].usages  # be more permissive
             hidpp_long = 0x11 in rd.input_report_ids and 19 * 8 == int(rd.get_input_report_size(0x11))
             # and _Usage(0xFF00, 0x0002) in rd.get_input_items(0x11)[0].usages  # be more permissive
-            # Centurion transport: report ID 0x51, 63-byte reports (usage page 0xFFA0)
-            centurion = (
-                0x51 in rd.input_report_ids and 63 * 8 == int(rd.get_input_report_size(0x51)) and 0x51 in rd.output_report_ids
-            )
+            # Centurion transport: 63-byte reports on usage page 0xFFA0 (both input and output)
+            # 0x51 = PRO X 2 LIGHTSPEED variant, 0x50 = G522 LIGHTSPEED variant (with device address byte)
+            if 0x51 in rd.input_report_ids and 63 * 8 == int(rd.get_input_report_size(0x51)) and 0x51 in rd.output_report_ids:
+                centurion_report_id = 0x51
+            elif (
+                0x50 in rd.input_report_ids and 63 * 8 == int(rd.get_input_report_size(0x50)) and 0x50 in rd.output_report_ids
+            ):
+                centurion_report_id = 0x50
+            centurion = centurion_report_id is not None
         if not hidpp_short and not hidpp_long and not centurion:
             return
     except Exception as e:  # if can't process report descriptor fall back to old scheme
         hidpp_short = None
         hidpp_long = None
         centurion = False
+        centurion_report_id = None
         logger.info(
             "Report Descriptor not processed for DEVICE %s BID %s VID %s PID %s: %s",
             device.device_node,
@@ -171,6 +178,7 @@ def _match(action: str, device, filter_func: typing.Callable[[int, int, int, boo
             hidpp_short=hidpp_short,
             hidpp_long=hidpp_long,
             centurion=centurion if centurion else False,
+            centurion_report_id=centurion_report_id,
         )
         return d_info
 

--- a/lib/logitech_receiver/advanced_para_eq.py
+++ b/lib/logitech_receiver/advanced_para_eq.py
@@ -24,16 +24,11 @@ gain is whole dB; getEQInfos returns 5 bytes [bandCount, dbRange,
 caps, dbMin, dbMax].
 
 V2 wire format: 5-byte band stride [filter_type, freq_hi, freq_lo,
-gain_hi, gain_lo] with NO header. Filter types are 0x00=HP (cutoff),
+gain_hi, gain_lo] with no header. Filter types are 0x00=HP (cutoff),
 0x78=peaking. Frequency is raw BE u16 in Hz. Gain is signed BE int16
 × step_db (step_db from getEQInfos). No Q on the wire — firmware-fixed
 per filter type. getEQInfos returns 13 bytes with gain bounds + step
 count, format enum, XY-support flag, and onboard preset counts.
-
-Authoritative source: HEADSET_ADVANCED_PARA_EQ_WIRE_PROTOCOL.md (the
-V2 layout was confirmed via live G522 probe — the default EQ is one
-HP filter at 20 Hz plus nine peaking filters at ISO centers 50, 125,
-250, 500, 1000, 2500, 5000, 10000, 20000 Hz with all gains at zero).
 """
 
 from __future__ import annotations

--- a/lib/logitech_receiver/advanced_para_eq.py
+++ b/lib/logitech_receiver/advanced_para_eq.py
@@ -193,6 +193,125 @@ def parse_v2_bands(result: bytes, step_db: float):
     return bands, header_len
 
 
+def get_advanced_eq_defaults(device, direction=DIRECTION_PLAYBACK, slot=0):
+    """Query getEQDefaults (function 5). Same per-band layout as getCustomEQ.
+
+    Factory presets, read-only. Reading them across all factory slots gives
+    us a corpus of (name, freq_u16[], q_u16[]) tuples that may reveal the
+    u16->Hz and u16->Q scaling without needing a pcap. Returns list of
+    (freq_u16, gain_db, q_u16) or None.
+    """
+    version = _get_version(device)
+    result = device.feature_request(SupportedFeature.HEADSET_ADVANCED_PARA_EQ, 0x50, direction, slot)
+    if result is None:
+        logger.info(
+            "AdvancedParaEQ getEQDefaults V%d (dir=%d slot=%d): feature_request returned None",
+            version,
+            direction,
+            slot,
+        )
+        return None
+    if version >= 2:
+        info = getattr(device, "_advanced_eq_info", None)
+        step_db = info["step_db"] if info and "step_db" in info else 1.0
+        bands, header_len = parse_v2_bands(result, step_db)
+        if bands is None:
+            logger.info(
+                "AdvancedParaEQ getEQDefaults V2 (dir=%d slot=%d): couldn't locate band payload raw=%s",
+                direction,
+                slot,
+                result.hex(),
+            )
+            return None
+        logger.info(
+            "AdvancedParaEQ getEQDefaults V2 (dir=%d slot=%d): %d band(s) header_len=%d raw=%s",
+            direction,
+            slot,
+            len(bands),
+            header_len,
+            result.hex(),
+        )
+        return bands
+    # V0/V1: 3-byte stride, gain is whole dB, no Q.
+    bands = []
+    offset = 0
+    while offset + 3 <= len(result):
+        freq = struct.unpack(">H", result[offset : offset + 2])[0]
+        if freq == 0:
+            break
+        gain_db = struct.unpack("b", bytes([result[offset + 2]]))[0]
+        bands.append((freq, float(gain_db), 0))
+        offset += 3
+    logger.info(
+        "AdvancedParaEQ getEQDefaults V%d (dir=%d slot=%d): %d band(s) raw=%s",
+        version,
+        direction,
+        slot,
+        len(bands),
+        result.hex(),
+    )
+    return bands
+
+
+def get_advanced_eq_friendly_name(device, direction=DIRECTION_PLAYBACK, slot=0):
+    """Query getEQFriendlyName (function 6). Returns the UTF-8 preset name or None."""
+    result = device.feature_request(SupportedFeature.HEADSET_ADVANCED_PARA_EQ, 0x60, direction, slot)
+    if result is None or len(result) < 1:
+        return None
+    name_len = result[0]
+    if 1 + name_len > len(result):
+        name_len = len(result) - 1
+    try:
+        name = bytes(result[1 : 1 + name_len]).decode("utf-8", errors="replace")
+    except Exception:
+        name = result[1 : 1 + name_len].hex()
+    return name
+
+
+def probe_all_presets(device, direction=DIRECTION_PLAYBACK):
+    """Read every factory and custom preset slot's name + band data and log it.
+
+    Diagnostic probe — intended to run once at HeadsetAdvancedEQ.build() time
+    so we accumulate a corpus of (name, freq_u16[], q_u16[]) tuples across
+    presets. Patterns in that corpus should reveal the u16->Hz and u16->Q
+    mappings without needing a live pcap from LGHUB.
+    """
+    info = getattr(device, "_advanced_eq_info", None)
+    if not info:
+        return
+    ro_count = info.get("onboard_ro_preset_count", 0)
+    custom_count = info.get("onboard_custom_preset_count", 0)
+    # Factory presets: read via getEQDefaults
+    for slot in range(ro_count):
+        name = get_advanced_eq_friendly_name(device, direction=direction, slot=slot)
+        bands = get_advanced_eq_defaults(device, direction=direction, slot=slot)
+        if bands is None:
+            continue
+        logger.info(
+            "AdvancedParaEQ factory preset %d/%d (dir=%d) name=%r: %s",
+            slot,
+            ro_count,
+            direction,
+            name,
+            [(f"0x{f:04X}", round(g, 3), f"0x{q:04X}") for f, g, q in bands],
+        )
+    # Custom preset slots: via getCustomEQ. Most will be empty/default, but
+    # any user-authored slots could give additional freq/Q samples.
+    for slot in range(custom_count):
+        name = get_advanced_eq_friendly_name(device, direction=direction, slot=slot)
+        bands = get_advanced_eq_params(device, direction=direction, slot=slot)
+        if bands is None:
+            continue
+        logger.info(
+            "AdvancedParaEQ custom preset %d/%d (dir=%d) name=%r: %s",
+            slot,
+            custom_count,
+            direction,
+            name,
+            [(f"0x{f:04X}", round(g, 3), f"0x{q:04X}") for f, g, q in bands],
+        )
+
+
 def get_advanced_eq_params(device, direction=DIRECTION_PLAYBACK, slot=0):
     """Query getCustomEQ (function 1). Returns list of (freq, gain_db, q) or None.
 

--- a/lib/logitech_receiver/advanced_para_eq.py
+++ b/lib/logitech_receiver/advanced_para_eq.py
@@ -108,7 +108,7 @@ def get_advanced_eq_info(device):
         }
         logger.info(
             "AdvancedParaEQ getEQInfos V2: gain=[%d,%d] steps=%d step_db=%.4f format=%d xy=%s "
-            "presets_ro=%d presets_custom=%d raw=%s",
+            "presets_ro=%d presets_custom=%d",
             gain_min,
             gain_max,
             gain_steps,
@@ -117,7 +117,6 @@ def get_advanced_eq_info(device):
             supports_xy,
             ro_presets,
             custom_presets,
-            result.hex(),
         )
         return info
 
@@ -140,14 +139,13 @@ def get_advanced_eq_info(device):
         "step_db": 1.0,
     }
     logger.info(
-        "AdvancedParaEQ getEQInfos V%d: bands=%d dbRange=%d caps=0x%02X gain=[%d,%d] raw=%s",
+        "AdvancedParaEQ getEQInfos V%d: bands=%d dbRange=%d caps=0x%02X gain=[%d,%d]",
         version,
         band_count,
         db_range,
         caps,
         gain_min,
         gain_max,
-        result.hex(),
     )
     return info
 
@@ -161,7 +159,7 @@ def get_advanced_eq_active_slot(device, direction=DIRECTION_PLAYBACK):
     if len(result) < 1:
         logger.info("AdvancedParaEQ getActiveEQ(dir=%d): empty response", direction)
         return None
-    logger.info("AdvancedParaEQ getActiveEQ(dir=%d): slot=%d raw=%s", direction, result[0], result.hex())
+    logger.info("AdvancedParaEQ getActiveEQ(dir=%d): slot=%d", direction, result[0])
     return result[0]
 
 
@@ -224,12 +222,11 @@ def get_advanced_eq_defaults(device, direction=DIRECTION_PLAYBACK, slot=0):
             )
             return None
         logger.info(
-            "AdvancedParaEQ getEQDefaults V2 (dir=%d slot=%d): %d band(s) %s raw=%s",
+            "AdvancedParaEQ getEQDefaults V2 (dir=%d slot=%d): %d band(s) %s",
             direction,
             slot,
             len(bands),
             [_band_label(t, f) + f" {round(g, 2)}dB" for t, f, g in bands],
-            result.hex(),
         )
         return bands
     # V0/V1 legacy 3-byte stride.
@@ -243,12 +240,11 @@ def get_advanced_eq_defaults(device, direction=DIRECTION_PLAYBACK, slot=0):
         bands.append((FILTER_TYPE_PEAKING, freq, float(gain_db)))
         offset += 3
     logger.info(
-        "AdvancedParaEQ getEQDefaults V%d (dir=%d slot=%d): %d band(s) raw=%s",
+        "AdvancedParaEQ getEQDefaults V%d (dir=%d slot=%d): %d band(s)",
         version,
         direction,
         slot,
         len(bands),
-        result.hex(),
     )
     return bands
 
@@ -346,13 +342,12 @@ def get_advanced_eq_params(device, direction=DIRECTION_PLAYBACK, slot=0):
             )
             return None
         logger.info(
-            "AdvancedParaEQ getCustomEQ V2 (dir=%d slot=%d): %d band(s) step_db=%.4f %s raw=%s",
+            "AdvancedParaEQ getCustomEQ V2 (dir=%d slot=%d): %d band(s) step_db=%.4f %s",
             direction,
             slot,
             len(bands),
             step_db,
             [f"{_band_label(t, f)} {round(g, 2)}dB" for t, f, g in bands],
-            result.hex(),
         )
         return bands
 
@@ -367,12 +362,11 @@ def get_advanced_eq_params(device, direction=DIRECTION_PLAYBACK, slot=0):
         bands.append((FILTER_TYPE_PEAKING, freq, float(gain_db)))
         offset += 3
     logger.info(
-        "AdvancedParaEQ getCustomEQ V%d (dir=%d slot=%d): parsed %d band(s) %s raw=%s",
+        "AdvancedParaEQ getCustomEQ V%d (dir=%d slot=%d): parsed %d band(s) %s",
         version,
         direction,
         slot,
         len(bands),
         bands,
-        result.hex(),
     )
     return bands

--- a/lib/logitech_receiver/advanced_para_eq.py
+++ b/lib/logitech_receiver/advanced_para_eq.py
@@ -1,0 +1,81 @@
+## Copyright (C) 2024  Solaar Contributors https://pwr-solaar.github.io/Solaar/
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License along
+## with this program; if not, write to the Free Software Foundation, Inc.,
+## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""AdvancedParaEQ (0x020D) helpers.
+
+Unlike OnboardEQ (0x0636) which requires host-computed biquad coefficients,
+AdvancedParaEQ is handled entirely by the device — we send frequency + gain
+per band and the device applies them. Band entries are 3 bytes each:
+[freq_hi, freq_lo, value] where value is the signed int8 gain in dB.
+"""
+
+from __future__ import annotations
+
+import struct
+
+from .hidpp20_constants import SupportedFeature
+
+# Direction parameter for getCustomEQ / getActiveEQ etc.
+DIRECTION_PLAYBACK = 0
+DIRECTION_CAPTURE = 1
+
+
+def get_advanced_eq_info(device):
+    """Query HEADSET_ADVANCED_PARA_EQ getEQInfos (function 0).
+
+    Returns (band_count, db_range, capabilities, db_min, db_max) or None.
+    """
+    result = device.feature_request(SupportedFeature.HEADSET_ADVANCED_PARA_EQ, 0x00)
+    if result is None or len(result) < 5:
+        return None
+    band_count = result[0]
+    db_range = result[1]
+    capabilities = result[2]
+    # dbMin / dbMax are signed int8 in the doc.
+    db_min = struct.unpack("b", bytes([result[3]]))[0]
+    db_max = struct.unpack("b", bytes([result[4]]))[0]
+    return (band_count, db_range, capabilities, db_min, db_max)
+
+
+def get_advanced_eq_active_slot(device, direction=DIRECTION_PLAYBACK):
+    """Query getActiveEQ (function 3). Returns the active slot index, or None."""
+    result = device.feature_request(SupportedFeature.HEADSET_ADVANCED_PARA_EQ, 0x30, direction)
+    if result is None or len(result) < 1:
+        return None
+    return result[0]
+
+
+def get_advanced_eq_params(device, direction=DIRECTION_PLAYBACK, slot=0):
+    """Query getCustomEQ (function 1) for the given direction and slot.
+
+    Returns a list of (freq_hz, gain_db) tuples, or None.
+    """
+    result = device.feature_request(SupportedFeature.HEADSET_ADVANCED_PARA_EQ, 0x10, direction, slot)
+    if result is None:
+        return None
+    bands = []
+    offset = 0
+    # Response is a tight-packed series of 3-byte band entries:
+    # [freq_hi, freq_lo, value].
+    while offset + 3 <= len(result):
+        freq = struct.unpack(">H", result[offset : offset + 2])[0]
+        if freq == 0:
+            # Trailing padding — stop parsing.
+            break
+        gain_db = struct.unpack("b", bytes([result[offset + 2]]))[0]
+        bands.append((freq, gain_db))
+        offset += 3
+    return bands

--- a/lib/logitech_receiver/advanced_para_eq.py
+++ b/lib/logitech_receiver/advanced_para_eq.py
@@ -17,17 +17,23 @@
 """AdvancedParaEQ (0x020D) helpers.
 
 The device handles biquad coefficient computation — we transmit only
-per-band frequency, gain, and (on V2) Q-factor; the DSP does the rest.
+per-band filter-type + frequency + gain; the DSP does the rest.
 
-V0/V1 wire format: 3-byte band stride [freq_hi, freq_lo, gain_i8];
-getEQInfos returns 5 bytes [bandCount, dbRange, caps, dbMin, dbMax].
+V0/V1 wire format: 3-byte band stride [freq_hi, freq_lo, gain_i8],
+gain is whole dB; getEQInfos returns 5 bytes [bandCount, dbRange,
+caps, dbMin, dbMax].
 
-V2 wire format: 5-byte band stride [freq_hi, freq_lo, gain_i8, q_hi,
-q_lo]; getEQInfos returns 13 bytes with gain bounds + step count,
-format enum, XY-support flag, and onboard preset counts. Frequency and
-Q are opaque u16 round-trip values — the u16→Hz / u16→Q mappings are
-unconfirmed and need a LGHUB pcap to pin down. See
-HEADSET_ADVANCED_PARA_EQ_WIRE_PROTOCOL.md.
+V2 wire format: 5-byte band stride [filter_type, freq_hi, freq_lo,
+gain_hi, gain_lo] with NO header. Filter types are 0x00=HP (cutoff),
+0x78=peaking. Frequency is raw BE u16 in Hz. Gain is signed BE int16
+× step_db (step_db from getEQInfos). No Q on the wire — firmware-fixed
+per filter type. getEQInfos returns 13 bytes with gain bounds + step
+count, format enum, XY-support flag, and onboard preset counts.
+
+Authoritative source: HEADSET_ADVANCED_PARA_EQ_WIRE_PROTOCOL.md (the
+V2 layout was confirmed via live G522 probe — the default EQ is one
+HP filter at 20 Hz plus nine peaking filters at ISO centers 50, 125,
+250, 500, 1000, 2500, 5000, 10000, 20000 Hz with all gains at zero).
 """
 
 from __future__ import annotations
@@ -41,6 +47,14 @@ logger = logging.getLogger(__name__)
 
 DIRECTION_PLAYBACK = 0
 DIRECTION_CAPTURE = 1
+
+# V2 filter-type taxonomy (byte [+0] of each band).
+FILTER_TYPE_HP = 0x00
+FILTER_TYPE_PEAKING = 0x78
+FILTER_TYPE_NAMES = {
+    FILTER_TYPE_HP: "HP",
+    FILTER_TYPE_PEAKING: "peaking",
+}
 
 
 def _get_version(device) -> int:
@@ -156,50 +170,41 @@ def get_advanced_eq_active_slot(device, direction=DIRECTION_PLAYBACK):
     return result[0]
 
 
-def _parse_v2_band_payload(result: bytes):
-    """Locate and parse the 5-byte band stride inside a V2 getCustomEQ response.
-
-    Header length before the first band is not yet nailed down (see
-    HEADSET_ADVANCED_PARA_EQ_WIRE_PROTOCOL.md section on band header).
-    Try candidate lengths {5, 2, 0} and pick the first where the tail is
-    a clean multiple of 5.
-
-    Returns (bands_bytes, header_len) or (None, None).
-    """
-    for hl in (5, 2, 0):
-        tail = result[hl:]
-        if tail and len(tail) % 5 == 0 and 1 <= len(tail) // 5 <= 64:
-            return tail, hl
-    return None, None
-
-
 def parse_v2_bands(result: bytes, step_db: float):
-    """Parse a V2 getCustomEQ response. Returns list of (freq_u16, gain_db, q_u16).
+    """Parse a V2 getCustomEQ/getEQDefaults response.
 
-    Trailing all-zero bands (terminators) are stripped.
+    Returns list of (filter_type_byte, freq_hz, gain_db) tuples, or None.
+    Response is N × 5 bytes with no header. Each band is
+    [filter_type, freq_hi, freq_lo, gain_hi, gain_lo].
     """
-    payload, header_len = _parse_v2_band_payload(result)
-    if payload is None:
-        return None, None
+    if result is None or len(result) == 0:
+        return None
+    if len(result) % 5 != 0:
+        return None
     bands = []
-    for i in range(len(payload) // 5):
-        e = payload[i * 5 : (i + 1) * 5]
-        freq_u16 = (e[0] << 8) | e[1]
-        gain_raw = struct.unpack("b", bytes([e[2]]))[0]
-        q_u16 = (e[3] << 8) | e[4]
-        bands.append((freq_u16, gain_raw * step_db, q_u16))
-    while bands and bands[-1] == (0, 0.0, 0):
-        bands.pop()
-    return bands, header_len
+    for i in range(len(result) // 5):
+        e = result[i * 5 : (i + 1) * 5]
+        filter_type = e[0]
+        freq_hz = (e[1] << 8) | e[2]
+        gain_int16 = struct.unpack(">h", bytes(e[3:5]))[0]
+        gain_db = gain_int16 * step_db
+        bands.append((filter_type, freq_hz, gain_db))
+    return bands
+
+
+def _band_label(filter_type_byte: int, freq_hz: int) -> str:
+    kind = FILTER_TYPE_NAMES.get(filter_type_byte, f"type-0x{filter_type_byte:02X}")
+    if filter_type_byte == FILTER_TYPE_HP:
+        return f"HP {freq_hz} Hz"
+    return f"{freq_hz} Hz" if kind == "peaking" else f"{kind} {freq_hz} Hz"
 
 
 def get_advanced_eq_defaults(device, direction=DIRECTION_PLAYBACK, slot=0):
     """Query getEQDefaults (function 5). Same per-band layout as getCustomEQ.
 
-    Factory presets, read-only. Reading them across all factory slots gives
-    us a corpus of (name, freq_u16[], q_u16[]) tuples that may reveal the
-    u16->Hz and u16->Q scaling without needing a pcap. Returns list of
-    (freq_u16, gain_db, q_u16) or None.
+    Returns list of (filter_type_byte, freq_hz, gain_db) tuples, or None.
+    V0/V1 callers receive (FILTER_TYPE_PEAKING, freq_hz, gain_db) for
+    compatibility with the V2 tuple shape.
     """
     version = _get_version(device)
     result = device.feature_request(SupportedFeature.HEADSET_ADVANCED_PARA_EQ, 0x50, direction, slot)
@@ -214,25 +219,25 @@ def get_advanced_eq_defaults(device, direction=DIRECTION_PLAYBACK, slot=0):
     if version >= 2:
         info = getattr(device, "_advanced_eq_info", None)
         step_db = info["step_db"] if info and "step_db" in info else 1.0
-        bands, header_len = parse_v2_bands(result, step_db)
+        bands = parse_v2_bands(result, step_db)
         if bands is None:
             logger.info(
-                "AdvancedParaEQ getEQDefaults V2 (dir=%d slot=%d): couldn't locate band payload raw=%s",
+                "AdvancedParaEQ getEQDefaults V2 (dir=%d slot=%d): payload not multiple of 5 raw=%s",
                 direction,
                 slot,
                 result.hex(),
             )
             return None
         logger.info(
-            "AdvancedParaEQ getEQDefaults V2 (dir=%d slot=%d): %d band(s) header_len=%d raw=%s",
+            "AdvancedParaEQ getEQDefaults V2 (dir=%d slot=%d): %d band(s) %s raw=%s",
             direction,
             slot,
             len(bands),
-            header_len,
+            [_band_label(t, f) + f" {round(g, 2)}dB" for t, f, g in bands],
             result.hex(),
         )
         return bands
-    # V0/V1: 3-byte stride, gain is whole dB, no Q.
+    # V0/V1 legacy 3-byte stride.
     bands = []
     offset = 0
     while offset + 3 <= len(result):
@@ -240,7 +245,7 @@ def get_advanced_eq_defaults(device, direction=DIRECTION_PLAYBACK, slot=0):
         if freq == 0:
             break
         gain_db = struct.unpack("b", bytes([result[offset + 2]]))[0]
-        bands.append((freq, float(gain_db), 0))
+        bands.append((FILTER_TYPE_PEAKING, freq, float(gain_db)))
         offset += 3
     logger.info(
         "AdvancedParaEQ getEQDefaults V%d (dir=%d slot=%d): %d band(s) raw=%s",
@@ -269,19 +274,17 @@ def get_advanced_eq_friendly_name(device, direction=DIRECTION_PLAYBACK, slot=0):
 
 
 def probe_all_presets(device, direction=DIRECTION_PLAYBACK):
-    """Read every factory and custom preset slot's name + band data and log it.
+    """Read every factory + custom preset slot and log name + band data at INFO.
 
-    Diagnostic probe — intended to run once at HeadsetAdvancedEQ.build() time
-    so we accumulate a corpus of (name, freq_u16[], q_u16[]) tuples across
-    presets. Patterns in that corpus should reveal the u16->Hz and u16->Q
-    mappings without needing a live pcap from LGHUB.
+    Diagnostic probe — intended to run once at HeadsetAdvancedEQ.build() time.
+    The logged corpus is useful for spotting filter-type or frequency pattern
+    differences between named presets.
     """
     info = getattr(device, "_advanced_eq_info", None)
     if not info:
         return
     ro_count = info.get("onboard_ro_preset_count", 0)
     custom_count = info.get("onboard_custom_preset_count", 0)
-    # Factory presets: read via getEQDefaults
     for slot in range(ro_count):
         name = get_advanced_eq_friendly_name(device, direction=direction, slot=slot)
         bands = get_advanced_eq_defaults(device, direction=direction, slot=slot)
@@ -293,10 +296,8 @@ def probe_all_presets(device, direction=DIRECTION_PLAYBACK):
             ro_count,
             direction,
             name,
-            [(f"0x{f:04X}", round(g, 3), f"0x{q:04X}") for f, g, q in bands],
+            [f"{_band_label(t, f)} {round(g, 2)}dB" for t, f, g in bands],
         )
-    # Custom preset slots: via getCustomEQ. Most will be empty/default, but
-    # any user-authored slots could give additional freq/Q samples.
     for slot in range(custom_count):
         name = get_advanced_eq_friendly_name(device, direction=direction, slot=slot)
         bands = get_advanced_eq_params(device, direction=direction, slot=slot)
@@ -308,25 +309,29 @@ def probe_all_presets(device, direction=DIRECTION_PLAYBACK):
             custom_count,
             direction,
             name,
-            [(f"0x{f:04X}", round(g, 3), f"0x{q:04X}") for f, g, q in bands],
+            [f"{_band_label(t, f)} {round(g, 2)}dB" for t, f, g in bands],
         )
 
 
 def get_advanced_eq_params(device, direction=DIRECTION_PLAYBACK, slot=0):
-    """Query getCustomEQ (function 1). Returns list of (freq, gain_db, q) or None.
+    """Query getCustomEQ (function 1). Returns list of (filter_type, freq_hz, gain_db) or None.
 
-    V0/V1: freq is raw Hz (u16), q is always 0 (V0/V1 has no Q).
-    V2: freq is opaque u16 bin index (Hz mapping unconfirmed), q is opaque u16
-    round-trip value (scale unconfirmed). See wire-protocol doc.
+    V0/V1: filter_type is always FILTER_TYPE_PEAKING (synthesized), freq is
+    raw Hz from wire, gain is whole dB.
+    V2: filter_type comes from the wire (0x00=HP, 0x78=peaking), freq is raw
+    Hz, gain is int16 × step_db.
 
-    step_db for V2 is derived from getEQInfos; the caller should pass it via
-    `device._advanced_eq_info` (set by get_advanced_eq_info) or we fall back
-    to 1.0 and log a warning.
+    step_db for V2 is cached on the device by get_advanced_eq_info.
     """
     version = _get_version(device)
     result = device.feature_request(SupportedFeature.HEADSET_ADVANCED_PARA_EQ, 0x10, direction, slot)
     if result is None:
-        logger.info("AdvancedParaEQ getCustomEQ V%d (dir=%d slot=%d): feature_request returned None", version, direction, slot)
+        logger.info(
+            "AdvancedParaEQ getCustomEQ V%d (dir=%d slot=%d): feature_request returned None",
+            version,
+            direction,
+            slot,
+        )
         return None
 
     if version >= 2:
@@ -336,22 +341,27 @@ def get_advanced_eq_params(device, direction=DIRECTION_PLAYBACK, slot=0):
             logger.warning(
                 "AdvancedParaEQ getCustomEQ V2: no cached getEQInfos — gain values will use step_db=1.0 and be wrong"
             )
-        bands, header_len = parse_v2_bands(result, step_db)
+        bands = parse_v2_bands(result, step_db)
         if bands is None:
-            logger.info("AdvancedParaEQ getCustomEQ V2: couldn't locate band payload raw=%s", result.hex())
+            logger.info(
+                "AdvancedParaEQ getCustomEQ V2 (dir=%d slot=%d): payload not multiple of 5 raw=%s",
+                direction,
+                slot,
+                result.hex(),
+            )
             return None
         logger.info(
-            "AdvancedParaEQ getCustomEQ V2 (dir=%d slot=%d): parsed %d band(s) header_len=%d step_db=%.4f raw=%s",
+            "AdvancedParaEQ getCustomEQ V2 (dir=%d slot=%d): %d band(s) step_db=%.4f %s raw=%s",
             direction,
             slot,
             len(bands),
-            header_len,
             step_db,
+            [f"{_band_label(t, f)} {round(g, 2)}dB" for t, f, g in bands],
             result.hex(),
         )
         return bands
 
-    # V0 / V1: 3-byte stride, freq is raw Hz, gain is whole dB, no Q.
+    # V0 / V1
     bands = []
     offset = 0
     while offset + 3 <= len(result):
@@ -359,7 +369,7 @@ def get_advanced_eq_params(device, direction=DIRECTION_PLAYBACK, slot=0):
         if freq == 0:
             break
         gain_db = struct.unpack("b", bytes([result[offset + 2]]))[0]
-        bands.append((freq, float(gain_db), 0))
+        bands.append((FILTER_TYPE_PEAKING, freq, float(gain_db)))
         offset += 3
     logger.info(
         "AdvancedParaEQ getCustomEQ V%d (dir=%d slot=%d): parsed %d band(s) %s raw=%s",

--- a/lib/logitech_receiver/advanced_para_eq.py
+++ b/lib/logitech_receiver/advanced_para_eq.py
@@ -16,10 +16,18 @@
 
 """AdvancedParaEQ (0x020D) helpers.
 
-Unlike OnboardEQ (0x0636) which requires host-computed biquad coefficients,
-AdvancedParaEQ is handled entirely by the device — we send frequency + gain
-per band and the device applies them. Band entries are 3 bytes each:
-[freq_hi, freq_lo, value] where value is the signed int8 gain in dB.
+The device handles biquad coefficient computation — we transmit only
+per-band frequency, gain, and (on V2) Q-factor; the DSP does the rest.
+
+V0/V1 wire format: 3-byte band stride [freq_hi, freq_lo, gain_i8];
+getEQInfos returns 5 bytes [bandCount, dbRange, caps, dbMin, dbMax].
+
+V2 wire format: 5-byte band stride [freq_hi, freq_lo, gain_i8, q_hi,
+q_lo]; getEQInfos returns 13 bytes with gain bounds + step count,
+format enum, XY-support flag, and onboard preset counts. Frequency and
+Q are opaque u16 round-trip values — the u16→Hz / u16→Q mappings are
+unconfirmed and need a LGHUB pcap to pin down. See
+HEADSET_ADVANCED_PARA_EQ_WIRE_PROTOCOL.md.
 """
 
 from __future__ import annotations
@@ -31,39 +39,108 @@ from .hidpp20_constants import SupportedFeature
 
 logger = logging.getLogger(__name__)
 
-# Direction parameter for getCustomEQ / getActiveEQ etc.
 DIRECTION_PLAYBACK = 0
 DIRECTION_CAPTURE = 1
 
 
-def get_advanced_eq_info(device):
-    """Query HEADSET_ADVANCED_PARA_EQ getEQInfos (function 0).
+def _get_version(device) -> int:
+    return device.features.get_feature_version(SupportedFeature.HEADSET_ADVANCED_PARA_EQ) or 0
 
-    Returns (band_count, db_range, capabilities, db_min, db_max) or None.
+
+def get_advanced_eq_info(device):
+    """Query getEQInfos (function 0). Returns a dict or None.
+
+    Common fields:
+      version       int      feature version (0, 1, 2)
+      gain_min_db   int      signed whole-dB min
+      gain_max_db   int      signed whole-dB max
+      step_db       float    dB per raw LSB (1.0 on V0/V1)
+
+    V0/V1 only:
+      band_count    int      number of bands (from wire byte 0)
+      db_range      int      raw byte 1
+      capabilities  int      raw byte 2
+
+    V2 only:
+      gain_steps    int      discrete gain positions
+      format        int      0=CLASSIC, 1=STYLES
+      supports_xy   bool
+      onboard_ro_preset_count     int  factory preset slots
+      onboard_custom_preset_count int  user-writable preset slots
     """
+    version = _get_version(device)
     result = device.feature_request(SupportedFeature.HEADSET_ADVANCED_PARA_EQ, 0x00)
     if result is None:
-        logger.info("AdvancedParaEQ getEQInfos: feature_request returned None")
+        logger.info("AdvancedParaEQ getEQInfos V%d: feature_request returned None", version)
         return None
+
+    if version >= 2:
+        if len(result) < 13:
+            logger.info("AdvancedParaEQ getEQInfos V2: short response len=%d %s", len(result), result.hex())
+            return None
+        gain_min = struct.unpack("b", bytes([result[2]]))[0]
+        gain_max = struct.unpack("b", bytes([result[3]]))[0]
+        gain_steps = struct.unpack(">H", result[4:6])[0]
+        fmt = result[6]
+        supports_xy = bool(result[7])
+        ro_presets = result[9]
+        custom_presets = result[10]
+        step_db = (gain_max - gain_min) / max(1, gain_steps - 1)
+        info = {
+            "version": 2,
+            "gain_min_db": gain_min,
+            "gain_max_db": gain_max,
+            "gain_steps": gain_steps,
+            "step_db": step_db,
+            "format": fmt,
+            "supports_xy": supports_xy,
+            "onboard_ro_preset_count": ro_presets,
+            "onboard_custom_preset_count": custom_presets,
+        }
+        logger.info(
+            "AdvancedParaEQ getEQInfos V2: gain=[%d,%d] steps=%d step_db=%.4f format=%d xy=%s "
+            "presets_ro=%d presets_custom=%d raw=%s",
+            gain_min,
+            gain_max,
+            gain_steps,
+            step_db,
+            fmt,
+            supports_xy,
+            ro_presets,
+            custom_presets,
+            result.hex(),
+        )
+        return info
+
+    # V0 / V1
     if len(result) < 5:
-        logger.info("AdvancedParaEQ getEQInfos: short response (len=%d) %s", len(result), result.hex())
+        logger.info("AdvancedParaEQ getEQInfos V%d: short response len=%d %s", version, len(result), result.hex())
         return None
     band_count = result[0]
     db_range = result[1]
-    capabilities = result[2]
-    # dbMin / dbMax are signed int8 in the doc.
-    db_min = struct.unpack("b", bytes([result[3]]))[0]
-    db_max = struct.unpack("b", bytes([result[4]]))[0]
+    caps = result[2]
+    gain_min = struct.unpack("b", bytes([result[3]]))[0]
+    gain_max = struct.unpack("b", bytes([result[4]]))[0]
+    info = {
+        "version": version,
+        "band_count": band_count,
+        "db_range": db_range,
+        "capabilities": caps,
+        "gain_min_db": gain_min,
+        "gain_max_db": gain_max,
+        "step_db": 1.0,
+    }
     logger.info(
-        "AdvancedParaEQ getEQInfos: bands=%d dbRange=%d caps=0x%02X dbMin=%d dbMax=%d raw=%s",
+        "AdvancedParaEQ getEQInfos V%d: bands=%d dbRange=%d caps=0x%02X gain=[%d,%d] raw=%s",
+        version,
         band_count,
         db_range,
-        capabilities,
-        db_min,
-        db_max,
+        caps,
+        gain_min,
+        gain_max,
         result.hex(),
     )
-    return (band_count, db_range, capabilities, db_min, db_max)
+    return info
 
 
 def get_advanced_eq_active_slot(device, direction=DIRECTION_PLAYBACK):
@@ -79,29 +156,95 @@ def get_advanced_eq_active_slot(device, direction=DIRECTION_PLAYBACK):
     return result[0]
 
 
-def get_advanced_eq_params(device, direction=DIRECTION_PLAYBACK, slot=0):
-    """Query getCustomEQ (function 1) for the given direction and slot.
+def _parse_v2_band_payload(result: bytes):
+    """Locate and parse the 5-byte band stride inside a V2 getCustomEQ response.
 
-    Returns a list of (freq_hz, gain_db) tuples, or None.
+    Header length before the first band is not yet nailed down (see
+    HEADSET_ADVANCED_PARA_EQ_WIRE_PROTOCOL.md section on band header).
+    Try candidate lengths {5, 2, 0} and pick the first where the tail is
+    a clean multiple of 5.
+
+    Returns (bands_bytes, header_len) or (None, None).
     """
+    for hl in (5, 2, 0):
+        tail = result[hl:]
+        if tail and len(tail) % 5 == 0 and 1 <= len(tail) // 5 <= 64:
+            return tail, hl
+    return None, None
+
+
+def parse_v2_bands(result: bytes, step_db: float):
+    """Parse a V2 getCustomEQ response. Returns list of (freq_u16, gain_db, q_u16).
+
+    Trailing all-zero bands (terminators) are stripped.
+    """
+    payload, header_len = _parse_v2_band_payload(result)
+    if payload is None:
+        return None, None
+    bands = []
+    for i in range(len(payload) // 5):
+        e = payload[i * 5 : (i + 1) * 5]
+        freq_u16 = (e[0] << 8) | e[1]
+        gain_raw = struct.unpack("b", bytes([e[2]]))[0]
+        q_u16 = (e[3] << 8) | e[4]
+        bands.append((freq_u16, gain_raw * step_db, q_u16))
+    while bands and bands[-1] == (0, 0.0, 0):
+        bands.pop()
+    return bands, header_len
+
+
+def get_advanced_eq_params(device, direction=DIRECTION_PLAYBACK, slot=0):
+    """Query getCustomEQ (function 1). Returns list of (freq, gain_db, q) or None.
+
+    V0/V1: freq is raw Hz (u16), q is always 0 (V0/V1 has no Q).
+    V2: freq is opaque u16 bin index (Hz mapping unconfirmed), q is opaque u16
+    round-trip value (scale unconfirmed). See wire-protocol doc.
+
+    step_db for V2 is derived from getEQInfos; the caller should pass it via
+    `device._advanced_eq_info` (set by get_advanced_eq_info) or we fall back
+    to 1.0 and log a warning.
+    """
+    version = _get_version(device)
     result = device.feature_request(SupportedFeature.HEADSET_ADVANCED_PARA_EQ, 0x10, direction, slot)
     if result is None:
-        logger.info("AdvancedParaEQ getCustomEQ(dir=%d slot=%d): feature_request returned None", direction, slot)
+        logger.info("AdvancedParaEQ getCustomEQ V%d (dir=%d slot=%d): feature_request returned None", version, direction, slot)
         return None
+
+    if version >= 2:
+        info = getattr(device, "_advanced_eq_info", None)
+        step_db = info["step_db"] if info and "step_db" in info else 1.0
+        if step_db == 1.0 and not info:
+            logger.warning(
+                "AdvancedParaEQ getCustomEQ V2: no cached getEQInfos — gain values will use step_db=1.0 and be wrong"
+            )
+        bands, header_len = parse_v2_bands(result, step_db)
+        if bands is None:
+            logger.info("AdvancedParaEQ getCustomEQ V2: couldn't locate band payload raw=%s", result.hex())
+            return None
+        logger.info(
+            "AdvancedParaEQ getCustomEQ V2 (dir=%d slot=%d): parsed %d band(s) header_len=%d step_db=%.4f raw=%s",
+            direction,
+            slot,
+            len(bands),
+            header_len,
+            step_db,
+            result.hex(),
+        )
+        return bands
+
+    # V0 / V1: 3-byte stride, freq is raw Hz, gain is whole dB, no Q.
     bands = []
     offset = 0
-    # Response is a tight-packed series of 3-byte band entries:
-    # [freq_hi, freq_lo, value].
     while offset + 3 <= len(result):
         freq = struct.unpack(">H", result[offset : offset + 2])[0]
         if freq == 0:
-            # Trailing padding — stop parsing.
             break
         gain_db = struct.unpack("b", bytes([result[offset + 2]]))[0]
-        bands.append((freq, gain_db))
+        bands.append((freq, float(gain_db), 0))
         offset += 3
     logger.info(
-        "AdvancedParaEQ getCustomEQ(dir=%d slot=%d): parsed %d band(s) %s raw=%s",
+        "AdvancedParaEQ getCustomEQ V%d (dir=%d slot=%d): parsed %d band(s) %s raw=%s",
+        version,
         direction,
         slot,
         len(bands),

--- a/lib/logitech_receiver/advanced_para_eq.py
+++ b/lib/logitech_receiver/advanced_para_eq.py
@@ -24,9 +24,12 @@ per band and the device applies them. Band entries are 3 bytes each:
 
 from __future__ import annotations
 
+import logging
 import struct
 
 from .hidpp20_constants import SupportedFeature
+
+logger = logging.getLogger(__name__)
 
 # Direction parameter for getCustomEQ / getActiveEQ etc.
 DIRECTION_PLAYBACK = 0
@@ -39,7 +42,11 @@ def get_advanced_eq_info(device):
     Returns (band_count, db_range, capabilities, db_min, db_max) or None.
     """
     result = device.feature_request(SupportedFeature.HEADSET_ADVANCED_PARA_EQ, 0x00)
-    if result is None or len(result) < 5:
+    if result is None:
+        logger.info("AdvancedParaEQ getEQInfos: feature_request returned None")
+        return None
+    if len(result) < 5:
+        logger.info("AdvancedParaEQ getEQInfos: short response (len=%d) %s", len(result), result.hex())
         return None
     band_count = result[0]
     db_range = result[1]
@@ -47,14 +54,28 @@ def get_advanced_eq_info(device):
     # dbMin / dbMax are signed int8 in the doc.
     db_min = struct.unpack("b", bytes([result[3]]))[0]
     db_max = struct.unpack("b", bytes([result[4]]))[0]
+    logger.info(
+        "AdvancedParaEQ getEQInfos: bands=%d dbRange=%d caps=0x%02X dbMin=%d dbMax=%d raw=%s",
+        band_count,
+        db_range,
+        capabilities,
+        db_min,
+        db_max,
+        result.hex(),
+    )
     return (band_count, db_range, capabilities, db_min, db_max)
 
 
 def get_advanced_eq_active_slot(device, direction=DIRECTION_PLAYBACK):
     """Query getActiveEQ (function 3). Returns the active slot index, or None."""
     result = device.feature_request(SupportedFeature.HEADSET_ADVANCED_PARA_EQ, 0x30, direction)
-    if result is None or len(result) < 1:
+    if result is None:
+        logger.info("AdvancedParaEQ getActiveEQ(dir=%d): feature_request returned None", direction)
         return None
+    if len(result) < 1:
+        logger.info("AdvancedParaEQ getActiveEQ(dir=%d): empty response", direction)
+        return None
+    logger.info("AdvancedParaEQ getActiveEQ(dir=%d): slot=%d raw=%s", direction, result[0], result.hex())
     return result[0]
 
 
@@ -65,6 +86,7 @@ def get_advanced_eq_params(device, direction=DIRECTION_PLAYBACK, slot=0):
     """
     result = device.feature_request(SupportedFeature.HEADSET_ADVANCED_PARA_EQ, 0x10, direction, slot)
     if result is None:
+        logger.info("AdvancedParaEQ getCustomEQ(dir=%d slot=%d): feature_request returned None", direction, slot)
         return None
     bands = []
     offset = 0
@@ -78,4 +100,12 @@ def get_advanced_eq_params(device, direction=DIRECTION_PLAYBACK, slot=0):
         gain_db = struct.unpack("b", bytes([result[offset + 2]]))[0]
         bands.append((freq, gain_db))
         offset += 3
+    logger.info(
+        "AdvancedParaEQ getCustomEQ(dir=%d slot=%d): parsed %d band(s) %s raw=%s",
+        direction,
+        slot,
+        len(bands),
+        bands,
+        result.hex(),
+    )
     return bands

--- a/lib/logitech_receiver/advanced_para_eq.py
+++ b/lib/logitech_receiver/advanced_para_eq.py
@@ -1,0 +1,456 @@
+## Copyright (C) 2024  Solaar Contributors https://pwr-solaar.github.io/Solaar/
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License along
+## with this program; if not, write to the Free Software Foundation, Inc.,
+## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""AdvancedParaEQ (0x020D) helpers.
+
+The device handles biquad coefficient computation — we transmit only
+per-band filter-type + frequency + gain; the DSP does the rest.
+
+V0/V1 wire format: 3-byte band stride [freq_hi, freq_lo, gain_i8],
+gain is whole dB; getEQInfos returns 5 bytes [bandCount, dbRange,
+caps, dbMin, dbMax].
+
+V2 wire format: 1-byte header [direction_echo], then N × 5-byte band
+stride [freq_hi, freq_lo, filter_type, gain_hi, gain_lo], with 0..3
+trailer bytes (opaque, ignored). The parser consumes 5-byte chunks
+until <5 bytes remain or a freq=0 sentinel is hit. Frequency u16 BE
+in Hz; gain u16 BE in **offset-binary**: raw 0..(steps-1) maps
+linearly to gain_min..gain_max (so on G522 with steps=241 /
+gain=[-6..6], raw=120 = 0 dB). getEQInfos returns 13 bytes with gain
+bounds + step count, format enum, XY-support flag, and onboard preset
+counts.
+
+(The protocol spec lists a 2-byte header [dir_echo, slot_echo] for
+getCustomEQ, but G522 firmware via the centurion bridge omits the
+slot_echo and emits a 1-byte header that matches getEQDefaults.
+Verified against pcap traces of LGHUB ↔ G522 LIGHTSPEED traffic.)
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+
+from .hidpp20_constants import SupportedFeature
+
+logger = logging.getLogger(__name__)
+
+DIRECTION_PLAYBACK = 0
+DIRECTION_CAPTURE = 1
+
+# V2 filter-type taxonomy (byte [+0] of each band). 0x16 is observed on
+# G522 for every band of its factory custom slot at ISO third-octave
+# centers, treated as peaking. Other filter kinds (LP, shelf, notch …)
+# need a live probe per device firmware to enumerate.
+FILTER_TYPE_HP = 0x00
+FILTER_TYPE_PEAKING_G522 = 0x16
+FILTER_TYPE_PEAKING = 0x78
+FILTER_TYPE_NAMES = {
+    FILTER_TYPE_HP: "HP",
+    FILTER_TYPE_PEAKING_G522: "peaking",
+    FILTER_TYPE_PEAKING: "peaking",
+}
+
+
+def _get_version(device) -> int:
+    return device.features.get_feature_version(SupportedFeature.HEADSET_ADVANCED_PARA_EQ) or 0
+
+
+def get_advanced_eq_info(device):
+    """Query getEQInfos (function 0). Returns a dict or None.
+
+    Common fields:
+      version       int      feature version (0, 1, 2)
+      gain_min_db   int      signed whole-dB min
+      gain_max_db   int      signed whole-dB max
+      step_db       float    dB per raw LSB (1.0 on V0/V1)
+
+    V0/V1 only:
+      band_count    int      number of bands (from wire byte 0)
+      db_range      int      raw byte 1
+      capabilities  int      raw byte 2
+
+    V2 only:
+      gain_steps    int      discrete gain positions
+      format        int      0=CLASSIC, 1=STYLES
+      supports_xy   bool
+      onboard_ro_preset_count     int  factory preset slots
+      onboard_custom_preset_count int  user-writable preset slots
+    """
+    version = _get_version(device)
+    result = device.feature_request(SupportedFeature.HEADSET_ADVANCED_PARA_EQ, 0x00)
+    if result is None:
+        logger.debug("AdvancedParaEQ getEQInfos V%d: feature_request returned None", version)
+        return None
+
+    if version >= 2:
+        if len(result) < 13:
+            logger.debug("AdvancedParaEQ getEQInfos V2: short response len=%d %s", len(result), result.hex())
+            return None
+        gain_min = struct.unpack("b", bytes([result[2]]))[0]
+        gain_max = struct.unpack("b", bytes([result[3]]))[0]
+        gain_steps = struct.unpack(">H", result[4:6])[0]
+        fmt = result[6]
+        supports_xy = bool(result[7])
+        ro_presets = result[9]
+        custom_presets = result[10]
+        step_db = (gain_max - gain_min) / max(1, gain_steps - 1)
+        info = {
+            "version": 2,
+            "gain_min_db": gain_min,
+            "gain_max_db": gain_max,
+            "gain_steps": gain_steps,
+            "step_db": step_db,
+            "format": fmt,
+            "supports_xy": supports_xy,
+            "onboard_ro_preset_count": ro_presets,
+            "onboard_custom_preset_count": custom_presets,
+        }
+        logger.debug(
+            "AdvancedParaEQ getEQInfos V2: gain=[%d,%d] steps=%d step_db=%.4f format=%d xy=%s "
+            "presets_ro=%d presets_custom=%d",
+            gain_min,
+            gain_max,
+            gain_steps,
+            step_db,
+            fmt,
+            supports_xy,
+            ro_presets,
+            custom_presets,
+        )
+        device._advanced_eq_info = info
+        return info
+
+    # V0 / V1
+    if len(result) < 5:
+        logger.debug("AdvancedParaEQ getEQInfos V%d: short response len=%d %s", version, len(result), result.hex())
+        return None
+    band_count = result[0]
+    db_range = result[1]
+    caps = result[2]
+    gain_min = struct.unpack("b", bytes([result[3]]))[0]
+    gain_max = struct.unpack("b", bytes([result[4]]))[0]
+    info = {
+        "version": version,
+        "band_count": band_count,
+        "db_range": db_range,
+        "capabilities": caps,
+        "gain_min_db": gain_min,
+        "gain_max_db": gain_max,
+        "step_db": 1.0,
+    }
+    logger.debug(
+        "AdvancedParaEQ getEQInfos V%d: bands=%d dbRange=%d caps=0x%02X gain=[%d,%d]",
+        version,
+        band_count,
+        db_range,
+        caps,
+        gain_min,
+        gain_max,
+    )
+    device._advanced_eq_info = info
+    return info
+
+
+def get_advanced_eq_active_slot(device, direction=DIRECTION_PLAYBACK):
+    """Query getActiveEQ (function 3). Returns the active slot index, or None."""
+    result = device.feature_request(SupportedFeature.HEADSET_ADVANCED_PARA_EQ, 0x30, direction)
+    if result is None:
+        logger.debug("AdvancedParaEQ getActiveEQ(dir=%d): feature_request returned None", direction)
+        return None
+    if len(result) < 1:
+        logger.debug("AdvancedParaEQ getActiveEQ(dir=%d): empty response", direction)
+        return None
+    logger.debug("AdvancedParaEQ getActiveEQ(dir=%d): slot=%d", direction, result[0])
+    return result[0]
+
+
+def parse_v2_bands(result: bytes, info: dict | None):
+    """Parse a V2 getCustomEQ / getEQDefaults response.
+
+    Wire layout (see module docstring):
+      [direction_echo]                              (1-byte header)
+      N × [freq_hi, freq_lo, filter_type, gain_hi, gain_lo]   (5 bytes)
+      [trailer …]                                   (0..3 bytes, ignored)
+
+    Gain is offset-binary against `info`'s gain bounds:
+      gain_db = gain_min + (gain_max - gain_min) * raw / (steps - 1)
+
+    `info` is the dict returned by `get_advanced_eq_info`. If absent we
+    fall back to step_db=1.0 (and log via the caller, not here) which is
+    wrong but won't crash.
+
+    Returns list of (filter_type_byte, freq_hz, gain_db) tuples, or None
+    if the payload is too short to contain a header. Empty payload with
+    valid header returns []. Bands with freq=0 are treated as the
+    end-of-bands sentinel (matches V0/V1 behavior at lines below).
+    """
+    if result is None or len(result) < 1:
+        return None
+    payload = result[1:]  # skip [dir_echo]
+    band_size = 5
+    if info:
+        gain_min = info.get("gain_min_db", -6)
+        gain_max = info.get("gain_max_db", 6)
+        steps = info.get("gain_steps", 241)
+    else:
+        gain_min, gain_max, steps = 0, 0, 1  # produces gain_db=0 for any raw
+    bands = []
+    for i in range(len(payload) // band_size):
+        e = payload[i * band_size : (i + 1) * band_size]
+        freq_hz = (e[0] << 8) | e[1]
+        filter_type = e[2]
+        gain_raw = (e[3] << 8) | e[4]
+        if freq_hz == 0:
+            break  # disabled band — end-of-bands sentinel
+        if steps > 1:
+            gain_db = gain_min + (gain_max - gain_min) * gain_raw / (steps - 1)
+        else:
+            gain_db = 0.0
+        bands.append((filter_type, freq_hz, float(gain_db)))
+    return bands
+
+
+def _band_label(filter_type_byte: int, freq_hz: int) -> str:
+    kind = FILTER_TYPE_NAMES.get(filter_type_byte, f"type-0x{filter_type_byte:02X}")
+    if filter_type_byte == FILTER_TYPE_HP:
+        return f"HP {freq_hz} Hz"
+    return f"{freq_hz} Hz" if kind == "peaking" else f"{kind} {freq_hz} Hz"
+
+
+def get_advanced_eq_defaults(device, direction=DIRECTION_PLAYBACK, slot=0):
+    """Query getEQDefaults (function 5). Same per-band layout as getCustomEQ.
+
+    Returns list of (filter_type_byte, freq_hz, gain_db) tuples, or None.
+    V0/V1 callers receive (FILTER_TYPE_PEAKING, freq_hz, gain_db) for
+    compatibility with the V2 tuple shape.
+    """
+    version = _get_version(device)
+    result = device.feature_request(SupportedFeature.HEADSET_ADVANCED_PARA_EQ, 0x50, direction, slot)
+    if result is None:
+        logger.debug(
+            "AdvancedParaEQ getEQDefaults V%d (dir=%d slot=%d): feature_request returned None",
+            version,
+            direction,
+            slot,
+        )
+        return None
+    if version >= 2:
+        info = getattr(device, "_advanced_eq_info", None)
+        bands = parse_v2_bands(result, info)
+        if bands is None:
+            logger.debug(
+                "AdvancedParaEQ getEQDefaults V2 (dir=%d slot=%d): payload too short raw=%s",
+                direction,
+                slot,
+                result.hex(),
+            )
+            return None
+        logger.debug(
+            "AdvancedParaEQ getEQDefaults V2 (dir=%d slot=%d): %d band(s) raw=%s %s",
+            direction,
+            slot,
+            len(bands),
+            result.hex(),
+            [_band_label(t, f) + f" {round(g, 2)}dB" for t, f, g in bands],
+        )
+        return bands
+    # V0/V1 legacy 3-byte stride.
+    bands = []
+    offset = 0
+    while offset + 3 <= len(result):
+        freq = struct.unpack(">H", result[offset : offset + 2])[0]
+        if freq == 0:
+            break
+        gain_db = struct.unpack("b", bytes([result[offset + 2]]))[0]
+        bands.append((FILTER_TYPE_PEAKING, freq, float(gain_db)))
+        offset += 3
+    logger.debug(
+        "AdvancedParaEQ getEQDefaults V%d (dir=%d slot=%d): %d band(s)",
+        version,
+        direction,
+        slot,
+        len(bands),
+    )
+    return bands
+
+
+def get_advanced_eq_friendly_name(device, direction=DIRECTION_PLAYBACK, slot=0):
+    """Query getEQFriendlyName (function 6). Returns the UTF-8 preset name or None."""
+    result = device.feature_request(SupportedFeature.HEADSET_ADVANCED_PARA_EQ, 0x60, direction, slot)
+    if result is None or len(result) < 1:
+        return None
+    name_len = result[0]
+    if 1 + name_len > len(result):
+        name_len = len(result) - 1
+    try:
+        name = bytes(result[1 : 1 + name_len]).decode("utf-8", errors="replace")
+    except Exception:
+        name = result[1 : 1 + name_len].hex()
+    return name
+
+
+def probe_advanced_eq_slots(device, direction=DIRECTION_PLAYBACK, info=None):
+    """Probe every advertised EQ slot via getCustomEQ and cache which respond.
+
+    Some firmware (G522) advertises N slots via getEQInfos but only honors a
+    subset for getCustomEQ / setActiveEQ — the rest return 0x0B NOT_SUPPORTED.
+    This iterates 0..total-1 and records which slots actually have data.
+
+    Result is cached on `device._advanced_eq_working_slots` as a list of
+    `(slot_index, name, bands)` tuples. The HeadsetActiveEQPreset selector
+    builds its choices from this list; the HeadsetAdvancedEQ panel uses it
+    to skip dead slots in its diagnostic output.
+
+    Logs each working slot's bands at INFO and a summary line indicating
+    how many of the advertised slots are actually accessible.
+    """
+    cached = getattr(device, "_advanced_eq_working_slots", None)
+    if cached is not None:
+        return cached
+    if info is None:
+        info = getattr(device, "_advanced_eq_info", None) or get_advanced_eq_info(device)
+    if not info:
+        return []
+    ro_count = info.get("onboard_ro_preset_count", 0) or 0
+    custom_count = info.get("onboard_custom_preset_count", 0) or 0
+    total = ro_count + custom_count
+    if total == 0:
+        return []
+
+    def probe(slot):
+        bands = get_advanced_eq_params(device, direction=direction, slot=slot)
+        if bands is None:
+            return None
+        name = get_advanced_eq_friendly_name(device, direction=direction, slot=slot)
+        kind = "factory" if slot < ro_count else "custom"
+        logger.debug(
+            "AdvancedParaEQ %s preset slot=%d (dir=%d) name=%r: %s",
+            kind,
+            slot,
+            direction,
+            name,
+            [f"{_band_label(t, f)} {round(g, 2)}dB" for t, f, g in bands],
+        )
+        return (slot, name, bands)
+
+    working = []
+    # Slot 0 is canonical. If it fails the device is unusable; bail.
+    entry = probe(0)
+    if entry is None:
+        device._advanced_eq_working_slots = working
+        return working
+    working.append(entry)
+    # Slot 1 acts as a "multi-slot capable?" canary. G522 firmware
+    # advertises 16 slots but only honors slot 0; LGHUB itself never
+    # touches slots > 0 on this device. When the canary fails, skip the
+    # remaining 14 NOT_SUPPORTED probes.
+    if total > 1:
+        entry = probe(1)
+        if entry is None:
+            logger.debug(
+                "AdvancedParaEQ: slot 1 returned NOT_SUPPORTED; " "firmware advertises %d slots but only honors slot 0",
+                total,
+            )
+            device._advanced_eq_working_slots = working
+            return working
+        working.append(entry)
+        for slot in range(2, total):
+            entry = probe(slot)
+            if entry is not None:
+                working.append(entry)
+    device._advanced_eq_working_slots = working
+    logger.debug(
+        "AdvancedParaEQ working slots on dir=%d: %d of %d advertised %s",
+        direction,
+        len(working),
+        total,
+        [w[0] for w in working],
+    )
+    return working
+
+
+# Backward-compat alias kept until external callers are migrated.
+probe_all_presets = probe_advanced_eq_slots
+
+
+def get_advanced_eq_params(device, direction=DIRECTION_PLAYBACK, slot=0):
+    """Query getCustomEQ (function 1). Returns list of (filter_type, freq_hz, gain_db) or None.
+
+    V0/V1: filter_type is always FILTER_TYPE_PEAKING (synthesized), freq is
+    raw Hz from wire, gain is whole dB.
+    V2: filter_type comes from the wire (0x00=HP, 0x78=peaking), freq is raw
+    Hz, gain is int16 × step_db.
+
+    step_db for V2 is cached on the device by get_advanced_eq_info.
+    """
+    version = _get_version(device)
+    result = device.feature_request(SupportedFeature.HEADSET_ADVANCED_PARA_EQ, 0x10, direction, slot)
+    if result is None:
+        logger.debug(
+            "AdvancedParaEQ getCustomEQ V%d (dir=%d slot=%d): feature_request returned None",
+            version,
+            direction,
+            slot,
+        )
+        return None
+
+    if version >= 2:
+        info = getattr(device, "_advanced_eq_info", None)
+        if not info:
+            logger.warning("AdvancedParaEQ getCustomEQ V2: no cached getEQInfos — gain values will be wrong")
+        bands = parse_v2_bands(result, info)
+        if bands is None:
+            logger.debug(
+                "AdvancedParaEQ getCustomEQ V2 (dir=%d slot=%d): payload too short raw=%s",
+                direction,
+                slot,
+                result.hex(),
+            )
+            return None
+        step_db = info["step_db"] if info and "step_db" in info else 1.0
+        # Log raw=... too so we can compare wire shapes across firmware
+        # variants and across get-fns (getCustomEQ vs getEQDefaults).
+        logger.debug(
+            "AdvancedParaEQ getCustomEQ V2 (dir=%d slot=%d): %d band(s) step_db=%.4f raw=%s %s",
+            direction,
+            slot,
+            len(bands),
+            step_db,
+            result.hex(),
+            [f"{_band_label(t, f)} {round(g, 2)}dB" for t, f, g in bands],
+        )
+        return bands
+
+    # V0 / V1
+    bands = []
+    offset = 0
+    while offset + 3 <= len(result):
+        freq = struct.unpack(">H", result[offset : offset + 2])[0]
+        if freq == 0:
+            break
+        gain_db = struct.unpack("b", bytes([result[offset + 2]]))[0]
+        bands.append((FILTER_TYPE_PEAKING, freq, float(gain_db)))
+        offset += 3
+    logger.debug(
+        "AdvancedParaEQ getCustomEQ V%d (dir=%d slot=%d): parsed %d band(s) %s",
+        version,
+        direction,
+        slot,
+        len(bands),
+        bands,
+    )
+    return bands

--- a/lib/logitech_receiver/base.py
+++ b/lib/logitech_receiver/base.py
@@ -338,6 +338,46 @@ def _centurion_frame_header(state: CenturionHandleState, cpl_length: int, flags:
 
 _CENTURION_REPORT_IDS = (CENTURION_REPORT_ID, CENTURION_ADDRESSED_REPORT_ID)
 
+# Per-iteration read timeout (ms) and total iterations for the 0x50 probe below.
+_CENTURION_PROBE_READ_TIMEOUT_MS = 500
+_CENTURION_PROBE_READ_ITERATIONS = 3
+
+
+def probe_centurion_device_addr(handle, state: CenturionHandleState) -> bool:
+    """Probe the device address byte for a 0x50-variant Centurion handle.
+
+    Sends a 64-byte all-zero frame with the detected report ID and reads back
+    the first response. The device answers with an error/unsolicited frame
+    whose byte[1] holds its device address. Without this probe, the very first
+    real TX ships with device_addr=0x00, which stricter firmware silently
+    drops — breaking dongle feature discovery before it starts.
+
+    No-op for 0x51 (no device_addr byte) or when an address is already known.
+    Returns True if the address was learned.
+    """
+    if state.report_id != CENTURION_ADDRESSED_REPORT_ID or state.device_addr is not None:
+        return False
+    ihandle = int(handle)
+    probe = bytes([state.report_id]) + b"\x00" * (CENTURION_FRAME_SIZE - 1)
+    try:
+        hidapi.write(ihandle, probe)
+    except Exception as reason:
+        logger.warning("(%s) centurion device_addr probe write failed: %s", handle, reason)
+        return False
+    for _ in range(_CENTURION_PROBE_READ_ITERATIONS):
+        try:
+            data = hidapi.read(ihandle, CENTURION_FRAME_SIZE, _CENTURION_PROBE_READ_TIMEOUT_MS)
+        except Exception as reason:
+            logger.warning("(%s) centurion device_addr probe read failed: %s", handle, reason)
+            return False
+        if data and len(data) >= 2 and ord(data[:1]) == state.report_id:
+            state.device_addr = ord(data[1:2])
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug("(%s) probed centurion device addr 0x%02X", handle, state.device_addr)
+            return True
+    logger.warning("(%s) centurion device_addr probe timed out, subsequent TX will use 0x00", handle)
+    return False
+
 
 def _unwrap_centurion_frame(data: bytes, ihandle: int, handle) -> bytes:
     """Unwrap a Centurion CPL frame (0x50 or 0x51) into a standard HID++ long message.

--- a/lib/logitech_receiver/base.py
+++ b/lib/logitech_receiver/base.py
@@ -338,18 +338,19 @@ def _centurion_frame_header(state: CenturionHandleState, cpl_length: int, flags:
 
 _CENTURION_REPORT_IDS = (CENTURION_REPORT_ID, CENTURION_ADDRESSED_REPORT_ID)
 
-# Read timeout (ms) for the brute-force device_addr probe below.
-_CENTURION_PROBE_READ_TIMEOUT_MS = 500
-_CENTURION_PROBE_READ_ITERATIONS = 3
+# Per-candidate read timeout (ms) for the device_addr probe.
+# USB round-trip is <1ms; 20ms gives plenty of margin.
+_CENTURION_PROBE_PER_ADDR_TIMEOUT_MS = 20
 
 
 def probe_centurion_device_addr(handle, state: CenturionHandleState) -> bool:
     """Brute-force probe the device address byte for a 0x50-variant Centurion handle.
 
-    Sends a ROOT.GetProtocolVersion request for every possible device_addr
-    (0x00–0xFF). The dongle silently ignores wrong addresses and responds
-    only to the correct one. The response carries the real address at byte[1],
-    which we extract and store on the handle state.
+    Sends a ROOT.GetProtocolVersion request for each candidate device_addr
+    (0x00–0xFF), reading briefly after each write. The dongle silently ignores
+    wrong addresses and responds only to the correct one. Stops on first hit.
+
+    Worst case (addr=0xFF): 256 × 20ms = ~5s. Typical G522 (addr=0x23): ~0.7s.
 
     No-op for 0x51 (no device_addr byte) or when an address is already known.
     Returns True if the address was learned.
@@ -357,40 +358,35 @@ def probe_centurion_device_addr(handle, state: CenturionHandleState) -> bool:
     if state.report_id != CENTURION_ADDRESSED_REPORT_ID or state.device_addr is not None:
         return False
     ihandle = int(handle)
-    logger.info("(%s) probing centurion device_addr: brute-force 0x00-0xFF", handle)
+    logger.info("(%s) probing centurion device_addr: scanning 0x00-0xFF", handle)
 
     # ROOT.GetProtocolVersion: feat_idx=0x00, func=0x10, 3 zero param bytes
     payload = bytes([0x00, 0x10, 0x00, 0x00, 0x00])
     cpl_length = len(payload) + 1  # +1 for flags byte
-    write_failed = 0
+    write_errors = 0
 
-    # Send a ROOT query for every possible device_addr (256 frames).
-    # The dongle ignores frames with the wrong address. Only the matching
-    # one produces a response that we can read back.
     for addr in range(256):
         frame = struct.pack("!BBBB", CENTURION_ADDRESSED_REPORT_ID, addr, cpl_length, 0x00) + payload
         frame = frame + b"\x00" * (CENTURION_FRAME_SIZE - len(frame))
         try:
             hidapi.write(ihandle, frame)
         except Exception:
-            write_failed += 1
-            if write_failed > 3:
+            write_errors += 1
+            if write_errors > 3:
                 logger.warning("(%s) centurion device_addr probe: too many write failures, aborting", handle)
                 return False
-
-    # Read back the response — dongle only replied to the correct address.
-    for _attempt in range(_CENTURION_PROBE_READ_ITERATIONS):
+            continue
         try:
-            data = hidapi.read(ihandle, CENTURION_FRAME_SIZE, _CENTURION_PROBE_READ_TIMEOUT_MS)
+            data = hidapi.read(ihandle, CENTURION_FRAME_SIZE, _CENTURION_PROBE_PER_ADDR_TIMEOUT_MS)
         except Exception as reason:
             logger.warning("(%s) centurion device_addr probe read failed: %s", handle, reason)
             return False
         if data and len(data) >= 2 and ord(data[:1]) == state.report_id:
             state.device_addr = ord(data[1:2])
-            logger.info("(%s) probed centurion device addr 0x%02X", handle, state.device_addr)
+            logger.info("(%s) probed centurion device addr 0x%02X (after %d candidates)", handle, state.device_addr, addr + 1)
             return True
 
-    logger.warning("(%s) centurion device_addr brute-force probe got no response", handle)
+    logger.warning("(%s) centurion device_addr probe: no response from any of 256 candidates", handle)
     return False
 
 

--- a/lib/logitech_receiver/base.py
+++ b/lib/logitech_receiver/base.py
@@ -338,19 +338,18 @@ def _centurion_frame_header(state: CenturionHandleState, cpl_length: int, flags:
 
 _CENTURION_REPORT_IDS = (CENTURION_REPORT_ID, CENTURION_ADDRESSED_REPORT_ID)
 
-# Per-iteration read timeout (ms) and total iterations for the 0x50 probe below.
+# Read timeout (ms) for the brute-force device_addr probe below.
 _CENTURION_PROBE_READ_TIMEOUT_MS = 500
 _CENTURION_PROBE_READ_ITERATIONS = 3
 
 
 def probe_centurion_device_addr(handle, state: CenturionHandleState) -> bool:
-    """Probe the device address byte for a 0x50-variant Centurion handle.
+    """Brute-force probe the device address byte for a 0x50-variant Centurion handle.
 
-    Sends a 64-byte all-zero frame with the detected report ID and reads back
-    the first response. The device answers with an error/unsolicited frame
-    whose byte[1] holds its device address. Without this probe, the very first
-    real TX ships with device_addr=0x00, which stricter firmware silently
-    drops — breaking dongle feature discovery before it starts.
+    Sends a ROOT.GetProtocolVersion request for every possible device_addr
+    (0x00–0xFF). The dongle silently ignores wrong addresses and responds
+    only to the correct one. The response carries the real address at byte[1],
+    which we extract and store on the handle state.
 
     No-op for 0x51 (no device_addr byte) or when an address is already known.
     Returns True if the address was learned.
@@ -358,58 +357,40 @@ def probe_centurion_device_addr(handle, state: CenturionHandleState) -> bool:
     if state.report_id != CENTURION_ADDRESSED_REPORT_ID or state.device_addr is not None:
         return False
     ihandle = int(handle)
-    if logger.isEnabledFor(logging.DEBUG):
-        logger.debug(
-            "(%s) probing centurion device_addr (report_id=0x%02X, %d iters x %d ms)",
-            handle,
-            state.report_id,
-            _CENTURION_PROBE_READ_ITERATIONS,
-            _CENTURION_PROBE_READ_TIMEOUT_MS,
-        )
-    probe = bytes([state.report_id]) + b"\x00" * (CENTURION_FRAME_SIZE - 1)
-    try:
-        hidapi.write(ihandle, probe)
-    except Exception as reason:
-        logger.warning("(%s) centurion device_addr probe write failed: %s", handle, reason)
-        return False
-    for attempt in range(1, _CENTURION_PROBE_READ_ITERATIONS + 1):
+    logger.info("(%s) probing centurion device_addr: brute-force 0x00-0xFF", handle)
+
+    # ROOT.GetProtocolVersion: feat_idx=0x00, func=0x10, 3 zero param bytes
+    payload = bytes([0x00, 0x10, 0x00, 0x00, 0x00])
+    cpl_length = len(payload) + 1  # +1 for flags byte
+    write_failed = 0
+
+    # Send a ROOT query for every possible device_addr (256 frames).
+    # The dongle ignores frames with the wrong address. Only the matching
+    # one produces a response that we can read back.
+    for addr in range(256):
+        frame = struct.pack("!BBBB", CENTURION_ADDRESSED_REPORT_ID, addr, cpl_length, 0x00) + payload
+        frame = frame + b"\x00" * (CENTURION_FRAME_SIZE - len(frame))
+        try:
+            hidapi.write(ihandle, frame)
+        except Exception:
+            write_failed += 1
+            if write_failed > 3:
+                logger.warning("(%s) centurion device_addr probe: too many write failures, aborting", handle)
+                return False
+
+    # Read back the response — dongle only replied to the correct address.
+    for _attempt in range(_CENTURION_PROBE_READ_ITERATIONS):
         try:
             data = hidapi.read(ihandle, CENTURION_FRAME_SIZE, _CENTURION_PROBE_READ_TIMEOUT_MS)
         except Exception as reason:
             logger.warning("(%s) centurion device_addr probe read failed: %s", handle, reason)
             return False
-        if logger.isEnabledFor(logging.DEBUG):
-            if data:
-                logger.debug(
-                    "(%s) centurion probe attempt %d/%d: got %d bytes, head=%s",
-                    handle,
-                    attempt,
-                    _CENTURION_PROBE_READ_ITERATIONS,
-                    len(data),
-                    common.strhex(data[:4]) if len(data) >= 4 else common.strhex(data),
-                )
-            else:
-                logger.debug(
-                    "(%s) centurion probe attempt %d/%d: read timeout (no data)",
-                    handle,
-                    attempt,
-                    _CENTURION_PROBE_READ_ITERATIONS,
-                )
         if data and len(data) >= 2 and ord(data[:1]) == state.report_id:
             state.device_addr = ord(data[1:2])
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(
-                    "(%s) probed centurion device addr 0x%02X on attempt %d",
-                    handle,
-                    state.device_addr,
-                    attempt,
-                )
+            logger.info("(%s) probed centurion device addr 0x%02X", handle, state.device_addr)
             return True
-    logger.warning(
-        "(%s) centurion device_addr probe timed out after %d attempts, subsequent TX will use 0x00",
-        handle,
-        _CENTURION_PROBE_READ_ITERATIONS,
-    )
+
+    logger.warning("(%s) centurion device_addr brute-force probe got no response", handle)
     return False
 
 

--- a/lib/logitech_receiver/base.py
+++ b/lib/logitech_receiver/base.py
@@ -97,18 +97,30 @@ HIDPP_LONG_MESSAGE_ID = 0x11
 DJ_MESSAGE_ID = 0x20
 
 # Centurion transport (used by PRO X 2 LIGHTSPEED headset and similar)
-# Uses report ID 0x51 on usage page 0xFFA0, 64-byte frames.
-# Wire format (CPL): [0x51, cpl_length, flags=0x00, feat_idx, func_sw, params..., pad]
+# Two variants exist, distinguished by report ID:
+#   0x51 (PRO X 2): [0x51, cpl_length, flags, feat_idx, func_sw, params..., pad]
+#   0x50 (G522):    [0x50, device_addr, cpl_length, flags, feat_idx, func_sw, params..., pad]
+# The 0x50 variant adds a device_addr byte at position [1], shifting all CPL fields by +1.
 # cpl_length = number of bytes from flags to end of meaningful data (includes flags byte).
 # The device_index byte from standard HID++ is NOT present in Centurion framing.
 CENTURION_REPORT_ID = 0x51
+CENTURION_ADDRESSED_REPORT_ID = 0x50  # addressed variant with device_addr byte at frame[1] (G522 etc.)
 CENTURION_FRAME_SIZE = 64  # 1 byte report ID + 63 bytes payload
 _CENTURION_MSG_SIZE = 63  # max reconstructed message size after unwrapping (2 + 61 payload bytes)
 
-# Set of handles that use Centurion framing
-_centurion_handles: set[int] = set()
-# Raw Centurion protocol version (major, minor) by handle, from ping response
-_centurion_protocol_versions: dict[int, tuple[int, int]] = {}
+
+@dataclasses.dataclass
+class CenturionHandleState:
+    """Per-handle state for Centurion devices."""
+
+    report_id: int = CENTURION_REPORT_ID  # 0x50 or 0x51
+    device_addr: int | None = None  # learned from first RX (0x50 only)
+    protocol_version: tuple[int, int] | None = None  # from ping response
+
+
+# All centurion per-handle state in a single dict.
+# Membership test (ihandle in _centurion_handles) gates centurion-specific code paths.
+_centurion_handles: dict[int, CenturionHandleState] = {}
 
 
 """Default timeout on read (in seconds)."""
@@ -301,8 +313,7 @@ def close(handle):
     if handle:
         try:
             if isinstance(handle, int):
-                _centurion_handles.discard(handle)
-                _centurion_protocol_versions.pop(handle, None)
+                _centurion_handles.pop(handle, None)
                 hidapi.close(handle)
             else:
                 handle.close()
@@ -311,6 +322,58 @@ def close(handle):
             pass
 
     return False
+
+
+def _centurion_frame_header(state: CenturionHandleState, cpl_length: int, flags: int) -> bytes:
+    """Build the fixed prefix of a centurion frame.
+
+    0x51: [0x51, cpl_length, flags]           (3 bytes)
+    0x50: [0x50, device_addr, cpl_length, flags]  (4 bytes)
+    """
+    if state.report_id == CENTURION_ADDRESSED_REPORT_ID:
+        device_addr = state.device_addr if state.device_addr is not None else 0x00
+        return struct.pack("!BBBB", CENTURION_ADDRESSED_REPORT_ID, device_addr, cpl_length, flags)
+    return struct.pack("!BBB", CENTURION_REPORT_ID, cpl_length, flags)
+
+
+_CENTURION_REPORT_IDS = (CENTURION_REPORT_ID, CENTURION_ADDRESSED_REPORT_ID)
+
+
+def _unwrap_centurion_frame(data: bytes, ihandle: int, handle) -> bytes:
+    """Unwrap a Centurion CPL frame (0x50 or 0x51) into a standard HID++ long message.
+
+    Auto-detects the variant from the raw report ID byte (self-describing),
+    matching how _read() handles 0x10 vs 0x11.
+
+    For 0x50, learns the device address from byte[1] on first receive.
+    """
+    raw_report_id = ord(data[:1])
+    if raw_report_id == CENTURION_ADDRESSED_REPORT_ID:
+        # 0x50: [report_id, device_addr, cpl_length, flags, feat_idx, func_sw, data...]
+        device_addr = ord(data[1:2])
+        state = _centurion_handles.get(ihandle)
+        if state is not None and state.device_addr is None:
+            state.device_addr = device_addr
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug("(%s) learned centurion device addr 0x%02X", handle, device_addr)
+        cpl_length = ord(data[2:3])
+        inner_payload = data[4 : 3 + cpl_length]  # cpl_length - 1 bytes (skip flags)
+    elif raw_report_id == CENTURION_REPORT_ID:
+        # 0x51: [report_id, cpl_length, flags, feat_idx, func_sw, data...]
+        cpl_length = ord(data[1:2])
+        inner_payload = data[3 : 2 + cpl_length]  # cpl_length - 1 bytes (skip flags)
+    else:
+        return data  # not a centurion frame
+
+    data = bytes([HIDPP_LONG_MESSAGE_ID, 0xFF]) + inner_payload
+    # Pad to a valid message size: standard long (20) or Centurion extended (63)
+    if len(data) <= _LONG_MESSAGE_SIZE:
+        data = data + b"\x00" * (_LONG_MESSAGE_SIZE - len(data))
+    elif len(data) <= _CENTURION_MSG_SIZE:
+        data = data + b"\x00" * (_CENTURION_MSG_SIZE - len(data))
+    else:
+        data = data[:_CENTURION_MSG_SIZE]
+    return data
 
 
 def write(handle, devnumber, data, long_message=False):
@@ -337,12 +400,12 @@ def write(handle, devnumber, data, long_message=False):
 
     ihandle = int(handle)
     if ihandle in _centurion_handles:
-        # Centurion CPL framing: [0x51, cpl_length, flags=0x00, feat_idx, func_sw, params...]
-        # cpl_length = len(meaningful_payload) + 1 (the +1 counts the flags byte)
-        # The device_index is stripped — only the HID++ payload (feat_idx + func_sw + params) remains.
+        # Centurion CPL framing — strip device_index from HID++ and wrap in CPL header.
+        # cpl_length = len(meaningful_payload) + 1 (the +1 counts the flags byte).
+        state = _centurion_handles[ihandle]
         payload = wdata[2:]  # skip report_id and devnumber from standard frame
         cpl_length = len(data) + 1  # data is the unpadded payload; +1 for flags byte
-        wdata = struct.pack("!BBB", CENTURION_REPORT_ID, cpl_length, 0x00) + payload
+        wdata = _centurion_frame_header(state, cpl_length, 0x00) + payload
         wdata = wdata + b"\x00" * (CENTURION_FRAME_SIZE - len(wdata))
 
     if logger.isEnabledFor(logging.DEBUG):
@@ -366,7 +429,9 @@ def write(handle, devnumber, data, long_message=False):
 def write_centurion_cpl(handle, layer3_payload, flags=0x00):
     """Send a Centurion CPL frame with the given Layer 3+ payload.
 
-    Builds: [0x51, cpl_length, flags, layer3_payload..., zero-pad to 64 bytes]
+    Builds the appropriate header for the handle's report ID variant:
+      0x51: [0x51, cpl_length, flags, layer3_payload..., pad to 64]
+      0x50: [0x50, device_addr, cpl_length, flags, layer3_payload..., pad to 64]
     where cpl_length = len(layer3_payload) + 1 (the +1 counts the flags byte).
 
     For multi-fragment sends, flags encodes fragment index and continuation:
@@ -376,11 +441,13 @@ def write_centurion_cpl(handle, layer3_payload, flags=0x00):
     ihandle = int(handle)
     if ihandle not in _centurion_handles:
         raise ValueError("write_centurion_cpl called on non-Centurion handle")
+    state = _centurion_handles[ihandle]
     cpl_length = len(layer3_payload) + 1  # +1 for flags byte
-    wdata = struct.pack("!BBB", CENTURION_REPORT_ID, cpl_length, flags) + layer3_payload
+    header = _centurion_frame_header(state, cpl_length, flags)
+    wdata = header + layer3_payload
     wdata = wdata + b"\x00" * (CENTURION_FRAME_SIZE - len(wdata))
     if logger.isEnabledFor(logging.DEBUG):
-        logger.debug("(%s) <= centurion_cpl[%s]", handle, common.strhex(wdata[: cpl_length + 2]))
+        logger.debug("(%s) <= centurion_cpl[%s]", handle, common.strhex(wdata[: len(header) + cpl_length - 1]))
     try:
         hidapi.write(ihandle, wdata)
     except Exception as reason:
@@ -452,22 +519,8 @@ def _read(handle, timeout) -> tuple[int, int, bytes]:
         close(handle)
         raise exceptions.NoReceiver(reason=reason) from reason
 
-    if data and is_centurion and ord(data[:1]) == CENTURION_REPORT_ID:
-        # Unwrap Centurion CPL framing:
-        # RX: [0x51, cpl_length, flags=0x00, feat_idx, func_sw, data...]
-        # cpl_length includes the flags byte, so meaningful payload starts at byte 3
-        # and has (cpl_length - 1) bytes.
-        # Reconstruct as HID++ long message: [0x11, devnumber=0xFF, feat_idx, func_sw, data...]
-        cpl_length = ord(data[1:2])
-        inner_payload = data[3 : 2 + cpl_length]  # bytes 3..2+cpl_length-1 = cpl_length-1 bytes
-        data = bytes([HIDPP_LONG_MESSAGE_ID, 0xFF]) + inner_payload
-        # Pad to a valid message size: standard long (20) or Centurion extended (63)
-        if len(data) <= _LONG_MESSAGE_SIZE:
-            data = data + b"\x00" * (_LONG_MESSAGE_SIZE - len(data))
-        elif len(data) <= _CENTURION_MSG_SIZE:
-            data = data + b"\x00" * (_CENTURION_MSG_SIZE - len(data))
-        else:
-            data = data[:_CENTURION_MSG_SIZE]
+    if data and is_centurion and ord(data[:1]) in _CENTURION_REPORT_IDS:
+        data = _unwrap_centurion_frame(data, ihandle, handle)
 
     if data and _is_relevant_message(data):  # ignore messages that fail check
         report_id = ord(data[:1])
@@ -725,7 +778,7 @@ def ping(handle, devnumber, long_message: bool = False):
                         major = ord(reply_data[2:3])
                         minor = ord(reply_data[3:4])
                         if is_centurion:
-                            _centurion_protocol_versions[int(handle)] = (major, minor)
+                            _centurion_handles[int(handle)].protocol_version = (major, minor)
                         return major + minor / 10.0
 
                     if (
@@ -771,17 +824,8 @@ def _read_input_buffer(handle, ihandle, notifications_hook):
             raise exceptions.NoReceiver(reason=reason) from reason
 
         if data:
-            if is_centurion and ord(data[:1]) == CENTURION_REPORT_ID:
-                # Unwrap Centurion CPL framing same as in _read()
-                cpl_length = ord(data[1:2])
-                inner_payload = data[3 : 2 + cpl_length]
-                data = bytes([HIDPP_LONG_MESSAGE_ID, 0xFF]) + inner_payload
-                if len(data) <= _LONG_MESSAGE_SIZE:
-                    data = data + b"\x00" * (_LONG_MESSAGE_SIZE - len(data))
-                elif len(data) <= _CENTURION_MSG_SIZE:
-                    data = data + b"\x00" * (_CENTURION_MSG_SIZE - len(data))
-                else:
-                    data = data[:_CENTURION_MSG_SIZE]
+            if is_centurion and ord(data[:1]) in _CENTURION_REPORT_IDS:
+                data = _unwrap_centurion_frame(data, ihandle, handle)
             if _is_relevant_message(data):  # only process messages that pass check
                 # report_id = ord(data[:1])
                 if notifications_hook:

--- a/lib/logitech_receiver/base.py
+++ b/lib/logitech_receiver/base.py
@@ -358,24 +358,58 @@ def probe_centurion_device_addr(handle, state: CenturionHandleState) -> bool:
     if state.report_id != CENTURION_ADDRESSED_REPORT_ID or state.device_addr is not None:
         return False
     ihandle = int(handle)
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            "(%s) probing centurion device_addr (report_id=0x%02X, %d iters x %d ms)",
+            handle,
+            state.report_id,
+            _CENTURION_PROBE_READ_ITERATIONS,
+            _CENTURION_PROBE_READ_TIMEOUT_MS,
+        )
     probe = bytes([state.report_id]) + b"\x00" * (CENTURION_FRAME_SIZE - 1)
     try:
         hidapi.write(ihandle, probe)
     except Exception as reason:
         logger.warning("(%s) centurion device_addr probe write failed: %s", handle, reason)
         return False
-    for _ in range(_CENTURION_PROBE_READ_ITERATIONS):
+    for attempt in range(1, _CENTURION_PROBE_READ_ITERATIONS + 1):
         try:
             data = hidapi.read(ihandle, CENTURION_FRAME_SIZE, _CENTURION_PROBE_READ_TIMEOUT_MS)
         except Exception as reason:
             logger.warning("(%s) centurion device_addr probe read failed: %s", handle, reason)
             return False
+        if logger.isEnabledFor(logging.DEBUG):
+            if data:
+                logger.debug(
+                    "(%s) centurion probe attempt %d/%d: got %d bytes, head=%s",
+                    handle,
+                    attempt,
+                    _CENTURION_PROBE_READ_ITERATIONS,
+                    len(data),
+                    common.strhex(data[:4]) if len(data) >= 4 else common.strhex(data),
+                )
+            else:
+                logger.debug(
+                    "(%s) centurion probe attempt %d/%d: read timeout (no data)",
+                    handle,
+                    attempt,
+                    _CENTURION_PROBE_READ_ITERATIONS,
+                )
         if data and len(data) >= 2 and ord(data[:1]) == state.report_id:
             state.device_addr = ord(data[1:2])
             if logger.isEnabledFor(logging.DEBUG):
-                logger.debug("(%s) probed centurion device addr 0x%02X", handle, state.device_addr)
+                logger.debug(
+                    "(%s) probed centurion device addr 0x%02X on attempt %d",
+                    handle,
+                    state.device_addr,
+                    attempt,
+                )
             return True
-    logger.warning("(%s) centurion device_addr probe timed out, subsequent TX will use 0x00", handle)
+    logger.warning(
+        "(%s) centurion device_addr probe timed out after %d attempts, subsequent TX will use 0x00",
+        handle,
+        _CENTURION_PROBE_READ_ITERATIONS,
+    )
     return False
 
 

--- a/lib/logitech_receiver/base.py
+++ b/lib/logitech_receiver/base.py
@@ -339,8 +339,8 @@ def _centurion_frame_header(state: CenturionHandleState, cpl_length: int, flags:
 _CENTURION_REPORT_IDS = (CENTURION_REPORT_ID, CENTURION_ADDRESSED_REPORT_ID)
 
 # Per-candidate read timeout (ms) for the device_addr probe.
-# USB round-trip is <1ms; 20ms gives plenty of margin.
-_CENTURION_PROBE_PER_ADDR_TIMEOUT_MS = 20
+# USB round-trip is <1ms; 5ms gives 5x margin.
+_CENTURION_PROBE_PER_ADDR_TIMEOUT_MS = 5
 
 
 def probe_centurion_device_addr(handle, state: CenturionHandleState) -> bool:
@@ -348,25 +348,23 @@ def probe_centurion_device_addr(handle, state: CenturionHandleState) -> bool:
 
     Sends a ROOT.GetProtocolVersion request for each candidate device_addr
     (0x00–0xFF), reading briefly after each write. The dongle silently ignores
-    wrong addresses and responds only to the correct one.
+    wrong addresses and responds only to the correct one. Stops on first hit.
 
-    Sweeps ALL 256 candidates and logs every address that responds, so we can
-    discover special addresses (broadcast, etc.) during initial field testing.
-    Uses the first responding address as the device_addr.
+    Worst case (no response): 256 × 5ms = ~1.3s.
+    Typical G522 (addr=0x23): 36 × 5ms = ~180ms.
 
     No-op for 0x51 (no device_addr byte) or when an address is already known.
-    Returns True if at least one address responded.
+    Returns True if the address was learned.
     """
     if state.report_id != CENTURION_ADDRESSED_REPORT_ID or state.device_addr is not None:
         return False
     ihandle = int(handle)
-    logger.info("(%s) probing centurion device_addr: full sweep 0x00-0xFF", handle)
+    logger.info("(%s) probing centurion device_addr: scanning 0x00-0xFF", handle)
 
     # ROOT.GetProtocolVersion: feat_idx=0x00, func=0x10, 3 zero param bytes
     payload = bytes([0x00, 0x10, 0x00, 0x00, 0x00])
     cpl_length = len(payload) + 1  # +1 for flags byte
     write_errors = 0
-    responding_addrs = []
 
     for addr in range(256):
         frame = struct.pack("!BBBB", CENTURION_ADDRESSED_REPORT_ID, addr, cpl_length, 0x00) + payload
@@ -377,30 +375,24 @@ def probe_centurion_device_addr(handle, state: CenturionHandleState) -> bool:
             write_errors += 1
             if write_errors > 3:
                 logger.warning("(%s) centurion device_addr probe: too many write failures, aborting", handle)
-                break
+                return False
             continue
         try:
             data = hidapi.read(ihandle, CENTURION_FRAME_SIZE, _CENTURION_PROBE_PER_ADDR_TIMEOUT_MS)
         except Exception as reason:
             logger.warning("(%s) centurion device_addr probe read failed at addr 0x%02X: %s", handle, addr, reason)
-            break
+            return False
         if data and len(data) >= 2 and ord(data[:1]) == state.report_id:
-            resp_addr = ord(data[1:2])
-            responding_addrs.append((addr, resp_addr, common.strhex(data[:8])))
-            if state.device_addr is None:
-                state.device_addr = resp_addr
+            state.device_addr = ord(data[1:2])
+            logger.info(
+                "(%s) probed centurion device addr 0x%02X (after %d candidates)",
+                handle,
+                state.device_addr,
+                addr + 1,
+            )
+            return True
 
-    logger.info(
-        "(%s) centurion device_addr probe complete: %d responding, results=%s",
-        handle,
-        len(responding_addrs),
-        responding_addrs,
-    )
-    if state.device_addr is not None:
-        logger.info("(%s) using centurion device addr 0x%02X", handle, state.device_addr)
-        return True
-
-    logger.warning("(%s) centurion device_addr probe: no response from any candidate", handle)
+    logger.warning("(%s) centurion device_addr probe: no response from any of 256 candidates", handle)
     return False
 
 

--- a/lib/logitech_receiver/base.py
+++ b/lib/logitech_receiver/base.py
@@ -348,22 +348,25 @@ def probe_centurion_device_addr(handle, state: CenturionHandleState) -> bool:
 
     Sends a ROOT.GetProtocolVersion request for each candidate device_addr
     (0x00–0xFF), reading briefly after each write. The dongle silently ignores
-    wrong addresses and responds only to the correct one. Stops on first hit.
+    wrong addresses and responds only to the correct one.
 
-    Worst case (addr=0xFF): 256 × 20ms = ~5s. Typical G522 (addr=0x23): ~0.7s.
+    Sweeps ALL 256 candidates and logs every address that responds, so we can
+    discover special addresses (broadcast, etc.) during initial field testing.
+    Uses the first responding address as the device_addr.
 
     No-op for 0x51 (no device_addr byte) or when an address is already known.
-    Returns True if the address was learned.
+    Returns True if at least one address responded.
     """
     if state.report_id != CENTURION_ADDRESSED_REPORT_ID or state.device_addr is not None:
         return False
     ihandle = int(handle)
-    logger.info("(%s) probing centurion device_addr: scanning 0x00-0xFF", handle)
+    logger.info("(%s) probing centurion device_addr: full sweep 0x00-0xFF", handle)
 
     # ROOT.GetProtocolVersion: feat_idx=0x00, func=0x10, 3 zero param bytes
     payload = bytes([0x00, 0x10, 0x00, 0x00, 0x00])
     cpl_length = len(payload) + 1  # +1 for flags byte
     write_errors = 0
+    responding_addrs = []
 
     for addr in range(256):
         frame = struct.pack("!BBBB", CENTURION_ADDRESSED_REPORT_ID, addr, cpl_length, 0x00) + payload
@@ -374,19 +377,30 @@ def probe_centurion_device_addr(handle, state: CenturionHandleState) -> bool:
             write_errors += 1
             if write_errors > 3:
                 logger.warning("(%s) centurion device_addr probe: too many write failures, aborting", handle)
-                return False
+                break
             continue
         try:
             data = hidapi.read(ihandle, CENTURION_FRAME_SIZE, _CENTURION_PROBE_PER_ADDR_TIMEOUT_MS)
         except Exception as reason:
-            logger.warning("(%s) centurion device_addr probe read failed: %s", handle, reason)
-            return False
+            logger.warning("(%s) centurion device_addr probe read failed at addr 0x%02X: %s", handle, addr, reason)
+            break
         if data and len(data) >= 2 and ord(data[:1]) == state.report_id:
-            state.device_addr = ord(data[1:2])
-            logger.info("(%s) probed centurion device addr 0x%02X (after %d candidates)", handle, state.device_addr, addr + 1)
-            return True
+            resp_addr = ord(data[1:2])
+            responding_addrs.append((addr, resp_addr, common.strhex(data[:8])))
+            if state.device_addr is None:
+                state.device_addr = resp_addr
 
-    logger.warning("(%s) centurion device_addr probe: no response from any of 256 candidates", handle)
+    logger.info(
+        "(%s) centurion device_addr probe complete: %d responding, results=%s",
+        handle,
+        len(responding_addrs),
+        responding_addrs,
+    )
+    if state.device_addr is not None:
+        logger.info("(%s) using centurion device addr 0x%02X", handle, state.device_addr)
+        return True
+
+    logger.warning("(%s) centurion device_addr probe: no response from any candidate", handle)
     return False
 
 

--- a/lib/logitech_receiver/base.py
+++ b/lib/logitech_receiver/base.py
@@ -97,18 +97,30 @@ HIDPP_LONG_MESSAGE_ID = 0x11
 DJ_MESSAGE_ID = 0x20
 
 # Centurion transport (used by PRO X 2 LIGHTSPEED headset and similar)
-# Uses report ID 0x51 on usage page 0xFFA0, 64-byte frames.
-# Wire format (CPL): [0x51, cpl_length, flags=0x00, feat_idx, func_sw, params..., pad]
+# Two variants exist, distinguished by report ID:
+#   0x51 (PRO X 2): [0x51, cpl_length, flags, feat_idx, func_sw, params..., pad]
+#   0x50 (G522):    [0x50, device_addr, cpl_length, flags, feat_idx, func_sw, params..., pad]
+# The 0x50 variant adds a device_addr byte at position [1], shifting all CPL fields by +1.
 # cpl_length = number of bytes from flags to end of meaningful data (includes flags byte).
 # The device_index byte from standard HID++ is NOT present in Centurion framing.
 CENTURION_REPORT_ID = 0x51
+CENTURION_ADDRESSED_REPORT_ID = 0x50  # addressed variant with device_addr byte at frame[1] (G522 etc.)
 CENTURION_FRAME_SIZE = 64  # 1 byte report ID + 63 bytes payload
 _CENTURION_MSG_SIZE = 63  # max reconstructed message size after unwrapping (2 + 61 payload bytes)
 
-# Set of handles that use Centurion framing
-_centurion_handles: set[int] = set()
-# Raw Centurion protocol version (major, minor) by handle, from ping response
-_centurion_protocol_versions: dict[int, tuple[int, int]] = {}
+
+@dataclasses.dataclass
+class CenturionHandleState:
+    """Per-handle state for Centurion devices."""
+
+    report_id: int = CENTURION_REPORT_ID  # 0x50 or 0x51
+    device_addr: int | None = None  # learned from first RX (0x50 only)
+    protocol_version: tuple[int, int] | None = None  # from ping response
+
+
+# All centurion per-handle state in a single dict.
+# Membership test (ihandle in _centurion_handles) gates centurion-specific code paths.
+_centurion_handles: dict[int, CenturionHandleState] = {}
 
 
 """Default timeout on read (in seconds)."""
@@ -301,8 +313,7 @@ def close(handle):
     if handle:
         try:
             if isinstance(handle, int):
-                _centurion_handles.discard(handle)
-                _centurion_protocol_versions.pop(handle, None)
+                _centurion_handles.pop(handle, None)
                 hidapi.close(handle)
             else:
                 handle.close()
@@ -311,6 +322,115 @@ def close(handle):
             pass
 
     return False
+
+
+def _centurion_frame_header(state: CenturionHandleState, cpl_length: int, flags: int) -> bytes:
+    """Build the fixed prefix of a centurion frame.
+
+    0x51: [0x51, cpl_length, flags]           (3 bytes)
+    0x50: [0x50, device_addr, cpl_length, flags]  (4 bytes)
+    """
+    if state.report_id == CENTURION_ADDRESSED_REPORT_ID:
+        device_addr = state.device_addr if state.device_addr is not None else 0x00
+        return struct.pack("!BBBB", CENTURION_ADDRESSED_REPORT_ID, device_addr, cpl_length, flags)
+    return struct.pack("!BBB", CENTURION_REPORT_ID, cpl_length, flags)
+
+
+_CENTURION_REPORT_IDS = (CENTURION_REPORT_ID, CENTURION_ADDRESSED_REPORT_ID)
+
+# Per-candidate read timeout (ms) for the device_addr probe.
+# USB round-trip is <1ms; 5ms gives 5x margin.
+_CENTURION_PROBE_PER_ADDR_TIMEOUT_MS = 5
+
+
+def probe_centurion_device_addr(handle, state: CenturionHandleState) -> bool:
+    """Brute-force probe the device address byte for a 0x50-variant Centurion handle.
+
+    Sends a ROOT.GetProtocolVersion request for each candidate device_addr
+    (0x00–0xFF), reading briefly after each write. The dongle silently ignores
+    wrong addresses and responds only to the correct one. Stops on first hit.
+
+    Worst case (no response): 256 × 5ms = ~1.3s.
+    Typical G522 (addr=0x23): 36 × 5ms = ~180ms.
+
+    No-op for 0x51 (no device_addr byte) or when an address is already known.
+    Returns True if the address was learned.
+    """
+    if state.report_id != CENTURION_ADDRESSED_REPORT_ID or state.device_addr is not None:
+        return False
+    ihandle = int(handle)
+    logger.debug("(%s) probing centurion device_addr: scanning 0x00-0xFF", handle)
+
+    # ROOT.GetProtocolVersion: feat_idx=0x00, func=0x10, 3 zero param bytes
+    payload = bytes([0x00, 0x10, 0x00, 0x00, 0x00])
+    cpl_length = len(payload) + 1  # +1 for flags byte
+    write_errors = 0
+
+    for addr in range(256):
+        frame = struct.pack("!BBBB", CENTURION_ADDRESSED_REPORT_ID, addr, cpl_length, 0x00) + payload
+        frame = frame + b"\x00" * (CENTURION_FRAME_SIZE - len(frame))
+        try:
+            hidapi.write(ihandle, frame)
+        except Exception:
+            write_errors += 1
+            if write_errors > 3:
+                logger.debug("(%s) centurion device_addr probe: too many write failures, aborting", handle)
+                return False
+            continue
+        try:
+            data = hidapi.read(ihandle, CENTURION_FRAME_SIZE, _CENTURION_PROBE_PER_ADDR_TIMEOUT_MS)
+        except Exception as reason:
+            logger.debug("(%s) centurion device_addr probe read failed at addr 0x%02X: %s", handle, addr, reason)
+            return False
+        if data and len(data) >= 2 and ord(data[:1]) == state.report_id:
+            state.device_addr = ord(data[1:2])
+            logger.debug(
+                "(%s) probed centurion device addr 0x%02X (after %d candidates)",
+                handle,
+                state.device_addr,
+                addr + 1,
+            )
+            return True
+
+    logger.debug("(%s) centurion device_addr probe: no response from any of 256 candidates", handle)
+    return False
+
+
+def _unwrap_centurion_frame(data: bytes, ihandle: int, handle) -> bytes:
+    """Unwrap a Centurion CPL frame (0x50 or 0x51) into a standard HID++ long message.
+
+    Auto-detects the variant from the raw report ID byte (self-describing),
+    matching how _read() handles 0x10 vs 0x11.
+
+    For 0x50, learns the device address from byte[1] on first receive.
+    """
+    raw_report_id = ord(data[:1])
+    if raw_report_id == CENTURION_ADDRESSED_REPORT_ID:
+        # 0x50: [report_id, device_addr, cpl_length, flags, feat_idx, func_sw, data...]
+        device_addr = ord(data[1:2])
+        state = _centurion_handles.get(ihandle)
+        if state is not None and state.device_addr is None:
+            state.device_addr = device_addr
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug("(%s) learned centurion device addr 0x%02X", handle, device_addr)
+        cpl_length = ord(data[2:3])
+        inner_payload = data[4 : 3 + cpl_length]  # cpl_length - 1 bytes (skip flags)
+    elif raw_report_id == CENTURION_REPORT_ID:
+        # 0x51: [report_id, cpl_length, flags, feat_idx, func_sw, data...]
+        cpl_length = ord(data[1:2])
+        inner_payload = data[3 : 2 + cpl_length]  # cpl_length - 1 bytes (skip flags)
+    else:
+        return data  # not a centurion frame
+
+    data = bytes([HIDPP_LONG_MESSAGE_ID, 0xFF]) + inner_payload
+    # Pad to a valid message size: standard long (20) or Centurion extended (63)
+    if len(data) <= _LONG_MESSAGE_SIZE:
+        data = data + b"\x00" * (_LONG_MESSAGE_SIZE - len(data))
+    elif len(data) <= _CENTURION_MSG_SIZE:
+        data = data + b"\x00" * (_CENTURION_MSG_SIZE - len(data))
+    else:
+        data = data[:_CENTURION_MSG_SIZE]
+    return data
 
 
 def write(handle, devnumber, data, long_message=False):
@@ -337,12 +457,12 @@ def write(handle, devnumber, data, long_message=False):
 
     ihandle = int(handle)
     if ihandle in _centurion_handles:
-        # Centurion CPL framing: [0x51, cpl_length, flags=0x00, feat_idx, func_sw, params...]
-        # cpl_length = len(meaningful_payload) + 1 (the +1 counts the flags byte)
-        # The device_index is stripped — only the HID++ payload (feat_idx + func_sw + params) remains.
+        # Centurion CPL framing — strip device_index from HID++ and wrap in CPL header.
+        # cpl_length = len(meaningful_payload) + 1 (the +1 counts the flags byte).
+        state = _centurion_handles[ihandle]
         payload = wdata[2:]  # skip report_id and devnumber from standard frame
         cpl_length = len(data) + 1  # data is the unpadded payload; +1 for flags byte
-        wdata = struct.pack("!BBB", CENTURION_REPORT_ID, cpl_length, 0x00) + payload
+        wdata = _centurion_frame_header(state, cpl_length, 0x00) + payload
         wdata = wdata + b"\x00" * (CENTURION_FRAME_SIZE - len(wdata))
 
     if logger.isEnabledFor(logging.DEBUG):
@@ -366,7 +486,9 @@ def write(handle, devnumber, data, long_message=False):
 def write_centurion_cpl(handle, layer3_payload, flags=0x00):
     """Send a Centurion CPL frame with the given Layer 3+ payload.
 
-    Builds: [0x51, cpl_length, flags, layer3_payload..., zero-pad to 64 bytes]
+    Builds the appropriate header for the handle's report ID variant:
+      0x51: [0x51, cpl_length, flags, layer3_payload..., pad to 64]
+      0x50: [0x50, device_addr, cpl_length, flags, layer3_payload..., pad to 64]
     where cpl_length = len(layer3_payload) + 1 (the +1 counts the flags byte).
 
     For multi-fragment sends, flags encodes fragment index and continuation:
@@ -376,11 +498,13 @@ def write_centurion_cpl(handle, layer3_payload, flags=0x00):
     ihandle = int(handle)
     if ihandle not in _centurion_handles:
         raise ValueError("write_centurion_cpl called on non-Centurion handle")
+    state = _centurion_handles[ihandle]
     cpl_length = len(layer3_payload) + 1  # +1 for flags byte
-    wdata = struct.pack("!BBB", CENTURION_REPORT_ID, cpl_length, flags) + layer3_payload
+    header = _centurion_frame_header(state, cpl_length, flags)
+    wdata = header + layer3_payload
     wdata = wdata + b"\x00" * (CENTURION_FRAME_SIZE - len(wdata))
     if logger.isEnabledFor(logging.DEBUG):
-        logger.debug("(%s) <= centurion_cpl[%s]", handle, common.strhex(wdata[: cpl_length + 2]))
+        logger.debug("(%s) <= centurion_cpl[%s]", handle, common.strhex(wdata[: len(header) + cpl_length - 1]))
     try:
         hidapi.write(ihandle, wdata)
     except Exception as reason:
@@ -452,22 +576,8 @@ def _read(handle, timeout) -> tuple[int, int, bytes]:
         close(handle)
         raise exceptions.NoReceiver(reason=reason) from reason
 
-    if data and is_centurion and ord(data[:1]) == CENTURION_REPORT_ID:
-        # Unwrap Centurion CPL framing:
-        # RX: [0x51, cpl_length, flags=0x00, feat_idx, func_sw, data...]
-        # cpl_length includes the flags byte, so meaningful payload starts at byte 3
-        # and has (cpl_length - 1) bytes.
-        # Reconstruct as HID++ long message: [0x11, devnumber=0xFF, feat_idx, func_sw, data...]
-        cpl_length = ord(data[1:2])
-        inner_payload = data[3 : 2 + cpl_length]  # bytes 3..2+cpl_length-1 = cpl_length-1 bytes
-        data = bytes([HIDPP_LONG_MESSAGE_ID, 0xFF]) + inner_payload
-        # Pad to a valid message size: standard long (20) or Centurion extended (63)
-        if len(data) <= _LONG_MESSAGE_SIZE:
-            data = data + b"\x00" * (_LONG_MESSAGE_SIZE - len(data))
-        elif len(data) <= _CENTURION_MSG_SIZE:
-            data = data + b"\x00" * (_CENTURION_MSG_SIZE - len(data))
-        else:
-            data = data[:_CENTURION_MSG_SIZE]
+    if data and is_centurion and ord(data[:1]) in _CENTURION_REPORT_IDS:
+        data = _unwrap_centurion_frame(data, ihandle, handle)
 
     if data and _is_relevant_message(data):  # ignore messages that fail check
         report_id = ord(data[:1])
@@ -725,7 +835,7 @@ def ping(handle, devnumber, long_message: bool = False):
                         major = ord(reply_data[2:3])
                         minor = ord(reply_data[3:4])
                         if is_centurion:
-                            _centurion_protocol_versions[int(handle)] = (major, minor)
+                            _centurion_handles[int(handle)].protocol_version = (major, minor)
                         return major + minor / 10.0
 
                     if (
@@ -771,17 +881,8 @@ def _read_input_buffer(handle, ihandle, notifications_hook):
             raise exceptions.NoReceiver(reason=reason) from reason
 
         if data:
-            if is_centurion and ord(data[:1]) == CENTURION_REPORT_ID:
-                # Unwrap Centurion CPL framing same as in _read()
-                cpl_length = ord(data[1:2])
-                inner_payload = data[3 : 2 + cpl_length]
-                data = bytes([HIDPP_LONG_MESSAGE_ID, 0xFF]) + inner_payload
-                if len(data) <= _LONG_MESSAGE_SIZE:
-                    data = data + b"\x00" * (_LONG_MESSAGE_SIZE - len(data))
-                elif len(data) <= _CENTURION_MSG_SIZE:
-                    data = data + b"\x00" * (_CENTURION_MSG_SIZE - len(data))
-                else:
-                    data = data[:_CENTURION_MSG_SIZE]
+            if is_centurion and ord(data[:1]) in _CENTURION_REPORT_IDS:
+                data = _unwrap_centurion_frame(data, ihandle, handle)
             if _is_relevant_message(data):  # only process messages that pass check
                 # report_id = ord(data[:1])
                 if notifications_hook:

--- a/lib/logitech_receiver/centurion.py
+++ b/lib/logitech_receiver/centurion.py
@@ -265,6 +265,7 @@ class CenturionReceiver:
         self._devices = {}
         self._firmware = None
         self._dongle_features = None  # independently probed dongle features
+        self._pending = False  # True when device_addr unknown; deferred init completes on first RX
         self.cleanups = []
 
         # Receiver identity
@@ -364,10 +365,62 @@ class CenturionReceiver:
             self._firmware = get_firmware_centurion(self)
         return self._firmware or ()
 
+    def _complete_deferred_init(self):
+        """Re-run feature discovery after device_addr has been learned.
+
+        Called once from the notification handler when the first 0x50 frame
+        arrives on a pending CenturionReceiver.
+        """
+        if not self._pending:
+            return False
+        self._pending = False
+        ihandle = int(self.handle)
+        state = base._centurion_handles.get(ihandle)
+        learned_addr = state.device_addr if state else None
+        logger.info(
+            "CenturionReceiver %s: completing deferred init (device_addr=0x%02X)",
+            self.path,
+            learned_addr or 0,
+        )
+
+        self._dongle_features = None
+        self._discover_dongle_features()
+        logger.info(
+            "CenturionReceiver %s: deferred discovery found %d feature(s): %s",
+            self.path,
+            len(self._dongle_features or []),
+            [(f"{feat_id:#06x}", idx) for _, feat_id, idx in (self._dongle_features or [])],
+        )
+
+        if self.serial is None:
+            try:
+                s = get_serial_centurion(self)
+                if s and s.strip() and s.strip().isprintable():
+                    self.serial = s.strip()
+            except Exception:
+                pass
+
+        has_bridge = any(feat_id == CenturionCoreFeature.CENT_PP_BRIDGE for _, feat_id, _ in (self._dongle_features or []))
+        if has_bridge:
+            self.notify_devices()
+            return True
+        logger.warning(
+            "CenturionReceiver %s: deferred init completed but no bridge found " "(features: %s)",
+            self.path,
+            [f"{feat_id:#06x}" for _, feat_id, _ in (self._dongle_features or [])],
+        )
+        return False
+
     def notify_devices(self):
         """Create child Device for the headset and trigger its initialization."""
         # Import Device locally to avoid circular import (centurion.py ↔ device.py)
         from .device import Device
+
+        if self._pending:
+            # Don't create children yet — feature discovery hasn't succeeded.
+            # Signal receiver to UI so the tray entry exists.
+            self.changed(alert=Alert.NONE)
+            return
 
         # Signal receiver to UI first — tray/window need the receiver entry
         # before a child device can be added under it.
@@ -407,6 +460,13 @@ class CenturionReceiver:
         # Ping to determine online status.
         # Notify UI either way — offline devices show as greyed out (matching receiver behavior).
         online = dev.ping()
+        logger.info(
+            "CenturionReceiver %s: child device created, bridge_idx=%s, online=%s, protocol=%s",
+            self.path,
+            getattr(dev, "_centurion_bridge_index", None),
+            online,
+            dev._protocol,
+        )
         dev.changed(active=online)
         if self.status_callback is not None:
             self.status_callback(dev)
@@ -498,13 +558,26 @@ def create_centurion_receiver(low_level, device_info, setting_callback=None):
             cr = CenturionReceiver(low_level, handle, device_info, setting_callback)
             # Check if any discovered feature is CentPPBridge (0x0003)
             has_bridge = any(feat_id == CenturionCoreFeature.CENT_PP_BRIDGE for _, feat_id, _ in (cr.dongle_features or []))
-            if not has_bridge:
-                logger.info("Centurion device %s has no bridge, treating as direct device", device_info.path)
-                base._centurion_handles.pop(int(handle), None)
-                cr.handle = None  # prevent __del__ from double-closing
-                low_level.close(handle)
-                return None
-            return cr
+            if has_bridge:
+                return cr
+
+            # No bridge found. Distinguish "silent 0x50 dongle" (device_addr
+            # unknown, headset not yet powered on) from "wired 0x50 device"
+            # (responded to probe, features found, but no bridge).
+            is_0x50 = state.report_id == base.CENTURION_ADDRESSED_REPORT_ID
+            if is_0x50 and state.device_addr is None and not cr.dongle_features:
+                logger.info(
+                    "Centurion 0x50 device %s: probe and discovery failed, " "deferring init until first RX frame",
+                    device_info.path,
+                )
+                cr._pending = True
+                return cr
+
+            logger.info("Centurion device %s has no bridge, treating as direct device", device_info.path)
+            base._centurion_handles.pop(int(handle), None)
+            cr.handle = None  # prevent __del__ from double-closing
+            low_level.close(handle)
+            return None
     except OSError as e:
         logger.exception("open %s", device_info)
         if e.errno == errno.EACCES:

--- a/lib/logitech_receiver/centurion.py
+++ b/lib/logitech_receiver/centurion.py
@@ -492,7 +492,9 @@ def create_centurion_receiver(low_level, device_info, setting_callback=None):
         handle = low_level.open_path(device_info.path)
         if handle:
             report_id = getattr(device_info, "centurion_report_id", None) or base.CENTURION_REPORT_ID
-            base._centurion_handles[int(handle)] = base.CenturionHandleState(report_id=report_id)
+            state = base.CenturionHandleState(report_id=report_id)
+            base._centurion_handles[int(handle)] = state
+            base.probe_centurion_device_addr(handle, state)
             cr = CenturionReceiver(low_level, handle, device_info, setting_callback)
             # Check if any discovered feature is CentPPBridge (0x0003)
             has_bridge = any(feat_id == CenturionCoreFeature.CENT_PP_BRIDGE for _, feat_id, _ in (cr.dongle_features or []))

--- a/lib/logitech_receiver/centurion.py
+++ b/lib/logitech_receiver/centurion.py
@@ -491,13 +491,14 @@ def create_centurion_receiver(low_level, device_info, setting_callback=None):
     try:
         handle = low_level.open_path(device_info.path)
         if handle:
-            base._centurion_handles.add(int(handle))
+            report_id = getattr(device_info, "centurion_report_id", None) or base.CENTURION_REPORT_ID
+            base._centurion_handles[int(handle)] = base.CenturionHandleState(report_id=report_id)
             cr = CenturionReceiver(low_level, handle, device_info, setting_callback)
             # Check if any discovered feature is CentPPBridge (0x0003)
             has_bridge = any(feat_id == CenturionCoreFeature.CENT_PP_BRIDGE for _, feat_id, _ in (cr.dongle_features or []))
             if not has_bridge:
                 logger.info("Centurion device %s has no bridge, treating as direct device", device_info.path)
-                base._centurion_handles.discard(int(handle))
+                base._centurion_handles.pop(int(handle), None)
                 cr.handle = None  # prevent __del__ from double-closing
                 low_level.close(handle)
                 return None

--- a/lib/logitech_receiver/centurion.py
+++ b/lib/logitech_receiver/centurion.py
@@ -317,7 +317,7 @@ class CenturionReceiver:
             if feat_id == feature_int:
                 request_id = (index << 8) | (function & 0xFF)
                 return self.request(request_id, *params, no_reply=no_reply)
-        raise exceptions.FeatureNotSupported(feature)
+        raise exceptions.FeatureNotSupported(feature=feature)
 
     def _discover_dongle_features(self):
         """Independently discover features on the dongle hardware."""
@@ -361,7 +361,7 @@ class CenturionReceiver:
 
     @property
     def firmware(self):
-        if self._firmware is None and self.handle:
+        if self._firmware is None and self.handle and not self._pending:
             self._firmware = get_firmware_centurion(self)
         return self._firmware or ()
 

--- a/lib/logitech_receiver/centurion.py
+++ b/lib/logitech_receiver/centurion.py
@@ -265,6 +265,7 @@ class CenturionReceiver:
         self._devices = {}
         self._firmware = None
         self._dongle_features = None  # independently probed dongle features
+        self._pending = False  # True when device_addr unknown; deferred init completes on first RX
         self.cleanups = []
 
         # Receiver identity
@@ -316,7 +317,7 @@ class CenturionReceiver:
             if feat_id == feature_int:
                 request_id = (index << 8) | (function & 0xFF)
                 return self.request(request_id, *params, no_reply=no_reply)
-        raise exceptions.FeatureNotSupported(feature)
+        raise exceptions.FeatureNotSupported(feature=feature)
 
     def _discover_dongle_features(self):
         """Independently discover features on the dongle hardware."""
@@ -360,14 +361,66 @@ class CenturionReceiver:
 
     @property
     def firmware(self):
-        if self._firmware is None and self.handle:
+        if self._firmware is None and self.handle and not self._pending:
             self._firmware = get_firmware_centurion(self)
         return self._firmware or ()
+
+    def _complete_deferred_init(self):
+        """Re-run feature discovery after device_addr has been learned.
+
+        Called once from the notification handler when the first 0x50 frame
+        arrives on a pending CenturionReceiver.
+        """
+        if not self._pending:
+            return False
+        self._pending = False
+        ihandle = int(self.handle)
+        state = base._centurion_handles.get(ihandle)
+        learned_addr = state.device_addr if state else None
+        logger.debug(
+            "CenturionReceiver %s: completing deferred init (device_addr=0x%02X)",
+            self.path,
+            learned_addr or 0,
+        )
+
+        self._dongle_features = None
+        self._discover_dongle_features()
+        logger.debug(
+            "CenturionReceiver %s: deferred discovery found %d feature(s): %s",
+            self.path,
+            len(self._dongle_features or []),
+            [(f"{feat_id:#06x}", idx) for _, feat_id, idx in (self._dongle_features or [])],
+        )
+
+        if self.serial is None:
+            try:
+                s = get_serial_centurion(self)
+                if s and s.strip() and s.strip().isprintable():
+                    self.serial = s.strip()
+            except Exception:
+                pass
+
+        has_bridge = any(feat_id == CenturionCoreFeature.CENT_PP_BRIDGE for _, feat_id, _ in (self._dongle_features or []))
+        if has_bridge:
+            self.notify_devices()
+            return True
+        logger.warning(
+            "CenturionReceiver %s: deferred init completed but no bridge found " "(features: %s)",
+            self.path,
+            [f"{feat_id:#06x}" for _, feat_id, _ in (self._dongle_features or [])],
+        )
+        return False
 
     def notify_devices(self):
         """Create child Device for the headset and trigger its initialization."""
         # Import Device locally to avoid circular import (centurion.py ↔ device.py)
         from .device import Device
+
+        if self._pending:
+            # Don't create children yet — feature discovery hasn't succeeded.
+            # Signal receiver to UI so the tray entry exists.
+            self.changed(alert=Alert.NONE)
+            return
 
         # Signal receiver to UI first — tray/window need the receiver entry
         # before a child device can be added under it.
@@ -407,6 +460,13 @@ class CenturionReceiver:
         # Ping to determine online status.
         # Notify UI either way — offline devices show as greyed out (matching receiver behavior).
         online = dev.ping()
+        logger.debug(
+            "CenturionReceiver %s: child device created, bridge_idx=%s, online=%s, protocol=%s",
+            self.path,
+            getattr(dev, "_centurion_bridge_index", None),
+            online,
+            dev._protocol,
+        )
         dev.changed(active=online)
         if self.status_callback is not None:
             self.status_callback(dev)
@@ -492,17 +552,33 @@ def create_centurion_receiver(low_level, device_info, setting_callback=None):
     try:
         handle = low_level.open_path(device_info.path)
         if handle:
-            base._centurion_handles.add(int(handle))
+            report_id = getattr(device_info, "centurion_report_id", None) or base.CENTURION_REPORT_ID
+            state = base.CenturionHandleState(report_id=report_id)
+            base._centurion_handles[int(handle)] = state
+            base.probe_centurion_device_addr(handle, state)
             cr = CenturionReceiver(low_level, handle, device_info, setting_callback)
             # Check if any discovered feature is CentPPBridge (0x0003)
             has_bridge = any(feat_id == CenturionCoreFeature.CENT_PP_BRIDGE for _, feat_id, _ in (cr.dongle_features or []))
-            if not has_bridge:
-                logger.info("Centurion device %s has no bridge, treating as direct device", device_info.path)
-                base._centurion_handles.discard(int(handle))
-                cr.handle = None  # prevent __del__ from double-closing
-                low_level.close(handle)
-                return None
-            return cr
+            if has_bridge:
+                return cr
+
+            # No bridge found. Distinguish "silent 0x50 dongle" (device_addr
+            # unknown, headset not yet powered on) from "wired 0x50 device"
+            # (responded to probe, features found, but no bridge).
+            is_0x50 = state.report_id == base.CENTURION_ADDRESSED_REPORT_ID
+            if is_0x50 and state.device_addr is None and not cr.dongle_features:
+                logger.debug(
+                    "Centurion 0x50 device %s: probe and discovery failed, " "deferring init until first RX frame",
+                    device_info.path,
+                )
+                cr._pending = True
+                return cr
+
+            logger.info("Centurion device %s has no bridge, treating as direct device", device_info.path)
+            base._centurion_handles.pop(int(handle), None)
+            cr.handle = None  # prevent __del__ from double-closing
+            low_level.close(handle)
+            return None
     except OSError as e:
         logger.exception("open %s", device_info)
         if e.errno == errno.EACCES:

--- a/lib/logitech_receiver/descriptors.py
+++ b/lib/logitech_receiver/descriptors.py
@@ -466,3 +466,4 @@ _D(
     usbid=0x0ABA,
 )
 # PRO X 2 LIGHTSPEED Gaming Headset (0x0AF7) — fully probed via Centurion transport, no static descriptor needed
+# G522 LIGHTSPEED Gaming Headset (0x0B18 dongle, 0x0B19 wired) — Centurion 0x50 variant, no static descriptor needed

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -658,13 +658,13 @@ class Device:
             return hidpp20.feature_request(self, feature, function, *params, no_reply=no_reply)
 
     # Max sub-message bytes in the first bridge fragment (for 0x51):
-    # 64 - 1 (report ID) - 1 (cpl_len) - 1 (flags) - 2 (bridge prefix) - 2 (bridge hdr) = 57
-    # LGHUB uses 56 for first fragment (60 byte payload - 4 bridge overhead)
-    # For 0x50, subtract 1 more for the device_addr byte.
+    # 64 - 1 (report ID) - 1 (cpl_len) - 1 (flags) - 2 (bridge prefix) - 2 (bridge hdr) = 57;
+    # one byte of conservative margin gives 56. For 0x50 the device_addr byte
+    # eats one more, so first_chunk = 55 (handled dynamically below).
     _BRIDGE_FIRST_CHUNK = 56
     # Continuation fragments carry raw sub_msg data (no bridge prefix/hdr):
-    # 64 - 1 (report ID) - 1 (cpl_len) - 1 (flags) = 61, but LGHUB uses 60
-    # For 0x50, subtract 1 more for the device_addr byte.
+    # 64 - 1 (report ID) - 1 (cpl_len) - 1 (flags) = 61; one byte of margin
+    # gives 60.
     _BRIDGE_CONT_CHUNK = 60
 
     def centurion_bridge_request(self, sub_feat_idx, sub_function=0x00, *params, no_reply=False):
@@ -735,9 +735,8 @@ class Device:
                 # Fragments 1+: raw sub_msg continuation data (no bridge overhead)
                 # CPL flags = (frag_index << 1) | (1 if more_fragments else 0)
                 # All fragments are sent back-to-back without waiting for
-                # intermediate ACKs (verified via LGHUB pcap).  The device
-                # reassembles internally and sends a single ACK + MessageEvent
-                # after the last fragment.
+                # intermediate ACKs. The device reassembles internally and
+                # sends a single ACK + MessageEvent after the last fragment.
                 frag_index = 0
                 offset = 0
                 while offset < sub_len:

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -639,6 +639,18 @@ class Device:
                 # Ensure sub-device features are discovered before routing decision
                 if self.features is not None:
                     self.features._check()
+                # Guard against Centurion/HID++ 2.0 feature ID collisions. IntEnum
+                # members with the same int value hash equal, so a dict lookup for
+                # SupportedFeature.DEVICE_NAME (0x0005) succeeds even when the
+                # device actually has CenturionCoreFeature.MULTI_HOST_CONTROL at
+                # that slot. If the type of the stored enum differs from what the
+                # caller asked for, treat the feature as unsupported.
+                if self.features is not None:
+                    idx = self.features.get(feature)
+                    if idx is not None:
+                        stored = self.features.inverse.get(idx)
+                        if stored is not None and type(stored) is not type(feature):
+                            return None
                 if feature in getattr(self, "_centurion_sub_features", ()):
                     sub_idx = self.features.get(feature)
                     if sub_idx is not None:

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -758,6 +758,13 @@ class Device:
             if no_reply:
                 return None
 
+            # The device echoes our exact sub-device function+swid byte in
+            # MessageEvent responses. Match on that to reject cross-contamination
+            # from late-arriving responses to other function calls on the same
+            # feature (e.g. GetRGBZoneInfo response showing up on a later
+            # GetHostModeState read).
+            expected_sub_func_sw = (sub_function & 0xF0) | sw_id
+
             # Read ACK + MessageEvent response
             request_started = time.time()
             ack_received = False
@@ -774,7 +781,7 @@ class Device:
                         break
                     if (func_sw >> 4) == 0x01 and (func_sw & 0x0F) == 0:
                         # MessageEvent arrived before ACK — validate it's for our request
-                        if self._is_bridge_response_for(reply_data, sub_feat_idx):
+                        if self._is_bridge_response_for(reply_data, sub_feat_idx, expected_sub_func_sw):
                             if logger.isEnabledFor(logging.DEBUG):
                                 logger.debug("bridge idx=%d fn=0x%02X -> OK", sub_feat_idx, sub_function)
                             return self._parse_bridge_response(reply_data)
@@ -792,7 +799,7 @@ class Device:
                 if len(reply_data) >= 2 and reply_data[0] == bridge_idx:
                     func_sw = reply_data[1]
                     if (func_sw >> 4) == 0x01 and (func_sw & 0x0F) == 0:
-                        if self._is_bridge_response_for(reply_data, sub_feat_idx):
+                        if self._is_bridge_response_for(reply_data, sub_feat_idx, expected_sub_func_sw):
                             if logger.isEnabledFor(logging.DEBUG):
                                 logger.debug("bridge idx=%d fn=0x%02X -> OK", sub_feat_idx, sub_function)
                             return self._parse_bridge_response(reply_data)
@@ -816,12 +823,19 @@ class Device:
         return False
 
     @staticmethod
-    def _is_bridge_response_for(reply_data, expected_sub_feat_idx):
+    def _is_bridge_response_for(reply_data, expected_sub_feat_idx, expected_sub_func_sw=None):
         """Check if a bridge MessageEvent is a response for our specific sub-feature request.
 
         Accepts both normal responses (sub_feat_idx matches) and error responses
         (sub_feat_idx=0xFF with original feat_idx in next byte).
         Unsolicited notifications (sub_cpl=0xFF) are rejected.
+
+        If `expected_sub_func_sw` is provided, also matches on the echoed
+        sub-device function byte (`(function << 4) | sw_id`). This prevents
+        cross-talk between different function calls on the SAME feature, which
+        can happen when a late-arriving response for one function gets picked
+        up by a later request on the same feature (observed on G522 where a
+        GetRGBZoneInfo response contaminated a subsequent GetHostModeState).
         """
         if len(reply_data) < 6:
             return False
@@ -831,9 +845,15 @@ class Device:
         if sub_cpl != 0x00:
             return False
         if sub_feat_idx == expected_sub_feat_idx:
+            if expected_sub_func_sw is not None and len(reply_data) >= 7:
+                if reply_data[6] != expected_sub_func_sw:
+                    return False
             return True
         # Error response: sub_feat_idx=0xFF, next byte is the original feat_idx that errored
         if sub_feat_idx == 0xFF and len(reply_data) >= 7 and reply_data[6] == expected_sub_feat_idx:
+            if expected_sub_func_sw is not None and len(reply_data) >= 8:
+                if reply_data[7] != expected_sub_func_sw:
+                    return False
             return True
         return False
 

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -79,7 +79,9 @@ def create_device(low_level: LowLevelInterface, device_info, setting_callback=No
         if handle:
             if getattr(device_info, "centurion", False):
                 report_id = getattr(device_info, "centurion_report_id", None) or base.CENTURION_REPORT_ID
-                base._centurion_handles[int(handle)] = base.CenturionHandleState(report_id=report_id)
+                state = base.CenturionHandleState(report_id=report_id)
+                base._centurion_handles[int(handle)] = state
+                base.probe_centurion_device_addr(handle, state)
             # a direct connected device might not be online (as reported by user)
             return Device(
                 low_level,

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -714,11 +714,8 @@ class Device:
 
         timeout = base.DEFAULT_TIMEOUT
         with base.acquire_timeout(base.handle_lock(handle), handle, timeout):
-            # Log the outgoing sub-message at INFO so field diagnostics can
-            # correlate bridge NACKs with the exact payload we sent (e.g. to
-            # verify mic-gain byte landed in the device's accepted range).
-            if logger.isEnabledFor(logging.INFO):
-                logger.info(
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
                     "bridge TX: sub_idx=%d func=0x%02X sw_id=%d payload=%s",
                     sub_feat_idx,
                     sub_function,

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -842,9 +842,18 @@ class Device:
         sub_feat_idx = reply_data[5]
         # Error response from sub-device
         if sub_feat_idx == 0xFF:
-            error_code = reply_data[8] if len(reply_data) > 8 else 0
+            # Error frame layout after sub_cpl: [0xFF, orig_feat_idx, orig_func_sw, error_code, ...]
             orig_feat_idx = reply_data[6] if len(reply_data) > 6 else 0
-            logger.debug("bridge sub-device error: feat_idx=%d error=0x%02X", orig_feat_idx, error_code)
+            orig_func_sw = reply_data[7] if len(reply_data) > 7 else 0
+            error_code = reply_data[8] if len(reply_data) > 8 else 0
+            # INFO level so the error is visible without -dd — lets testers see when
+            # the device rejects a write even if they can't get DEBUG logs.
+            logger.info(
+                "bridge sub-device error: orig_feat_idx=%d orig_func=0x%02X error=0x%02X",
+                orig_feat_idx,
+                orig_func_sw,
+                error_code,
+            )
             return None
         return reply_data[7:]  # response data after sub_cpl, sub_feat_idx, sub_func_sw
 

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -222,7 +222,9 @@ class Device:
             self._protocol = self.descriptor.protocol if self.descriptor.protocol else None
             self.registers = self.descriptor.registers if self.descriptor.registers else []
 
-        if self._protocol is not None:
+        # Centurion devices always use HID++ 2.0 features regardless of the
+        # protocol version the dongle reports (e.g. G522 reports 1.1).
+        if self._protocol is not None and not self.centurion:
             self.features = {} if self._protocol < 2.0 else hidpp20.FeaturesArray(self)
         else:
             self.features = hidpp20.FeaturesArray(self)  # may be a 2.0 device; if not, it will fix itself later

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -714,6 +714,17 @@ class Device:
 
         timeout = base.DEFAULT_TIMEOUT
         with base.acquire_timeout(base.handle_lock(handle), handle, timeout):
+            # Log the outgoing sub-message at INFO so field diagnostics can
+            # correlate bridge NACKs with the exact payload we sent (e.g. to
+            # verify mic-gain byte landed in the device's accepted range).
+            if logger.isEnabledFor(logging.INFO):
+                logger.info(
+                    "bridge TX: sub_idx=%d func=0x%02X sw_id=%d payload=%s",
+                    sub_feat_idx,
+                    sub_function,
+                    sw_id,
+                    sub_params.hex() if sub_params else "",
+                )
             if sub_len <= first_chunk:
                 # Single-frame path
                 layer3 = bridge_prefix + bridge_hdr + sub_msg

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -242,7 +242,13 @@ class Device:
                 self.ping()
             except exceptions.NoSuchDevice:
                 logger.warning("device %s inaccessible - no protocol set", self)
-        return self._protocol or 0
+        result = self._protocol or 0
+        # Centurion devices always use HID++ 2.0 features regardless of the
+        # protocol version the dongle reports (e.g. G522 reports 1.1).
+        # Ensure all `protocol < 2.0` gates route through the 2.0 code path.
+        if self.centurion and result < 2.0:
+            return 2.0
+        return result
 
     @property
     def codename(self):

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -78,7 +78,8 @@ def create_device(low_level: LowLevelInterface, device_info, setting_callback=No
         handle = low_level.open_path(device_info.path)
         if handle:
             if getattr(device_info, "centurion", False):
-                base._centurion_handles.add(int(handle))
+                report_id = getattr(device_info, "centurion_report_id", None) or base.CENTURION_REPORT_ID
+                base._centurion_handles[int(handle)] = base.CenturionHandleState(report_id=report_id)
             # a direct connected device might not be online (as reported by user)
             return Device(
                 low_level,
@@ -625,20 +626,22 @@ class Device:
                         return self.centurion_bridge_request(sub_idx, function, *params, no_reply=no_reply)
             return hidpp20.feature_request(self, feature, function, *params, no_reply=no_reply)
 
-    # Max sub-message bytes in the first bridge fragment:
+    # Max sub-message bytes in the first bridge fragment (for 0x51):
     # 64 - 1 (report ID) - 1 (cpl_len) - 1 (flags) - 2 (bridge prefix) - 2 (bridge hdr) = 57
     # LGHUB uses 56 for first fragment (60 byte payload - 4 bridge overhead)
+    # For 0x50, subtract 1 more for the device_addr byte.
     _BRIDGE_FIRST_CHUNK = 56
     # Continuation fragments carry raw sub_msg data (no bridge prefix/hdr):
     # 64 - 1 (report ID) - 1 (cpl_len) - 1 (flags) = 61, but LGHUB uses 60
+    # For 0x50, subtract 1 more for the device_addr byte.
     _BRIDGE_CONT_CHUNK = 60
 
     def centurion_bridge_request(self, sub_feat_idx, sub_function=0x00, *params, no_reply=False):
         """Send a request to a Centurion sub-device via CentPPBridge.
 
         Builds the 4-layer nested message:
-        Layer 1: [0x51]
-        Layer 2: [cpl_length, flags]
+        Layer 1: [report_id]  (0x51 or 0x50)
+        Layer 2: [device_addr (0x50 only),] cpl_length, flags
         Layer 3: [bridge_idx, sendFragment_func|swid, bridge_hdr...]
         Layer 4: [sub_cpl=0x00, sub_feat_idx, sub_func|swid, params...]
 
@@ -659,6 +662,12 @@ class Device:
         if not handle:
             return None
 
+        # Adjust bridge chunk sizes for 0x50 variant (device_addr byte takes 1 frame byte)
+        cent_state = base._centurion_handles.get(int(handle))
+        addr_overhead = 1 if cent_state and cent_state.report_id == base.CENTURION_ADDRESSED_REPORT_ID else 0
+        first_chunk = self._BRIDGE_FIRST_CHUNK - addr_overhead
+        cont_chunk = self._BRIDGE_CONT_CHUNK - addr_overhead
+
         sw_id = base._get_next_sw_id()
 
         # Build sub-device message: [sub_cpl=0x00, sub_feat_idx, sub_func|swid, params...]
@@ -674,7 +683,7 @@ class Device:
 
         timeout = base.DEFAULT_TIMEOUT
         with base.acquire_timeout(base.handle_lock(handle), handle, timeout):
-            if sub_len <= self._BRIDGE_FIRST_CHUNK:
+            if sub_len <= first_chunk:
                 # Single-frame path
                 layer3 = bridge_prefix + bridge_hdr + sub_msg
                 base.write_centurion_cpl(handle, layer3)
@@ -691,11 +700,11 @@ class Device:
                 offset = 0
                 while offset < sub_len:
                     if frag_index == 0:
-                        chunk_size = self._BRIDGE_FIRST_CHUNK
+                        chunk_size = first_chunk
                         chunk = sub_msg[offset : offset + chunk_size]
                         layer3 = bridge_prefix + bridge_hdr + chunk
                     else:
-                        chunk_size = self._BRIDGE_CONT_CHUNK
+                        chunk_size = cont_chunk
                         chunk = sub_msg[offset : offset + chunk_size]
                         layer3 = chunk
                     has_more = (offset + chunk_size) < sub_len
@@ -811,9 +820,9 @@ class Device:
     def _record_ping_protocol(self, handle, protocol):
         """Record a successful ping's protocol version, including raw Centurion (major, minor)."""
         self._protocol = protocol
-        cent_ver = base._centurion_protocol_versions.get(int(handle))
-        if cent_ver:
-            self._centurion_protocol = cent_ver
+        cent_state = base._centurion_handles.get(int(handle))
+        if cent_state and cent_state.protocol_version:
+            self._centurion_protocol = cent_state.protocol_version
 
     def ping(self):
         """Checks if the device is online and present, returns True of False.

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -785,7 +785,17 @@ class Device:
                             if logger.isEnabledFor(logging.DEBUG):
                                 logger.debug("bridge idx=%d fn=0x%02X -> OK", sub_feat_idx, sub_function)
                             return self._parse_bridge_response(reply_data)
-                        # Unsolicited notification, skip it
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.debug(
+                                "bridge skipping reply (pre-ACK): got sub_cpl=0x%02X sub_idx=0x%02X func_sw=0x%02X"
+                                " (expected idx=0x%02X func_sw=0x%02X) data=%s",
+                                reply_data[4] if len(reply_data) > 4 else 0,
+                                reply_data[5] if len(reply_data) > 5 else 0,
+                                reply_data[6] if len(reply_data) > 6 else 0,
+                                sub_feat_idx,
+                                expected_sub_func_sw,
+                                reply_data.hex(),
+                            )
             if not ack_received:
                 logger.warning("centurion_bridge_request: no ACK received")
                 return None
@@ -803,7 +813,17 @@ class Device:
                             if logger.isEnabledFor(logging.DEBUG):
                                 logger.debug("bridge idx=%d fn=0x%02X -> OK", sub_feat_idx, sub_function)
                             return self._parse_bridge_response(reply_data)
-                        # Unsolicited notification for a different feature, skip it
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.debug(
+                                "bridge skipping reply (post-ACK): got sub_cpl=0x%02X sub_idx=0x%02X func_sw=0x%02X"
+                                " (expected idx=0x%02X func_sw=0x%02X) data=%s",
+                                reply_data[4] if len(reply_data) > 4 else 0,
+                                reply_data[5] if len(reply_data) > 5 else 0,
+                                reply_data[6] if len(reply_data) > 6 else 0,
+                                sub_feat_idx,
+                                expected_sub_func_sw,
+                                reply_data.hex(),
+                            )
             logger.warning("centurion_bridge_request: no MessageEvent received")
             return None
 

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -468,6 +468,15 @@ class Device:
 
     def battery(self):  # None  or  level, next, status, voltage
         if self.protocol < 2.0:
+            if self.centurion:
+                logger.warning(
+                    "%s: battery() dispatching HID++ 1.0 path for a Centurion device "
+                    "(protocol=%s, _protocol=%s) — device_addr probe likely failed, "
+                    "expect INVALID_SUB_ID_COMMAND",
+                    self,
+                    self.protocol,
+                    self._protocol,
+                )
             return _hidpp10.get_battery(self)
         else:
             battery_feature = self.persister.get("_battery", None) if self.persister else None

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -310,8 +310,8 @@ class Device:
         hw_info = _hidpp20.get_hardware_info_centurion(self)
         if hw_info:
             model_id, hw_revision, product_id = hw_info
-            # modelId is the stable per-model disambiguator (G522 0x33, G325
-            # 0x45). productId is shared across the headset family and varies
+            # modelId is the stable per-model disambiguator (G522 0x32, G325
+            # 0x44). productId is shared across the headset family and varies
             # by firmware (G522 0x0508 -> 0x0509), so it must NOT key modelId.
             self._modelId = f"{model_id:02X}"
             self._tid_map = {"usbid": f"{product_id:04X}"}

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -79,7 +79,10 @@ def create_device(low_level: LowLevelInterface, device_info, setting_callback=No
         handle = low_level.open_path(device_info.path)
         if handle:
             if getattr(device_info, "centurion", False):
-                base._centurion_handles.add(int(handle))
+                report_id = getattr(device_info, "centurion_report_id", None) or base.CENTURION_REPORT_ID
+                state = base.CenturionHandleState(report_id=report_id)
+                base._centurion_handles[int(handle)] = state
+                base.probe_centurion_device_addr(handle, state)
             # a direct connected device might not be online (as reported by user)
             return Device(
                 low_level,
@@ -221,7 +224,9 @@ class Device:
             self._protocol = self.descriptor.protocol if self.descriptor.protocol else None
             self.registers = self.descriptor.registers if self.descriptor.registers else []
 
-        if self._protocol is not None:
+        # Centurion devices always use HID++ 2.0 features regardless of the
+        # protocol version the dongle reports (e.g. G522 reports 1.1).
+        if self._protocol is not None and not self.centurion:
             self.features = {} if self._protocol < 2.0 else hidpp20.FeaturesArray(self)
         else:
             self.features = hidpp20.FeaturesArray(self)  # may be a 2.0 device; if not, it will fix itself later
@@ -241,7 +246,13 @@ class Device:
                 self.ping()
             except exceptions.NoSuchDevice:
                 logger.warning("device %s inaccessible - no protocol set", self)
-        return self._protocol or 0
+        result = self._protocol or 0
+        # Centurion devices always use HID++ 2.0 features regardless of the
+        # protocol version the dongle reports (e.g. G522 reports 1.1).
+        # Ensure all `protocol < 2.0` gates route through the 2.0 code path.
+        if self.centurion and result < 2.0:
+            return 2.0
+        return result
 
     @property
     def codename(self):
@@ -533,6 +544,15 @@ class Device:
 
     def battery(self):  # None  or  level, next, status, voltage
         if self.protocol < 2.0:
+            if self.centurion:
+                logger.debug(
+                    "%s: battery() dispatching HID++ 1.0 path for a Centurion device "
+                    "(protocol=%s, _protocol=%s) — device_addr probe likely failed, "
+                    "expect INVALID_SUB_ID_COMMAND",
+                    self,
+                    self.protocol,
+                    self._protocol,
+                )
             return _hidpp10.get_battery(self)
         else:
             battery_feature = self.persister.get("_battery", None) if self.persister else None
@@ -700,26 +720,40 @@ class Device:
                 # Ensure sub-device features are discovered before routing decision
                 if self.features is not None:
                     self.features._check()
+                # Guard against Centurion/HID++ 2.0 feature ID collisions. IntEnum
+                # members with the same int value hash equal, so a dict lookup for
+                # SupportedFeature.DEVICE_NAME (0x0005) succeeds even when the
+                # device actually has CenturionCoreFeature.MULTI_HOST_CONTROL at
+                # that slot. If the type of the stored enum differs from what the
+                # caller asked for, treat the feature as unsupported.
+                if self.features is not None:
+                    idx = self.features.get(feature)
+                    if idx is not None:
+                        stored = self.features.inverse.get(idx)
+                        if stored is not None and type(stored) is not type(feature):
+                            return None
                 if feature in getattr(self, "_centurion_sub_features", ()):
                     sub_idx = self.features.get(feature)
                     if sub_idx is not None:
                         return self.centurion_bridge_request(sub_idx, function, *params, no_reply=no_reply)
             return hidpp20.feature_request(self, feature, function, *params, no_reply=no_reply)
 
-    # Max sub-message bytes in the first bridge fragment:
-    # 64 - 1 (report ID) - 1 (cpl_len) - 1 (flags) - 2 (bridge prefix) - 2 (bridge hdr) = 57
-    # LGHUB uses 56 for first fragment (60 byte payload - 4 bridge overhead)
+    # Max sub-message bytes in the first bridge fragment (for 0x51):
+    # 64 - 1 (report ID) - 1 (cpl_len) - 1 (flags) - 2 (bridge prefix) - 2 (bridge hdr) = 57;
+    # one byte of conservative margin gives 56. For 0x50 the device_addr byte
+    # eats one more, so first_chunk = 55 (handled dynamically below).
     _BRIDGE_FIRST_CHUNK = 56
     # Continuation fragments carry raw sub_msg data (no bridge prefix/hdr):
-    # 64 - 1 (report ID) - 1 (cpl_len) - 1 (flags) = 61, but LGHUB uses 60
+    # 64 - 1 (report ID) - 1 (cpl_len) - 1 (flags) = 61; one byte of margin
+    # gives 60.
     _BRIDGE_CONT_CHUNK = 60
 
     def centurion_bridge_request(self, sub_feat_idx, sub_function=0x00, *params, no_reply=False):
         """Send a request to a Centurion sub-device via CentPPBridge.
 
         Builds the 4-layer nested message:
-        Layer 1: [0x51]
-        Layer 2: [cpl_length, flags]
+        Layer 1: [report_id]  (0x51 or 0x50)
+        Layer 2: [device_addr (0x50 only),] cpl_length, flags
         Layer 3: [bridge_idx, sendFragment_func|swid, bridge_hdr...]
         Layer 4: [sub_cpl=0x00, sub_feat_idx, sub_func|swid, params...]
 
@@ -740,6 +774,12 @@ class Device:
         if not handle:
             return None
 
+        # Adjust bridge chunk sizes for 0x50 variant (device_addr byte takes 1 frame byte)
+        cent_state = base._centurion_handles.get(int(handle))
+        addr_overhead = 1 if cent_state and cent_state.report_id == base.CENTURION_ADDRESSED_REPORT_ID else 0
+        first_chunk = self._BRIDGE_FIRST_CHUNK - addr_overhead
+        cont_chunk = self._BRIDGE_CONT_CHUNK - addr_overhead
+
         sw_id = base._get_next_sw_id()
 
         # Build sub-device message: [sub_cpl=0x00, sub_feat_idx, sub_func|swid, params...]
@@ -755,7 +795,15 @@ class Device:
 
         timeout = base.DEFAULT_TIMEOUT
         with base.acquire_timeout(base.handle_lock(handle), handle, timeout):
-            if sub_len <= self._BRIDGE_FIRST_CHUNK:
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "bridge TX: sub_idx=%d func=0x%02X sw_id=%d payload=%s",
+                    sub_feat_idx,
+                    sub_function,
+                    sw_id,
+                    sub_params.hex() if sub_params else "",
+                )
+            if sub_len <= first_chunk:
                 # Single-frame path
                 layer3 = bridge_prefix + bridge_hdr + sub_msg
                 base.write_centurion_cpl(handle, layer3)
@@ -765,18 +813,17 @@ class Device:
                 # Fragments 1+: raw sub_msg continuation data (no bridge overhead)
                 # CPL flags = (frag_index << 1) | (1 if more_fragments else 0)
                 # All fragments are sent back-to-back without waiting for
-                # intermediate ACKs (verified via LGHUB pcap).  The device
-                # reassembles internally and sends a single ACK + MessageEvent
-                # after the last fragment.
+                # intermediate ACKs. The device reassembles internally and
+                # sends a single ACK + MessageEvent after the last fragment.
                 frag_index = 0
                 offset = 0
                 while offset < sub_len:
                     if frag_index == 0:
-                        chunk_size = self._BRIDGE_FIRST_CHUNK
+                        chunk_size = first_chunk
                         chunk = sub_msg[offset : offset + chunk_size]
                         layer3 = bridge_prefix + bridge_hdr + chunk
                     else:
-                        chunk_size = self._BRIDGE_CONT_CHUNK
+                        chunk_size = cont_chunk
                         chunk = sub_msg[offset : offset + chunk_size]
                         layer3 = chunk
                     has_more = (offset + chunk_size) < sub_len
@@ -787,6 +834,13 @@ class Device:
 
             if no_reply:
                 return None
+
+            # The device echoes our exact sub-device function+swid byte in
+            # MessageEvent responses. Match on that to reject cross-contamination
+            # from late-arriving responses to other function calls on the same
+            # feature (e.g. GetRGBZoneInfo response showing up on a later
+            # GetHostModeState read).
+            expected_sub_func_sw = (sub_function & 0xF0) | sw_id
 
             # Read ACK + MessageEvent response
             request_started = time.time()
@@ -804,11 +858,21 @@ class Device:
                         break
                     if (func_sw >> 4) == 0x01 and (func_sw & 0x0F) == 0:
                         # MessageEvent arrived before ACK — validate it's for our request
-                        if self._is_bridge_response_for(reply_data, sub_feat_idx):
+                        if self._is_bridge_response_for(reply_data, sub_feat_idx, expected_sub_func_sw):
                             if logger.isEnabledFor(logging.DEBUG):
                                 logger.debug("bridge idx=%d fn=0x%02X -> OK", sub_feat_idx, sub_function)
                             return self._parse_bridge_response(reply_data)
-                        # Unsolicited notification, skip it
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.debug(
+                                "bridge skipping reply (pre-ACK): got sub_cpl=0x%02X sub_idx=0x%02X func_sw=0x%02X"
+                                " (expected idx=0x%02X func_sw=0x%02X) data=%s",
+                                reply_data[4] if len(reply_data) > 4 else 0,
+                                reply_data[5] if len(reply_data) > 5 else 0,
+                                reply_data[6] if len(reply_data) > 6 else 0,
+                                sub_feat_idx,
+                                expected_sub_func_sw,
+                                reply_data.hex(),
+                            )
             if not ack_received:
                 logger.warning("centurion_bridge_request: no ACK received")
                 return None
@@ -822,11 +886,21 @@ class Device:
                 if len(reply_data) >= 2 and reply_data[0] == bridge_idx:
                     func_sw = reply_data[1]
                     if (func_sw >> 4) == 0x01 and (func_sw & 0x0F) == 0:
-                        if self._is_bridge_response_for(reply_data, sub_feat_idx):
+                        if self._is_bridge_response_for(reply_data, sub_feat_idx, expected_sub_func_sw):
                             if logger.isEnabledFor(logging.DEBUG):
                                 logger.debug("bridge idx=%d fn=0x%02X -> OK", sub_feat_idx, sub_function)
                             return self._parse_bridge_response(reply_data)
-                        # Unsolicited notification for a different feature, skip it
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.debug(
+                                "bridge skipping reply (post-ACK): got sub_cpl=0x%02X sub_idx=0x%02X func_sw=0x%02X"
+                                " (expected idx=0x%02X func_sw=0x%02X) data=%s",
+                                reply_data[4] if len(reply_data) > 4 else 0,
+                                reply_data[5] if len(reply_data) > 5 else 0,
+                                reply_data[6] if len(reply_data) > 6 else 0,
+                                sub_feat_idx,
+                                expected_sub_func_sw,
+                                reply_data.hex(),
+                            )
             logger.warning("centurion_bridge_request: no MessageEvent received")
             return None
 
@@ -846,12 +920,19 @@ class Device:
         return False
 
     @staticmethod
-    def _is_bridge_response_for(reply_data, expected_sub_feat_idx):
+    def _is_bridge_response_for(reply_data, expected_sub_feat_idx, expected_sub_func_sw=None):
         """Check if a bridge MessageEvent is a response for our specific sub-feature request.
 
         Accepts both normal responses (sub_feat_idx matches) and error responses
         (sub_feat_idx=0xFF with original feat_idx in next byte).
         Unsolicited notifications (sub_cpl=0xFF) are rejected.
+
+        If `expected_sub_func_sw` is provided, also matches on the echoed
+        sub-device function byte (`(function << 4) | sw_id`). This prevents
+        cross-talk between different function calls on the SAME feature, which
+        can happen when a late-arriving response for one function gets picked
+        up by a later request on the same feature (observed on G522 where a
+        GetRGBZoneInfo response contaminated a subsequent GetHostModeState).
         """
         if len(reply_data) < 6:
             return False
@@ -861,9 +942,15 @@ class Device:
         if sub_cpl != 0x00:
             return False
         if sub_feat_idx == expected_sub_feat_idx:
+            if expected_sub_func_sw is not None and len(reply_data) >= 7:
+                if reply_data[6] != expected_sub_func_sw:
+                    return False
             return True
         # Error response: sub_feat_idx=0xFF, next byte is the original feat_idx that errored
         if sub_feat_idx == 0xFF and len(reply_data) >= 7 and reply_data[6] == expected_sub_feat_idx:
+            if expected_sub_func_sw is not None and len(reply_data) >= 8:
+                if reply_data[7] != expected_sub_func_sw:
+                    return False
             return True
         return False
 
@@ -883,18 +970,25 @@ class Device:
         sub_feat_idx = reply_data[5]
         # Error response from sub-device
         if sub_feat_idx == 0xFF:
-            error_code = reply_data[8] if len(reply_data) > 8 else 0
+            # Error frame layout after sub_cpl: [0xFF, orig_feat_idx, orig_func_sw, error_code, ...]
             orig_feat_idx = reply_data[6] if len(reply_data) > 6 else 0
-            logger.debug("bridge sub-device error: feat_idx=%d error=0x%02X", orig_feat_idx, error_code)
+            orig_func_sw = reply_data[7] if len(reply_data) > 7 else 0
+            error_code = reply_data[8] if len(reply_data) > 8 else 0
+            logger.debug(
+                "bridge sub-device error: orig_feat_idx=%d orig_func=0x%02X error=0x%02X",
+                orig_feat_idx,
+                orig_func_sw,
+                error_code,
+            )
             return None
         return reply_data[7:]  # response data after sub_cpl, sub_feat_idx, sub_func_sw
 
     def _record_ping_protocol(self, handle, protocol):
         """Record a successful ping's protocol version, including raw Centurion (major, minor)."""
         self._protocol = protocol
-        cent_ver = base._centurion_protocol_versions.get(int(handle))
-        if cent_ver:
-            self._centurion_protocol = cent_ver
+        cent_state = base._centurion_handles.get(int(handle))
+        if cent_state and cent_state.protocol_version:
+            self._centurion_protocol = cent_state.protocol_version
 
     def ping(self):
         """Checks if the device is online and present, returns True of False.

--- a/lib/logitech_receiver/device.py
+++ b/lib/logitech_receiver/device.py
@@ -310,7 +310,10 @@ class Device:
         hw_info = _hidpp20.get_hardware_info_centurion(self)
         if hw_info:
             model_id, hw_revision, product_id = hw_info
-            self._modelId = f"{product_id:04X}"
+            # modelId is the stable per-model disambiguator (G522 0x33, G325
+            # 0x45). productId is shared across the headset family and varies
+            # by firmware (G522 0x0508 -> 0x0509), so it must NOT key modelId.
+            self._modelId = f"{model_id:02X}"
             self._tid_map = {"usbid": f"{product_id:04X}"}
 
     @property

--- a/lib/logitech_receiver/device_quirks.py
+++ b/lib/logitech_receiver/device_quirks.py
@@ -1,47 +1,91 @@
-"""Per-device-model quirks.
+"""Per-device-model quirks for RGB lighting.
 
-Keyed by ``device.modelId``, which Logitech composes by concatenating every
-transport-specific PID (btid + btleid + wpid + usbid) for a single physical
-model. That makes one entry cover the same device regardless of how it is
-currently connected — no transport-aliasing gotchas.
+Keyed by ``device.modelId``. For normal HID++ devices that is the string
+Logitech composes by concatenating every transport PID (btid + btleid + wpid
++ usbid) — one entry covers the model on any transport. For Centurion
+headsets it is the firmware-stable model byte (G522 ``"33"``, G325 ``"45"``);
+see ``device._get_ids_centurion``.
 
-Quirks are hand-curated. Devices do not self-report behaviors like "this
-firmware ignores the bytes I wrote", so each entry is observation-derived.
-Keep entries narrow and document the observation in a comment.
+Two postures, by feature class:
+
+* **Effect parameters that do NOT persist** (zone effects, LED directions) —
+  default-ALLOW. Those are validated and low-harm (a wrong value is cosmetic
+  and transient). They use blocklists elsewhere, e.g. ``LedDirectionBlocklist``
+  in ``hidpp20.py``. Nothing of that kind lives here.
+
+* **NVconfig-saved colors** (0x8071 RGBEffects boot effects, 0x0622 HeadsetRGB
+  signature effects) — default-DENY. Those writes persist to non-volatile
+  storage, so an unvalidated control can durably misconfigure a device. Every
+  field is hidden and every slot suppressed unless the exact model is listed
+  here as known-good.
+
+Setting ``SOLAAR_EXPERIMENTAL`` truthy bypasses the allowlists entirely — for
+testers / reverse-engineering on devices not yet validated.
+
+Entries are hand-curated; document the observation in a comment.
 """
 
 from __future__ import annotations
 
-# Quirk keys are named after the doc-canonical feature/function path so a
-# grep for the HID++ feature name (e.g. "RGBEffects", "NvConfig") lands here.
-#
-# Default-allow: each quirk lists what is KNOWN to be broken or ignored on
-# that device model. Unlisted models / unlisted entries get the full UI.
-#
-#   rgb_effects_nvconfig_colors_inert
-#       Feature 0x8071 RGBEffects, Function 3 NvConfig — cap-id → set of
-#       color slot names ({"color1", "color2"}) whose bytes the firmware
-#       accepts but does not visibly apply. UI hides color pickers for
-#       slots in the set.
-QUIRKS: dict[str, dict[str, object]] = {
-    # G502 X PLUS — RGBEffects NvConfig startup effect (cap 0x0001): color
-    # bytes are entirely ignored; only the enabled flag is honored. Shutdown
-    # cap (0x0040) is not supported and is suppressed via build()-time probe.
-    "4099C0950000": {
-        "rgb_effects_nvconfig_colors_inert": {
-            0x0001: {"color1", "color2"},
-        },
+import os
+
+_ALL_NVCONFIG_FIELDS = {"color1", "color2", "speed"}
+
+
+def _experimental() -> bool:
+    """True when SOLAAR_EXPERIMENTAL is set truthy — bypasses allowlist masking."""
+    return os.environ.get("SOLAAR_EXPERIMENTAL", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+# Feature 0x8071 RGBEffects, Function 3 NvConfig — persistent boot/shutdown
+# effects. Default-DENY allowlist: modelId -> cap_id -> set of color fields
+# the firmware is KNOWN to honor. A listed cap shows the setting (its On/Off
+# toggle plus the listed color pickers); an empty set shows the toggle only.
+# An unlisted cap or unlisted model suppresses the setting entirely.
+RGB_EFFECTS_NVCONFIG_ALLOWED: dict[str, dict[int, set[str]]] = {
+    # G502 X PLUS — startup (0x0001): color bytes are inert, only the enabled
+    # flag is honored, so no color fields are allowed (toggle only). Shutdown
+    # (0x0040) is not supported and is suppressed by build()-time probe anyway.
+    "4099C0950000": {0x0001: set()},
+    # G515 LIGHTSPEED TKL — startup and shutdown both honor both colors.
+    "B38940B4C355": {0x0001: {"color1", "color2"}, 0x0040: {"color1", "color2"}},
+}
+
+# Feature 0x0622 HeadsetRGB signature effects — persistent startup / shutdown
+# / passive effects. Default-DENY allowlist: modelId -> effect_id -> set of
+# fields the firmware is KNOWN to honor. An unlisted effect_id or model
+# suppresses that signature-effect setting entirely.
+HEADSET_SIGNATURE_EFFECTS_ALLOWED: dict[str, dict[int, set[str]]] = {
+    # G522 LIGHTSPEED (Centurion model byte 0x33). Verified against user
+    # reports: startup honors only the primary color (secondary unused, speed
+    # has no effect); shutdown honors both colors (speed has no effect). The
+    # passive slot (effect_id 2) is omitted — its behavior is not understood,
+    # so the whole passive setting is suppressed.
+    "33": {
+        0: {"color1"},
+        1: {"color1", "color2"},
     },
 }
 
 
-def get(device, key, default=None):
-    """Look up a quirk by key for the device's model.
+def rgb_effects_nvconfig_allowed_fields(device, cap_id: int) -> set[str] | None:
+    """Color fields to expose for an 0x8071 NvConfig boot effect.
 
-    Returns ``default`` when either the model has no quirks entry or the
-    entry lacks the requested key.
+    Returns the allowed field set (possibly empty — On/Off toggle only), or
+    ``None`` to suppress the setting entirely.
     """
-    model_id = getattr(device, "modelId", None)
-    if not model_id:
-        return default
-    return QUIRKS.get(model_id, {}).get(key, default)
+    if _experimental():
+        return set(_ALL_NVCONFIG_FIELDS)
+    model_id = getattr(device, "modelId", None) or ""
+    return RGB_EFFECTS_NVCONFIG_ALLOWED.get(model_id, {}).get(cap_id)
+
+
+def headset_signature_allowed_fields(device, effect_id: int) -> set[str] | None:
+    """Fields to expose for an 0x0622 signature effect slot.
+
+    Returns the allowed field set, or ``None`` to suppress the slot entirely.
+    """
+    if _experimental():
+        return set(_ALL_NVCONFIG_FIELDS)
+    model_id = getattr(device, "modelId", None) or ""
+    return HEADSET_SIGNATURE_EFFECTS_ALLOWED.get(model_id, {}).get(effect_id)

--- a/lib/logitech_receiver/device_quirks.py
+++ b/lib/logitech_receiver/device_quirks.py
@@ -3,7 +3,7 @@
 Keyed by ``device.modelId``. For normal HID++ devices that is the string
 Logitech composes by concatenating every transport PID (btid + btleid + wpid
 + usbid) — one entry covers the model on any transport. For Centurion
-headsets it is the firmware-stable model byte (G522 ``"33"``, G325 ``"45"``);
+headsets it is the firmware-stable model byte (G522 ``"32"``, G325 ``"44"``);
 see ``device._get_ids_centurion``.
 
 Two postures, by feature class:
@@ -56,12 +56,13 @@ RGB_EFFECTS_NVCONFIG_ALLOWED: dict[str, dict[int, set[str]]] = {
 # fields the firmware is KNOWN to honor. An unlisted effect_id or model
 # suppresses that signature-effect setting entirely.
 HEADSET_SIGNATURE_EFFECTS_ALLOWED: dict[str, dict[int, set[str]]] = {
-    # G522 LIGHTSPEED (Centurion model byte 0x33). Verified against user
+    # G522 LIGHTSPEED (Centurion model byte 0x32, from DeviceInfo func 0;
+    # confirmed against multiple diagnostic logs). Verified against user
     # reports: startup honors only the primary color (secondary unused, speed
     # has no effect); shutdown honors both colors (speed has no effect). The
     # passive slot (effect_id 2) is omitted — its behavior is not understood,
     # so the whole passive setting is suppressed.
-    "33": {
+    "32": {
         0: {"color1"},
         1: {"color1", "color2"},
     },

--- a/lib/logitech_receiver/headset_rgb.py
+++ b/lib/logitech_receiver/headset_rgb.py
@@ -1,0 +1,211 @@
+## Copyright (C) 2024  Solaar Contributors https://pwr-solaar.github.io/Solaar/
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License along
+## with this program; if not, write to the Free Software Foundation, Inc.,
+## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Shared helpers for devices exposing Feature 0x0620 HEADSET_RGB_HOSTMODE.
+
+The G522 is currently the only Solaar-supported device advertising this
+feature, but anything else presenting 0x0620 will pick the same code path
+automatically. The module deliberately avoids G522-specific assumptions
+so future RGB-capable headsets can reuse it.
+
+Two entry points the settings templates rely on:
+
+- `discover_zones(device)` — one-shot zone enumeration run at setting
+  build time. Briefly claims Solaar host control so GetRGBZoneInfo
+  returns a non-empty zone list, then restores the previous host-mode
+  state. Result is cached on the device.
+- `write_zone_map(device, zone_color_map)` — the shared write path used
+  by both the "LEDs Primary" and "Per-zone Lighting" settings. Groups
+  zones by final RGB color and emits one SetRgbZonesSingleValue per
+  unique color, then a single FrameEnd to commit.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from typing import Iterable
+
+from .hidpp20_constants import SupportedFeature
+
+logger = logging.getLogger(__name__)
+
+# Function IDs on Feature 0x0620 we actually use.
+FN_GET_RGB_ZONE_INFO = 0x10
+FN_SET_RGB_ZONES_SINGLE = 0x50
+FN_FRAME_END = 0x60
+FN_GET_HOST_MODE_STATE = 0x70
+FN_SET_HOST_MODE_STATE = 0x80
+
+# Frame type sent with FrameEnd. 0x01 = transient commit (re-applies on the
+# next refresh). 0x02 would be persistent, but G522 firmware rejects it
+# with LOGITECH_INTERNAL (0x05) unless an onboard profile precondition we
+# haven't mapped yet is satisfied.
+FRAME_TYPE_TRANSIENT = 0x01
+
+_HOST_MODE_SOLAAR = 1
+_HOST_MODE_DEVICE = 0
+
+
+def _device_cache_attr() -> str:
+    return "_headset_rgb_zone_ids"
+
+
+def _read_host_mode(device) -> int | None:
+    """Read the current host-mode state byte, or None on any failure."""
+    try:
+        resp = device.feature_request(SupportedFeature.HEADSET_RGB_HOSTMODE, FN_GET_HOST_MODE_STATE)
+    except Exception as e:
+        logger.warning("headset_rgb: GetHostModeState raised %s", e)
+        return None
+    if not resp or len(resp) < 1:
+        return None
+    return resp[0]
+
+
+def _set_host_mode(device, value: int) -> bool:
+    try:
+        device.feature_request(SupportedFeature.HEADSET_RGB_HOSTMODE, FN_SET_HOST_MODE_STATE, bytes([value & 0xFF]))
+    except Exception as e:
+        logger.warning("headset_rgb: SetHostModeState(%d) raised %s", value, e)
+        return False
+    return True
+
+
+def _parse_zone_info(resp: bytes) -> list[int]:
+    """Parse a GetRGBZoneInfo response into a zone-id list.
+
+    Two formats observed: "tight" ([count, zone_ids...]) on G522, and
+    the canonical protocol-doc layout (3-byte gap + 1-byte reserved
+    before zone IDs). Both are tried; whichever yields exactly `count`
+    IDs wins. Zone id 0 isn't filtered — some devices may use it.
+    """
+    if not resp or len(resp) < 1:
+        return []
+    zone_count = resp[0]
+    tight = list(resp[1 : 1 + zone_count]) if 1 <= zone_count <= len(resp) - 1 else []
+    if tight and len(tight) == zone_count:
+        return tight
+    gap = list(resp[5 : 5 + zone_count]) if len(resp) >= 5 + zone_count else []
+    if gap and len(gap) == zone_count:
+        return gap
+    return []
+
+
+def discover_zones(device) -> list[int] | None:
+    """Return the list of RGB zone IDs on `device`, or None on failure.
+
+    Caches the result on `device._headset_rgb_zone_ids` so subsequent
+    callers don't repeat the round-trip. Briefly claims Solaar host mode
+    if needed — GetRGBZoneInfo has been observed to return count=0 when
+    the device is still under firmware control — and restores the prior
+    state afterward so user-configured onboard effects resume.
+    """
+    cached = getattr(device, _device_cache_attr(), None)
+    if cached:
+        return cached
+    if not getattr(device, "online", False):
+        return None
+
+    prior_mode = _read_host_mode(device)
+    claimed = False
+    if prior_mode != _HOST_MODE_SOLAAR:
+        if not _set_host_mode(device, _HOST_MODE_SOLAAR):
+            return None
+        claimed = True
+
+    try:
+        try:
+            resp = device.feature_request(SupportedFeature.HEADSET_RGB_HOSTMODE, FN_GET_RGB_ZONE_INFO)
+        except Exception as e:
+            logger.warning("headset_rgb: GetRGBZoneInfo raised %s", e)
+            return None
+        zones = _parse_zone_info(bytes(resp) if resp else b"")
+        if not zones:
+            logger.warning(
+                "headset_rgb: GetRGBZoneInfo returned no zones (raw=%s)",
+                resp.hex() if resp else resp,
+            )
+            return None
+        logger.info("headset_rgb: discovered %d zone(s) %s", len(zones), [f"0x{z:02X}" for z in zones])
+        setattr(device, _device_cache_attr(), zones)
+        return zones
+    finally:
+        if claimed and prior_mode is not None:
+            _set_host_mode(device, prior_mode)
+
+
+def _split_rgb(color_int: int) -> tuple[int, int, int]:
+    return (color_int >> 16) & 0xFF, (color_int >> 8) & 0xFF, color_int & 0xFF
+
+
+def write_zone_map(device, zone_color_map: dict) -> bool:
+    """Apply a zone->RGB mapping to the device.
+
+    `zone_color_map` maps zone id (int) to 24-bit RGB color (int,
+    `(r<<16)|(g<<8)|b`). Claims host mode, groups zones by color,
+    emits one SetRgbZonesSingleValue per unique color, then a single
+    FrameEnd. Returns True on success, False on any transport error.
+    """
+    if not zone_color_map:
+        return False
+    if not getattr(device, "online", False):
+        logger.info("headset_rgb: device offline, skipping write")
+        return False
+
+    # Group zones by color for batched writes.
+    groups: dict[int, list[int]] = {}
+    for zone, color in zone_color_map.items():
+        groups.setdefault(int(color), []).append(int(zone))
+
+    try:
+        _set_host_mode(device, _HOST_MODE_SOLAAR)
+        for color_int, zones in groups.items():
+            r, g, b = _split_rgb(color_int)
+            # SetRgbZonesSingleValue: [R, G, B, count, zone_ids...]
+            payload = bytes([r, g, b, len(zones)]) + bytes(zones)
+            device.feature_request(SupportedFeature.HEADSET_RGB_HOSTMODE, FN_SET_RGB_ZONES_SINGLE, payload)
+            logger.info(
+                "headset_rgb: set (%02X,%02X,%02X) on %d zone(s) %s",
+                r,
+                g,
+                b,
+                len(zones),
+                [f"0x{z:02X}" for z in zones],
+            )
+        # FrameEnd commits the pending per-zone updates. Transient commit
+        # only — persistent (0x02) requires onboard-profile preconditions
+        # that aren't mapped yet.
+        device.feature_request(
+            SupportedFeature.HEADSET_RGB_HOSTMODE,
+            FN_FRAME_END,
+            bytes([FRAME_TYPE_TRANSIENT, 0x00, 0x00, 0x00]),
+        )
+    except Exception as e:
+        logger.warning("headset_rgb: write_zone_map failed: %s", e)
+        return False
+    return True
+
+
+def zone_named_ints(zones: Iterable[int]):
+    """Build a list of NamedInt keys suitable for a ChoicesMap setting.
+
+    Factored out so settings code can import without pulling common.NamedInt
+    at module-load time if preferred.
+    """
+    from . import common
+
+    return [common.NamedInt(int(z), f"Zone {int(z)}") for z in zones]

--- a/lib/logitech_receiver/headset_rgb.py
+++ b/lib/logitech_receiver/headset_rgb.py
@@ -1,0 +1,211 @@
+## Copyright (C) 2024  Solaar Contributors https://pwr-solaar.github.io/Solaar/
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License along
+## with this program; if not, write to the Free Software Foundation, Inc.,
+## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Shared helpers for devices exposing Feature 0x0620 HEADSET_RGB_HOSTMODE.
+
+The G522 is currently the only Solaar-supported device advertising this
+feature, but anything else presenting 0x0620 will pick the same code path
+automatically. The module deliberately avoids G522-specific assumptions
+so future RGB-capable headsets can reuse it.
+
+Two entry points the settings templates rely on:
+
+- `discover_zones(device)` — one-shot zone enumeration run at setting
+  build time. Briefly claims Solaar host control so GetRGBZoneInfo
+  returns a non-empty zone list, then restores the previous host-mode
+  state. Result is cached on the device.
+- `write_zone_map(device, zone_color_map)` — the shared write path used
+  by both the "LEDs Primary" and "Per-zone Lighting" settings. Groups
+  zones by final RGB color and emits one SetRgbZonesSingleValue per
+  unique color, then a single FrameEnd to commit.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from typing import Iterable
+
+from .hidpp20_constants import SupportedFeature
+
+logger = logging.getLogger(__name__)
+
+# Function IDs on Feature 0x0620 we actually use.
+FN_GET_RGB_ZONE_INFO = 0x10
+FN_SET_RGB_ZONES_SINGLE = 0x50
+FN_FRAME_END = 0x60
+FN_GET_HOST_MODE_STATE = 0x70
+FN_SET_HOST_MODE_STATE = 0x80
+
+# Frame type sent with FrameEnd. 0x01 = transient commit (re-applies on the
+# next refresh). 0x02 would be persistent, but G522 firmware rejects it
+# with LOGITECH_INTERNAL (0x05) unless an onboard profile precondition we
+# haven't mapped yet is satisfied.
+FRAME_TYPE_TRANSIENT = 0x01
+
+_HOST_MODE_SOLAAR = 1
+_HOST_MODE_DEVICE = 0
+
+
+def _device_cache_attr() -> str:
+    return "_headset_rgb_zone_ids"
+
+
+def _read_host_mode(device) -> int | None:
+    """Read the current host-mode state byte, or None on any failure."""
+    try:
+        resp = device.feature_request(SupportedFeature.HEADSET_RGB_HOSTMODE, FN_GET_HOST_MODE_STATE)
+    except Exception as e:
+        logger.debug("headset_rgb: GetHostModeState raised %s", e)
+        return None
+    if not resp or len(resp) < 1:
+        return None
+    return resp[0]
+
+
+def _set_host_mode(device, value: int) -> bool:
+    try:
+        device.feature_request(SupportedFeature.HEADSET_RGB_HOSTMODE, FN_SET_HOST_MODE_STATE, bytes([value & 0xFF]))
+    except Exception as e:
+        logger.debug("headset_rgb: SetHostModeState(%d) raised %s", value, e)
+        return False
+    return True
+
+
+def _parse_zone_info(resp: bytes) -> list[int]:
+    """Parse a GetRGBZoneInfo response into a zone-id list.
+
+    Two formats observed: "tight" ([count, zone_ids...]) on G522, and
+    the canonical protocol-doc layout (3-byte gap + 1-byte reserved
+    before zone IDs). Both are tried; whichever yields exactly `count`
+    IDs wins. Zone id 0 isn't filtered — some devices may use it.
+    """
+    if not resp or len(resp) < 1:
+        return []
+    zone_count = resp[0]
+    tight = list(resp[1 : 1 + zone_count]) if 1 <= zone_count <= len(resp) - 1 else []
+    if tight and len(tight) == zone_count:
+        return tight
+    gap = list(resp[5 : 5 + zone_count]) if len(resp) >= 5 + zone_count else []
+    if gap and len(gap) == zone_count:
+        return gap
+    return []
+
+
+def discover_zones(device) -> list[int] | None:
+    """Return the list of RGB zone IDs on `device`, or None on failure.
+
+    Caches the result on `device._headset_rgb_zone_ids` so subsequent
+    callers don't repeat the round-trip. Briefly claims Solaar host mode
+    if needed — GetRGBZoneInfo has been observed to return count=0 when
+    the device is still under firmware control — and restores the prior
+    state afterward so user-configured onboard effects resume.
+    """
+    cached = getattr(device, _device_cache_attr(), None)
+    if cached:
+        return cached
+    if not getattr(device, "online", False):
+        return None
+
+    prior_mode = _read_host_mode(device)
+    claimed = False
+    if prior_mode != _HOST_MODE_SOLAAR:
+        if not _set_host_mode(device, _HOST_MODE_SOLAAR):
+            return None
+        claimed = True
+
+    try:
+        try:
+            resp = device.feature_request(SupportedFeature.HEADSET_RGB_HOSTMODE, FN_GET_RGB_ZONE_INFO)
+        except Exception as e:
+            logger.debug("headset_rgb: GetRGBZoneInfo raised %s", e)
+            return None
+        zones = _parse_zone_info(bytes(resp) if resp else b"")
+        if not zones:
+            logger.debug(
+                "headset_rgb: GetRGBZoneInfo returned no zones (raw=%s)",
+                resp.hex() if resp else resp,
+            )
+            return None
+        logger.debug("headset_rgb: discovered %d zone(s) %s", len(zones), [f"0x{z:02X}" for z in zones])
+        setattr(device, _device_cache_attr(), zones)
+        return zones
+    finally:
+        if claimed and prior_mode is not None:
+            _set_host_mode(device, prior_mode)
+
+
+def _split_rgb(color_int: int) -> tuple[int, int, int]:
+    return (color_int >> 16) & 0xFF, (color_int >> 8) & 0xFF, color_int & 0xFF
+
+
+def write_zone_map(device, zone_color_map: dict) -> bool:
+    """Apply a zone->RGB mapping to the device.
+
+    `zone_color_map` maps zone id (int) to 24-bit RGB color (int,
+    `(r<<16)|(g<<8)|b`). Claims host mode, groups zones by color,
+    emits one SetRgbZonesSingleValue per unique color, then a single
+    FrameEnd. Returns True on success, False on any transport error.
+    """
+    if not zone_color_map:
+        return False
+    if not getattr(device, "online", False):
+        logger.debug("headset_rgb: device offline, skipping write")
+        return False
+
+    # Group zones by color for batched writes.
+    groups: dict[int, list[int]] = {}
+    for zone, color in zone_color_map.items():
+        groups.setdefault(int(color), []).append(int(zone))
+
+    try:
+        _set_host_mode(device, _HOST_MODE_SOLAAR)
+        for color_int, zones in groups.items():
+            r, g, b = _split_rgb(color_int)
+            # SetRgbZonesSingleValue: [R, G, B, count, zone_ids...]
+            payload = bytes([r, g, b, len(zones)]) + bytes(zones)
+            device.feature_request(SupportedFeature.HEADSET_RGB_HOSTMODE, FN_SET_RGB_ZONES_SINGLE, payload)
+            logger.debug(
+                "headset_rgb: set (%02X,%02X,%02X) on %d zone(s) %s",
+                r,
+                g,
+                b,
+                len(zones),
+                [f"0x{z:02X}" for z in zones],
+            )
+        # FrameEnd commits the pending per-zone updates. Transient commit
+        # only — persistent (0x02) requires onboard-profile preconditions
+        # that aren't mapped yet.
+        device.feature_request(
+            SupportedFeature.HEADSET_RGB_HOSTMODE,
+            FN_FRAME_END,
+            bytes([FRAME_TYPE_TRANSIENT, 0x00, 0x00, 0x00]),
+        )
+    except Exception as e:
+        logger.warning("headset_rgb: write_zone_map failed: %s", e)
+        return False
+    return True
+
+
+def zone_named_ints(zones: Iterable[int]):
+    """Build a list of NamedInt keys suitable for a ChoicesMap setting.
+
+    Factored out so settings code can import without pulling common.NamedInt
+    at module-load time if preferred.
+    """
+    from . import common
+
+    return [common.NamedInt(int(z), f"Zone {int(z)}") for z in zones]

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -215,9 +215,11 @@ class FeaturesArray(dict):
     def _discover_sub_device_features(self, bridge_index):
         """Phase B: Discover sub-device features via CentPPBridge.
 
-        Uses CenturionFeatureSet bulk query (function 1) routed through the bridge.
-        Each response fits only ~13-14 features in a single Centurion frame, so
-        we loop with increasing start_index until we see an empty batch.
+        Uses per-index queries: GetCount (func 0) returns total count, then
+        GetFeatureId (func 1) returns one feature per call. Avoids the
+        single-frame truncation of bulk queries — a Centurion frame is 64
+        bytes so a bulk reply can only fit ~13 features regardless of how
+        many the sub-device actually has.
         """
         # First, find the sub-device's FeatureSet index via CenturionRoot (sub_feat_idx=0)
         # Query: CenturionRoot.GetFeature(0x0001) to find FeatureSet index on sub-device
@@ -232,45 +234,34 @@ class FeaturesArray(dict):
             logger.warning("Sub-device FeatureSet not found (index=0)")
             return
 
-        # Bulk enumerate: CenturionFeatureSet.GetFeatureId(func=1=0x10, start_index=N)
-        # Response per batch: [count, (feat_hi, feat_lo, type, flags) × count]
-        sub_feat_idx = 0  # sub-device feature indices start at 0
-        max_batches = 16  # safety bound: 16 × 14 = 224 features max
-        for _batch in range(max_batches):
-            response = self.device.centurion_bridge_request(sub_fs_index, 0x10, sub_feat_idx)
-            if response is None or len(response) < 1:
-                break
-            entry_count = response[0]
-            if entry_count == 0:
-                break
-            entries = response[1:]
-            parsed_this_batch = 0
-            for i in range(entry_count):
-                offset = i * 4
-                if offset + 2 > len(entries):
-                    break
-                feat_id = struct.unpack("!H", entries[offset : offset + 2])[0]
-                try:
-                    feature = SupportedFeature(feat_id)
-                except ValueError:
-                    feature = f"unknown:{feat_id:04X}"
-                # Store sub-device index for ALL features (including parent overlaps)
-                # This enables querying the sub-device's copy of shared features via bridge
-                self.device._centurion_sub_indices[feature] = sub_feat_idx
-                # Only store unique sub-device features in dict (skip parent overlaps like ROOT, FEATURE_SET)
-                # This avoids clobbering parent inverse entries via __setitem__
-                if dict.get(self, feature) is None:
-                    dict.__setitem__(self, feature, sub_feat_idx)
-                    self.device._centurion_sub_features.add(feature)
-                # Always store in sub_inverse for sub-device enumerate/display
-                self.sub_inverse[sub_feat_idx] = feature
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug("Centurion sub-device feature: %s at sub-index %d", feature, sub_feat_idx)
-                sub_feat_idx += 1
-                parsed_this_batch += 1
-            # If this batch was short (device returned fewer than requested), we're done.
-            if parsed_this_batch < entry_count:
-                break
+        # Query feature count (function 0 = GetCount). Response: [count, ...].
+        count_resp = self.device.centurion_bridge_request(sub_fs_index, 0x00)
+        if count_resp is None or len(count_resp) < 1:
+            logger.warning("Failed to read Centurion sub-device feature count")
+            return
+        total_count = count_resp[0]
+        logger.info("Centurion sub-device: FeatureSet reports %d features", total_count)
+
+        # Per-index query: GetFeatureId (function 1 = 0x10). Response: [remaining, feat_hi, feat_lo, type, flags].
+        sub_feat_idx = 0
+        for idx in range(total_count):
+            response = self.device.centurion_bridge_request(sub_fs_index, 0x10, idx)
+            if response is None or len(response) < 3:
+                logger.debug("Centurion sub-device: no response at index %d", idx)
+                continue
+            feat_id = struct.unpack("!H", response[1:3])[0]
+            try:
+                feature = SupportedFeature(feat_id)
+            except ValueError:
+                feature = f"unknown:{feat_id:04X}"
+            self.device._centurion_sub_indices[feature] = sub_feat_idx
+            if dict.get(self, feature) is None:
+                dict.__setitem__(self, feature, sub_feat_idx)
+                self.device._centurion_sub_features.add(feature)
+            self.sub_inverse[sub_feat_idx] = feature
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug("Centurion sub-device feature: %s at sub-index %d", feature, sub_feat_idx)
+            sub_feat_idx += 1
         self._sub_feature_count = sub_feat_idx
         logger.info("Centurion sub-device: discovered %d features total", sub_feat_idx)
 

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -2305,9 +2305,12 @@ class ForceSensingButtonArray(UserDict):
 # --- OnboardEQ (0x0636) — re-exported from onboard_eq.py ---
 # --- AdvancedParaEQ (0x020D) — re-exported from advanced_para_eq.py ---
 from .advanced_para_eq import get_advanced_eq_active_slot  # noqa: E402, F401
+from .advanced_para_eq import get_advanced_eq_defaults  # noqa: E402, F401
+from .advanced_para_eq import get_advanced_eq_friendly_name  # noqa: E402, F401
 from .advanced_para_eq import get_advanced_eq_info  # noqa: E402, F401
 from .advanced_para_eq import get_advanced_eq_params  # noqa: E402, F401
 from .advanced_para_eq import parse_v2_bands  # noqa: E402, F401
+from .advanced_para_eq import probe_all_presets as probe_advanced_eq_presets  # noqa: E402, F401
 from .onboard_eq import _build_set_eq_payload  # noqa: E402, F401
 from .onboard_eq import get_onboard_eq_info  # noqa: E402, F401
 from .onboard_eq import get_onboard_eq_params  # noqa: E402, F401

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -242,7 +242,11 @@ class FeaturesArray(dict):
         total_count = count_resp[0]
         logger.info("Centurion sub-device: FeatureSet reports %d features", total_count)
 
-        # Per-index query: GetFeatureId (function 1 = 0x10). Response: [remaining, feat_hi, feat_lo, type, flags].
+        # Per-index query: GetFeatureId (function 1 = 0x10).
+        # Response: [remaining, feat_hi, feat_lo, type, version].
+        # We now also record `type` (flags) and `version` for each feature so
+        # version-gated settings (sidetone, auto-sleep, etc.) can use the
+        # correct payload format instead of defaulting to V0.
         sub_feat_idx = 0
         for idx in range(total_count):
             response = self.device.centurion_bridge_request(sub_fs_index, 0x10, idx)
@@ -250,6 +254,8 @@ class FeaturesArray(dict):
                 logger.debug("Centurion sub-device: no response at index %d", idx)
                 continue
             feat_id = struct.unpack("!H", response[1:3])[0]
+            feat_type = response[3] if len(response) > 3 else 0
+            feat_version = response[4] if len(response) > 4 else 0
             try:
                 feature = SupportedFeature(feat_id)
             except ValueError:
@@ -259,8 +265,18 @@ class FeaturesArray(dict):
                 dict.__setitem__(self, feature, sub_feat_idx)
                 self.device._centurion_sub_features.add(feature)
             self.sub_inverse[sub_feat_idx] = feature
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug("Centurion sub-device feature: %s at sub-index %d", feature, sub_feat_idx)
+            # Record version/flags so downstream settings can version-gate their
+            # payload format. get_feature_version(feature) reads self.version[feature].
+            self.version[feature] = feat_version
+            self.flags[feature] = feat_type
+            if feat_version > 0 and logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "Centurion sub-device feature: %s at sub-index %d, version=%d, flags=0x%02X",
+                    feature,
+                    sub_feat_idx,
+                    feat_version,
+                    feat_type,
+                )
             sub_feat_idx += 1
         self._sub_feature_count = sub_feat_idx
         logger.info("Centurion sub-device: discovered %d features total", sub_feat_idx)

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -2304,6 +2304,8 @@ class ForceSensingButtonArray(UserDict):
 
 # --- OnboardEQ (0x0636) — re-exported from onboard_eq.py ---
 # --- AdvancedParaEQ (0x020D) — re-exported from advanced_para_eq.py ---
+from .advanced_para_eq import FILTER_TYPE_HP  # noqa: E402, F401
+from .advanced_para_eq import FILTER_TYPE_PEAKING  # noqa: E402, F401
 from .advanced_para_eq import get_advanced_eq_active_slot  # noqa: E402, F401
 from .advanced_para_eq import get_advanced_eq_defaults  # noqa: E402, F401
 from .advanced_para_eq import get_advanced_eq_friendly_name  # noqa: E402, F401

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -333,6 +333,12 @@ class FeaturesArray(dict):
             index = super().get(feature)
             if index is not None:
                 return index
+            # Centurion devices enumerate all features upfront in _check_centurion().
+            # If the feature isn't in the dict after _check(), it genuinely doesn't
+            # exist — skip the raw ROOT.GetFeature query that the dongle rejects
+            # with LOGITECH_ERROR and that creates cycling log spam during settings init.
+            if getattr(self.device, "centurion", False):
+                return None
             try:
                 response = self.device.request(0x0000, struct.pack("!H", feature))
             except exceptions.FeatureCallError:

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -209,13 +209,14 @@ class FeaturesArray(dict):
             # use the correct payload format on direct USB Centurion devices too.
             self.version[feature] = feat_version
             self.flags[feature] = feat_type
-            logger.info(
-                "Centurion parent feature: %s at index %d, version=%d, flags=0x%02X",
-                feature,
-                index,
-                feat_version,
-                feat_type,
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "Centurion parent feature: %s at index %d, version=%d, flags=0x%02X",
+                    feature,
+                    index,
+                    feat_version,
+                    feat_type,
+                )
             if feature is CenturionCoreFeature.CENT_PP_BRIDGE:
                 bridge_index = index
 
@@ -253,7 +254,8 @@ class FeaturesArray(dict):
             logger.warning("Failed to read Centurion sub-device feature count")
             return
         total_count = count_resp[0]
-        logger.info("Centurion sub-device: FeatureSet reports %d features", total_count)
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Centurion sub-device: FeatureSet reports %d features", total_count)
 
         # Per-index query: GetFeatureId (function 1 = 0x10).
         # Response: [remaining, feat_hi, feat_lo, type, version].
@@ -282,19 +284,18 @@ class FeaturesArray(dict):
             # payload format. get_feature_version(feature) reads self.version[feature].
             self.version[feature] = feat_version
             self.flags[feature] = feat_type
-            # Log every sub-device feature at INFO so field diagnostics can see
-            # both the version (V-gated payload formats) and flags (INTERNAL/HIDDEN
-            # bits silently suppress settings panels in check_feature).
-            logger.info(
-                "Centurion sub-device feature: %s at sub-index %d, version=%d, flags=0x%02X",
-                feature,
-                sub_feat_idx,
-                feat_version,
-                feat_type,
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "Centurion sub-device feature: %s at sub-index %d, version=%d, flags=0x%02X",
+                    feature,
+                    sub_feat_idx,
+                    feat_version,
+                    feat_type,
+                )
             sub_feat_idx += 1
         self._sub_feature_count = sub_feat_idx
-        logger.info("Centurion sub-device: discovered %d features total", sub_feat_idx)
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Centurion sub-device: discovered %d features total", sub_feat_idx)
 
     def get_feature(self, index: int) -> SupportedFeature | None:
         feature = self.inverse.get(index)

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -215,8 +215,9 @@ class FeaturesArray(dict):
     def _discover_sub_device_features(self, bridge_index):
         """Phase B: Discover sub-device features via CentPPBridge.
 
-        Uses CenturionFeatureSet bulk query (function 1, index 0) routed through
-        the bridge to get all sub-device features at once.
+        Uses CenturionFeatureSet bulk query (function 1) routed through the bridge.
+        Each response fits only ~13-14 features in a single Centurion frame, so
+        we loop with increasing start_index until we see an empty batch.
         """
         # First, find the sub-device's FeatureSet index via CenturionRoot (sub_feat_idx=0)
         # Query: CenturionRoot.GetFeature(0x0001) to find FeatureSet index on sub-device
@@ -231,39 +232,47 @@ class FeaturesArray(dict):
             logger.warning("Sub-device FeatureSet not found (index=0)")
             return
 
-        # Bulk enumerate: CenturionFeatureSet.GetFeatureId(func=1=0x10, start_index=0)
-        # Response: [count, (feat_hi, feat_lo, type, flags) × count]
-        response = self.device.centurion_bridge_request(sub_fs_index, 0x10, 0x00)
-        if response is None or len(response) < 1:
-            logger.warning("Failed to enumerate sub-device features")
-            return
-
-        entry_count = response[0]
-        entries = response[1:]
+        # Bulk enumerate: CenturionFeatureSet.GetFeatureId(func=1=0x10, start_index=N)
+        # Response per batch: [count, (feat_hi, feat_lo, type, flags) × count]
         sub_feat_idx = 0  # sub-device feature indices start at 0
-        for i in range(entry_count):
-            offset = i * 4
-            if offset + 2 > len(entries):
+        max_batches = 16  # safety bound: 16 × 14 = 224 features max
+        for _batch in range(max_batches):
+            response = self.device.centurion_bridge_request(sub_fs_index, 0x10, sub_feat_idx)
+            if response is None or len(response) < 1:
                 break
-            feat_id = struct.unpack("!H", entries[offset : offset + 2])[0]
-            try:
-                feature = SupportedFeature(feat_id)
-            except ValueError:
-                feature = f"unknown:{feat_id:04X}"
-            # Store sub-device index for ALL features (including parent overlaps)
-            # This enables querying the sub-device's copy of shared features via bridge
-            self.device._centurion_sub_indices[feature] = sub_feat_idx
-            # Only store unique sub-device features in dict (skip parent overlaps like ROOT, FEATURE_SET)
-            # This avoids clobbering parent inverse entries via __setitem__
-            if dict.get(self, feature) is None:
-                dict.__setitem__(self, feature, sub_feat_idx)
-                self.device._centurion_sub_features.add(feature)
-            # Always store in sub_inverse for sub-device enumerate/display
-            self.sub_inverse[sub_feat_idx] = feature
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug("Centurion sub-device feature: %s at sub-index %d", feature, sub_feat_idx)
-            sub_feat_idx += 1
+            entry_count = response[0]
+            if entry_count == 0:
+                break
+            entries = response[1:]
+            parsed_this_batch = 0
+            for i in range(entry_count):
+                offset = i * 4
+                if offset + 2 > len(entries):
+                    break
+                feat_id = struct.unpack("!H", entries[offset : offset + 2])[0]
+                try:
+                    feature = SupportedFeature(feat_id)
+                except ValueError:
+                    feature = f"unknown:{feat_id:04X}"
+                # Store sub-device index for ALL features (including parent overlaps)
+                # This enables querying the sub-device's copy of shared features via bridge
+                self.device._centurion_sub_indices[feature] = sub_feat_idx
+                # Only store unique sub-device features in dict (skip parent overlaps like ROOT, FEATURE_SET)
+                # This avoids clobbering parent inverse entries via __setitem__
+                if dict.get(self, feature) is None:
+                    dict.__setitem__(self, feature, sub_feat_idx)
+                    self.device._centurion_sub_features.add(feature)
+                # Always store in sub_inverse for sub-device enumerate/display
+                self.sub_inverse[sub_feat_idx] = feature
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug("Centurion sub-device feature: %s at sub-index %d", feature, sub_feat_idx)
+                sub_feat_idx += 1
+                parsed_this_batch += 1
+            # If this batch was short (device returned fewer than requested), we're done.
+            if parsed_this_batch < entry_count:
+                break
         self._sub_feature_count = sub_feat_idx
+        logger.info("Centurion sub-device: discovered %d features total", sub_feat_idx)
 
     def get_feature(self, index: int) -> SupportedFeature | None:
         feature = self.inverse.get(index)

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -2307,6 +2307,7 @@ class ForceSensingButtonArray(UserDict):
 from .advanced_para_eq import get_advanced_eq_active_slot  # noqa: E402, F401
 from .advanced_para_eq import get_advanced_eq_info  # noqa: E402, F401
 from .advanced_para_eq import get_advanced_eq_params  # noqa: E402, F401
+from .advanced_para_eq import parse_v2_bands  # noqa: E402, F401
 from .onboard_eq import _build_set_eq_payload  # noqa: E402, F401
 from .onboard_eq import get_onboard_eq_info  # noqa: E402, F401
 from .onboard_eq import get_onboard_eq_params  # noqa: E402, F401

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -2272,6 +2272,10 @@ class ForceSensingButtonArray(UserDict):
 
 
 # --- OnboardEQ (0x0636) — re-exported from onboard_eq.py ---
+# --- AdvancedParaEQ (0x020D) — re-exported from advanced_para_eq.py ---
+from .advanced_para_eq import get_advanced_eq_active_slot  # noqa: E402, F401
+from .advanced_para_eq import get_advanced_eq_info  # noqa: E402, F401
+from .advanced_para_eq import get_advanced_eq_params  # noqa: E402, F401
 from .onboard_eq import _build_set_eq_payload  # noqa: E402, F401
 from .onboard_eq import get_onboard_eq_info  # noqa: E402, F401
 from .onboard_eq import get_onboard_eq_params  # noqa: E402, F401

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -196,13 +196,19 @@ class FeaturesArray(dict):
             response = self.device.request((fs_index << 8) | 0x10, index)
             if response is None or len(response) < 3:
                 continue
-            # Centurion FeatureSet response: [remaining_count, feat_hi, feat_lo, type, flags]
+            # Centurion FeatureSet response: [remaining_count, feat_hi, feat_lo, type, version]
             feat_id = struct.unpack("!H", response[1:3])[0]
+            feat_type = response[3] if len(response) > 3 else 0
+            feat_version = response[4] if len(response) > 4 else 0
             feature = resolve_feature(feat_id, centurion=True)
             if feature is None:
                 feature = f"unknown:{feat_id:04X}"
             self[feature] = index
             self.inverse[index] = feature
+            # Record version/flags so version-gated settings (sidetone, auto-sleep)
+            # use the correct payload format on direct USB Centurion devices too.
+            self.version[feature] = feat_version
+            self.flags[feature] = feat_type
             if feature is CenturionCoreFeature.CENT_PP_BRIDGE:
                 bridge_index = index
 

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -209,6 +209,13 @@ class FeaturesArray(dict):
             # use the correct payload format on direct USB Centurion devices too.
             self.version[feature] = feat_version
             self.flags[feature] = feat_type
+            logger.info(
+                "Centurion parent feature: %s at index %d, version=%d, flags=0x%02X",
+                feature,
+                index,
+                feat_version,
+                feat_type,
+            )
             if feature is CenturionCoreFeature.CENT_PP_BRIDGE:
                 bridge_index = index
 
@@ -275,14 +282,16 @@ class FeaturesArray(dict):
             # payload format. get_feature_version(feature) reads self.version[feature].
             self.version[feature] = feat_version
             self.flags[feature] = feat_type
-            if feat_version > 0 and logger.isEnabledFor(logging.DEBUG):
-                logger.debug(
-                    "Centurion sub-device feature: %s at sub-index %d, version=%d, flags=0x%02X",
-                    feature,
-                    sub_feat_idx,
-                    feat_version,
-                    feat_type,
-                )
+            # Log every sub-device feature at INFO so field diagnostics can see
+            # both the version (V-gated payload formats) and flags (INTERNAL/HIDDEN
+            # bits silently suppress settings panels in check_feature).
+            logger.info(
+                "Centurion sub-device feature: %s at sub-index %d, version=%d, flags=0x%02X",
+                feature,
+                sub_feat_idx,
+                feat_version,
+                feat_type,
+            )
             sub_feat_idx += 1
         self._sub_feature_count = sub_feat_idx
         logger.info("Centurion sub-device: discovered %d features total", sub_feat_idx)

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -197,13 +197,27 @@ class FeaturesArray(dict):
             response = self.device.request((fs_index << 8) | 0x10, index)
             if response is None or len(response) < 3:
                 continue
-            # Centurion FeatureSet response: [remaining_count, feat_hi, feat_lo, type, flags]
+            # Centurion FeatureSet response: [remaining_count, feat_hi, feat_lo, type, version]
             feat_id = struct.unpack("!H", response[1:3])[0]
+            feat_type = response[3] if len(response) > 3 else 0
+            feat_version = response[4] if len(response) > 4 else 0
             feature = resolve_feature(feat_id, centurion=True)
             if feature is None:
                 feature = f"unknown:{feat_id:04X}"
             self[feature] = index
             self.inverse[index] = feature
+            # Record version/flags so version-gated settings (sidetone, auto-sleep)
+            # use the correct payload format on direct USB Centurion devices too.
+            self.version[feature] = feat_version
+            self.flags[feature] = feat_type
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "Centurion parent feature: %s at index %d, version=%d, flags=0x%02X",
+                    feature,
+                    index,
+                    feat_version,
+                    feat_type,
+                )
             if feature is CenturionCoreFeature.CENT_PP_BRIDGE:
                 bridge_index = index
 
@@ -216,8 +230,11 @@ class FeaturesArray(dict):
     def _discover_sub_device_features(self, bridge_index):
         """Phase B: Discover sub-device features via CentPPBridge.
 
-        Uses CenturionFeatureSet bulk query (function 1, index 0) routed through
-        the bridge to get all sub-device features at once.
+        Uses per-index queries: GetCount (func 0) returns total count, then
+        GetFeatureId (func 1) returns one feature per call. Avoids the
+        single-frame truncation of bulk queries — a Centurion frame is 64
+        bytes so a bulk reply can only fit ~13 features regardless of how
+        many the sub-device actually has.
         """
         # First, find the sub-device's FeatureSet index via CenturionRoot (sub_feat_idx=0)
         # Query: CenturionRoot.GetFeature(0x0001) to find FeatureSet index on sub-device
@@ -232,44 +249,62 @@ class FeaturesArray(dict):
             logger.warning("Sub-device FeatureSet not found (index=0)")
             return
 
-        # Bulk enumerate: CenturionFeatureSet.GetFeatureId(func=1=0x10, start_index=0)
-        # Response: [count, (feat_hi, feat_lo, type, flags) × count]
-        response = self.device.centurion_bridge_request(sub_fs_index, 0x10, 0x00)
-        if response is None or len(response) < 1:
-            logger.warning("Failed to enumerate sub-device features")
+        # Query feature count (function 0 = GetCount). Response: [count, ...].
+        count_resp = self.device.centurion_bridge_request(sub_fs_index, 0x00)
+        if count_resp is None or len(count_resp) < 1:
+            logger.warning("Failed to read Centurion sub-device feature count")
             return
+        total_count = count_resp[0]
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Centurion sub-device: FeatureSet reports %d features", total_count)
 
-        entry_count = response[0]
-        entries = response[1:]
-        sub_feat_idx = 0  # sub-device feature indices start at 0
-        for i in range(entry_count):
-            offset = i * 4
-            if offset + 2 > len(entries):
-                break
-            feat_id = struct.unpack("!H", entries[offset : offset + 2])[0]
+        # Per-index query: GetFeatureId (function 1 = 0x10).
+        # Response: [remaining, feat_hi, feat_lo, type, version].
+        # We now also record `type` (flags) and `version` for each feature so
+        # version-gated settings (sidetone, auto-sleep, etc.) can use the
+        # correct payload format instead of defaulting to V0.
+        sub_feat_idx = 0
+        for idx in range(total_count):
+            response = self.device.centurion_bridge_request(sub_fs_index, 0x10, idx)
+            if response is None or len(response) < 3:
+                logger.debug("Centurion sub-device: no response at index %d", idx)
+                continue
+            feat_id = struct.unpack("!H", response[1:3])[0]
+            feat_type = response[3] if len(response) > 3 else 0
+            feat_version = response[4] if len(response) > 4 else 0
             try:
                 feature = SupportedFeature(feat_id)
             except ValueError:
                 feature = f"unknown:{feat_id:04X}"
-            # Store sub-device index for ALL features (including parent overlaps)
-            # This enables querying the sub-device's copy of shared features via bridge
             self.device._centurion_sub_indices[feature] = sub_feat_idx
-            # Only store unique sub-device features in dict (skip parent overlaps like ROOT, FEATURE_SET)
-            # This avoids clobbering parent inverse entries via __setitem__
             if dict.get(self, feature) is None:
                 dict.__setitem__(self, feature, sub_feat_idx)
                 self.device._centurion_sub_features.add(feature)
-            # Always store in sub_inverse for sub-device enumerate/display
             self.sub_inverse[sub_feat_idx] = feature
+            # Record version/flags so downstream settings can version-gate their
+            # payload format. get_feature_version(feature) reads self.version[feature].
+            self.version[feature] = feat_version
+            self.flags[feature] = feat_type
             if logger.isEnabledFor(logging.DEBUG):
-                logger.debug("Centurion sub-device feature: %s at sub-index %d", feature, sub_feat_idx)
+                logger.debug(
+                    "Centurion sub-device feature: %s at sub-index %d, version=%d, flags=0x%02X",
+                    feature,
+                    sub_feat_idx,
+                    feat_version,
+                    feat_type,
+                )
             sub_feat_idx += 1
         self._sub_feature_count = sub_feat_idx
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Centurion sub-device: discovered %d features total", sub_feat_idx)
 
     def get_feature(self, index: int) -> SupportedFeature | None:
         feature = self.inverse.get(index)
         if feature is not None:
             return feature
+        # Sub-device index; bridge unwrap offsets by 0x100 (see listener).
+        if index >= 0x100:
+            return self.sub_inverse.get(index - 0x100)
         elif self._check():
             feature = self.inverse.get(index)
             if feature is not None:
@@ -334,6 +369,12 @@ class FeaturesArray(dict):
             index = super().get(feature)
             if index is not None:
                 return index
+            # Centurion devices enumerate all features upfront in _check_centurion().
+            # If the feature isn't in the dict after _check(), it genuinely doesn't
+            # exist — skip the raw ROOT.GetFeature query that the dongle rejects
+            # with LOGITECH_ERROR and that creates cycling log spam during settings init.
+            if getattr(self.device, "centurion", False):
+                return None
             try:
                 response = self.device.request(0x0000, struct.pack("!H", feature))
             except exceptions.FeatureCallError:
@@ -2365,6 +2406,18 @@ class ForceSensingButtonArray(UserDict):
 
 
 # --- OnboardEQ (0x0636) — re-exported from onboard_eq.py ---
+# --- AdvancedParaEQ (0x020D) — re-exported from advanced_para_eq.py ---
+from .advanced_para_eq import FILTER_TYPE_HP  # noqa: E402, F401
+from .advanced_para_eq import FILTER_TYPE_PEAKING  # noqa: E402, F401
+from .advanced_para_eq import FILTER_TYPE_PEAKING_G522  # noqa: E402, F401
+from .advanced_para_eq import get_advanced_eq_active_slot  # noqa: E402, F401
+from .advanced_para_eq import get_advanced_eq_defaults  # noqa: E402, F401
+from .advanced_para_eq import get_advanced_eq_friendly_name  # noqa: E402, F401
+from .advanced_para_eq import get_advanced_eq_info  # noqa: E402, F401
+from .advanced_para_eq import get_advanced_eq_params  # noqa: E402, F401
+from .advanced_para_eq import parse_v2_bands  # noqa: E402, F401
+from .advanced_para_eq import probe_advanced_eq_slots  # noqa: E402, F401
+from .advanced_para_eq import probe_all_presets as probe_advanced_eq_presets  # noqa: E402, F401
 from .onboard_eq import _build_set_eq_payload  # noqa: E402, F401
 from .onboard_eq import get_onboard_eq_info  # noqa: E402, F401
 from .onboard_eq import get_onboard_eq_params  # noqa: E402, F401

--- a/lib/logitech_receiver/hidpp20_constants.py
+++ b/lib/logitech_receiver/hidpp20_constants.py
@@ -214,6 +214,10 @@ class SupportedFeature(IntEnum):
     HEADSET_RGB_HOSTMODE = 0x0620
     HEADSET_RGB_ONBOARD_EFFECTS = 0x0621
     HEADSET_RGB_SIGNATURE_EFFECTS = 0x0622
+    # 0x0623 is present on G522 sub-device but its function set is unmapped;
+    # add probe coverage in rgb_effects_probe so the next bring-up captures
+    # whatever read functions respond.
+    HEADSET_RGB_0623 = 0x0623
     HEADSET_DO_NOT_DISTURB = 0x0631
     CENTURION_ONBOARD_PROFILES = 0x0634
     HEADSET_RGB_STREAMING = 0x0635

--- a/lib/logitech_receiver/hidpp20_constants.py
+++ b/lib/logitech_receiver/hidpp20_constants.py
@@ -214,10 +214,6 @@ class SupportedFeature(IntEnum):
     HEADSET_RGB_HOSTMODE = 0x0620
     HEADSET_RGB_ONBOARD_EFFECTS = 0x0621
     HEADSET_RGB_SIGNATURE_EFFECTS = 0x0622
-    # 0x0623 is present on G522 sub-device but its function set is unmapped;
-    # add probe coverage in rgb_effects_probe so the next bring-up captures
-    # whatever read functions respond.
-    HEADSET_RGB_0623 = 0x0623
     HEADSET_DO_NOT_DISTURB = 0x0631
     CENTURION_ONBOARD_PROFILES = 0x0634
     HEADSET_RGB_STREAMING = 0x0635

--- a/lib/logitech_receiver/listener.py
+++ b/lib/logitech_receiver/listener.py
@@ -15,6 +15,7 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import dataclasses
 import logging
 import queue
 import threading
@@ -52,9 +53,11 @@ class _ThreadedHandle:
         else:
             # if logger.isEnabledFor(logging.DEBUG):
             #     logger.debug("%r opened new handle %d", self, handle)
-            # If original handle was centurion, register new per-thread handle too
-            if any(h in base._centurion_handles for h in self._handles):
-                base._centurion_handles.add(handle)
+            # If original handle was centurion, copy state to new per-thread handle
+            for h in self._handles:
+                if h in base._centurion_handles:
+                    base._centurion_handles[handle] = dataclasses.replace(base._centurion_handles[h])
+                    break
             self._local.handle = handle
             self._handles.append(handle)
             return handle

--- a/lib/logitech_receiver/logivoice.py
+++ b/lib/logitech_receiver/logivoice.py
@@ -1,0 +1,250 @@
+## Copyright (C) 2024  Solaar Contributors https://pwr-solaar.github.io/Solaar/
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License along
+## with this program; if not, write to the Free Software Foundation, Inc.,
+## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""LogiVoice (0x0900 + 0x0901-0x0907) read helpers.
+
+Each LogiVoice processing module exposes the same 5-function API:
+
+  fn 0 SetState
+  fn 1 GetState       -> u8 state
+  fn 2 SetParameters
+  fn 3 GetParameters  -> module-specific payload
+  fn 4 GetInfo        -> device capability / bounds (opaque here)
+
+All multi-byte integers on the wire are big-endian. Parameters layouts
+are module-specific; PARAMETERS_FIELDS below encodes the per-field
+offset/width/signedness/range metadata we display read-only. Some
+fields are intentionally flagged `opaque=True` because their scale
+factor or bit layout isn't pinned down yet — we still expose the raw
+value so users/screenshots can build a corpus.
+
+Writes are NOT implemented yet. This is a read-only pass for data
+collection and visibility; write support can be added per-field once
+each encoding is verified live.
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+from typing import Iterable
+
+from .hidpp20_constants import SupportedFeature
+
+logger = logging.getLogger(__name__)
+
+# Wire function IDs (standard across all LogiVoice modules).
+FN_SET_STATE = 0x00
+FN_GET_STATE = 0x10
+FN_SET_PARAMETERS = 0x20
+FN_GET_PARAMETERS = 0x30
+FN_GET_INFO = 0x40
+
+# Human-readable names for the modules Solaar may see on a LogiVoice device.
+MODULE_NAMES = {
+    SupportedFeature.LOGIVOICE: "LogiVoice",
+    SupportedFeature.LOGIVOICE_NOISE_REDUCTION: "Noise Reduction",
+    SupportedFeature.LOGIVOICE_NOISE_GATE: "Noise Gate",
+    SupportedFeature.LOGIVOICE_COMPRESSOR: "Compressor",
+    SupportedFeature.LOGIVOICE_DE_ESSER: "De-esser",
+    SupportedFeature.LOGIVOICE_DE_POPPER: "De-popper",
+    SupportedFeature.LOGIVOICE_LIMITER: "Limiter",
+    SupportedFeature.LOGIVOICE_HIGH_PASS_FILTER: "High Pass Filter",
+}
+
+# Short slugs used in Solaar setting IDs (`logivoice-<slug>-<field>`).
+MODULE_SLUGS = {
+    SupportedFeature.LOGIVOICE_NOISE_REDUCTION: "nr",
+    SupportedFeature.LOGIVOICE_NOISE_GATE: "ng",
+    SupportedFeature.LOGIVOICE_COMPRESSOR: "comp",
+    SupportedFeature.LOGIVOICE_DE_ESSER: "deesser",
+    SupportedFeature.LOGIVOICE_DE_POPPER: "depopper",
+    SupportedFeature.LOGIVOICE_LIMITER: "limiter",
+    SupportedFeature.LOGIVOICE_HIGH_PASS_FILTER: "hpf",
+}
+
+
+class Field:
+    """Metadata for one decoded Parameters field.
+
+    offset:     byte offset within the GetParameters payload.
+    byte_count: width (1 or 2 for fields we currently decode).
+    signed:     whether to interpret as signed int.
+    min_value/max_value: range for the Solaar slider validator. For opaque
+                fields, use the full representable range (0..255 or 0..65535).
+    label:      human-readable name for UI.
+    opaque:     True if the field's wire encoding isn't pinned down — label
+                shows raw units and the caller should treat as round-trip.
+    """
+
+    def __init__(self, name, offset, byte_count, signed, min_value, max_value, label, opaque=False):
+        self.name = name
+        self.offset = offset
+        self.byte_count = byte_count
+        self.signed = signed
+        self.min_value = min_value
+        self.max_value = max_value
+        self.label = label
+        self.opaque = opaque
+
+
+# Per-module field layout for GetParameters response. Table-driven so adding
+# a new module or adjusting a field is a one-line change. Fields flagged
+# opaque=True have unknown scale / bit layout; we expose the raw bytes so a
+# future pass can pin them down from live data.
+PARAMETERS_FIELDS: dict[SupportedFeature, list[Field]] = {
+    SupportedFeature.LOGIVOICE_NOISE_REDUCTION: [
+        Field("state", 0, 1, False, 0, 255, "State"),
+        Field("sensitivity", 2, 2, False, 0, 65535, "Sensitivity"),
+        # NR serializer emits 5 bytes; byte 4 is a single-byte release surrogate.
+        Field("release_byte", 4, 1, False, 0, 255, "Release (raw)", opaque=True),
+    ],
+    SupportedFeature.LOGIVOICE_NOISE_GATE: [
+        Field("state", 0, 1, False, 0, 255, "State"),
+        Field("threshold", 1, 1, True, -128, 127, "Threshold (raw)", opaque=True),
+        Field("attenuation", 2, 2, False, 0, 65535, "Attenuation (raw)", opaque=True),
+        Field("attack", 4, 2, False, 0, 65535, "Attack (raw)", opaque=True),
+        Field("hold", 6, 2, False, 0, 65535, "Hold (raw)", opaque=True),
+    ],
+    SupportedFeature.LOGIVOICE_COMPRESSOR: [
+        Field("state", 0, 1, False, 0, 255, "State"),
+        Field("threshold", 2, 2, True, -32768, 32767, "Threshold (raw)", opaque=True),
+        Field("attack", 4, 2, False, 0, 65535, "Attack (raw)", opaque=True),
+        Field("post_gain", 6, 1, True, -128, 127, "Post Gain (raw)", opaque=True),
+        # Byte 7 packs pre_gain + ratio; bit layout unknown. Display raw byte.
+        Field("byte7_packed", 7, 1, False, 0, 255, "Byte 7 (pre_gain/ratio packed)", opaque=True),
+    ],
+    SupportedFeature.LOGIVOICE_DE_ESSER: [
+        Field("state", 0, 1, False, 0, 255, "State"),
+        Field("threshold", 1, 2, True, -32768, 32767, "Threshold (raw)", opaque=True),
+        # Frequency compressed from float to u8 with device-specific scale.
+        Field("frequency_raw", 3, 1, False, 0, 255, "Frequency (raw u8)", opaque=True),
+        Field("width_q_raw", 4, 2, False, 0, 65535, "Width/Q (raw u16)", opaque=True),
+        Field("attack", 6, 2, False, 0, 65535, "Attack (raw)", opaque=True),
+        Field("release", 8, 1, True, -128, 127, "Release (raw)", opaque=True),
+    ],
+    SupportedFeature.LOGIVOICE_DE_POPPER: [
+        Field("state", 0, 1, False, 0, 255, "State"),
+        Field("threshold", 1, 2, True, -32768, 32767, "Threshold (raw)", opaque=True),
+        Field("frequency_raw", 3, 1, False, 0, 255, "Frequency (raw u8)", opaque=True),
+        Field("width_q_raw", 4, 2, False, 0, 65535, "Width/Q (raw u16)", opaque=True),
+        Field("attack", 6, 2, False, 0, 65535, "Attack (raw)", opaque=True),
+        Field("release", 8, 1, True, -128, 127, "Release (raw)", opaque=True),
+    ],
+    SupportedFeature.LOGIVOICE_LIMITER: [
+        Field("state", 0, 1, False, 0, 255, "State"),
+        Field("boost", 2, 2, True, -32768, 32767, "Boost (raw)", opaque=True),
+        Field("bytes4_5_packed", 4, 2, False, 0, 65535, "Bytes 4-5 (attack/release packed)", opaque=True),
+    ],
+    SupportedFeature.LOGIVOICE_HIGH_PASS_FILTER: [
+        # HPF has no state byte in Parameters — state lives on fn 0/1 only.
+        Field("frequency", 0, 2, False, 0, 65535, "Cutoff (Hz)"),
+    ],
+}
+
+
+def expected_payload_length(feature: SupportedFeature) -> int:
+    fields = PARAMETERS_FIELDS.get(feature)
+    if not fields:
+        return 0
+    return max(f.offset + f.byte_count for f in fields)
+
+
+def get_state(device, feature: SupportedFeature):
+    """Read the module's on/off state via fn 1. Returns int 0-255 or None."""
+    result = device.feature_request(feature, FN_GET_STATE)
+    if result is None or len(result) < 1:
+        return None
+    return result[0]
+
+
+def get_parameters(device, feature: SupportedFeature):
+    """Read the module's Parameters struct via fn 3. Returns raw bytes or None."""
+    result = device.feature_request(feature, FN_GET_PARAMETERS)
+    if result is None:
+        return None
+    return bytes(result)
+
+
+def get_info(device, feature: SupportedFeature):
+    """Read module capability info via fn 4. Returns raw bytes or None.
+
+    Per-module Info layout isn't decoded yet — we log the raw hex for corpus.
+    """
+    result = device.feature_request(feature, FN_GET_INFO)
+    if result is None:
+        return None
+    return bytes(result)
+
+
+def parse_parameters(feature: SupportedFeature, payload: bytes) -> dict:
+    """Decode Parameters bytes into a dict per the per-module field table.
+
+    Returns {} on unknown feature or short payload — caller still has the raw
+    hex via get_parameters() for corpus logging.
+    """
+    fields = PARAMETERS_FIELDS.get(feature)
+    if not fields or payload is None:
+        return {}
+    parsed = {}
+    for f in fields:
+        end = f.offset + f.byte_count
+        if end > len(payload):
+            continue
+        chunk = payload[f.offset : end]
+        if f.byte_count == 1:
+            val = struct.unpack("b" if f.signed else "B", chunk)[0]
+        elif f.byte_count == 2:
+            val = struct.unpack(">h" if f.signed else ">H", chunk)[0]
+        else:
+            val = int.from_bytes(chunk, "big", signed=f.signed)
+        parsed[f.name] = val
+    return parsed
+
+
+def probe_module(device, feature: SupportedFeature) -> None:
+    """One-shot corpus probe. Logs state + raw parameters + parsed + raw info."""
+    name = MODULE_NAMES.get(feature, f"0x{int(feature):04X}")
+    state = get_state(device, feature)
+    params = get_parameters(device, feature)
+    info = get_info(device, feature)
+    logger.info(
+        "LogiVoice %s [0x%04X]: state=%s parameters=%s info=%s",
+        name,
+        int(feature),
+        state,
+        params.hex() if params else None,
+        info.hex() if info else None,
+    )
+    parsed = parse_parameters(feature, params) if params else {}
+    if parsed:
+        logger.info("LogiVoice %s parsed: %s", name, parsed)
+
+
+def probe_all_modules(device, features: Iterable[SupportedFeature]) -> None:
+    """Probe every LogiVoice module present on the device.
+
+    Call once at device-bring-up so the -dd corpus has a full snapshot.
+    Caller passes whichever subset of LogiVoice features are actually
+    discovered (usually derived from device.features).
+    """
+    for feature in features:
+        if feature not in PARAMETERS_FIELDS and feature != SupportedFeature.LOGIVOICE:
+            continue
+        try:
+            probe_module(device, feature)
+        except Exception as e:
+            logger.info("LogiVoice probe_module(%s) raised %s", feature, e)

--- a/lib/logitech_receiver/logivoice.py
+++ b/lib/logitech_receiver/logivoice.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import logging
 import struct
+
 from typing import Iterable
 
 from .hidpp20_constants import SupportedFeature

--- a/lib/logitech_receiver/logivoice.py
+++ b/lib/logitech_receiver/logivoice.py
@@ -1,0 +1,300 @@
+## Copyright (C) 2024  Solaar Contributors https://pwr-solaar.github.io/Solaar/
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License along
+## with this program; if not, write to the Free Software Foundation, Inc.,
+## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""LogiVoice (0x0900 + 0x0901-0x0907) read helpers.
+
+Each LogiVoice processing module exposes the same 5-function API:
+
+  fn 0 SetState
+  fn 1 GetState       -> u8 state (boolean)
+  fn 2 SetParameters
+  fn 3 GetParameters  -> module-specific payload (see PARAMETERS_FIELDS)
+  fn 4 GetInfo        -> per-field [min, max] bounds (see parse_info)
+
+All multi-byte integers on the wire are big-endian. Parameters layouts are
+module-specific; PARAMETERS_FIELDS encodes per-field offset / width /
+signedness / range / label metadata. The first field is at offset 0 — there
+is no leading "state" byte (the state toggle is on fn 0/1 only).
+
+Writes are NOT implemented yet. State toggles via fn 0x00/0x10 are
+shipping as boolean settings; per-field Parameters writes need a live
+round-trip verification before they're safe to expose.
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+
+from typing import Iterable
+
+from .hidpp20_constants import SupportedFeature
+
+logger = logging.getLogger(__name__)
+
+# Wire function IDs (standard across all LogiVoice modules).
+FN_SET_STATE = 0x00
+FN_GET_STATE = 0x10
+FN_SET_PARAMETERS = 0x20
+FN_GET_PARAMETERS = 0x30
+FN_GET_INFO = 0x40
+
+# Human-readable names for the modules Solaar may see on a LogiVoice device.
+MODULE_NAMES = {
+    SupportedFeature.LOGIVOICE: "LogiVoice",
+    SupportedFeature.LOGIVOICE_NOISE_REDUCTION: "Noise Reduction",
+    SupportedFeature.LOGIVOICE_NOISE_GATE: "Noise Gate",
+    SupportedFeature.LOGIVOICE_COMPRESSOR: "Compressor",
+    SupportedFeature.LOGIVOICE_DE_ESSER: "De-esser",
+    SupportedFeature.LOGIVOICE_DE_POPPER: "De-popper",
+    SupportedFeature.LOGIVOICE_LIMITER: "Limiter",
+    SupportedFeature.LOGIVOICE_HIGH_PASS_FILTER: "High Pass Filter",
+}
+
+# Short slugs used in Solaar setting IDs (`logivoice-<slug>-<field>`).
+MODULE_SLUGS = {
+    SupportedFeature.LOGIVOICE_NOISE_REDUCTION: "nr",
+    SupportedFeature.LOGIVOICE_NOISE_GATE: "ng",
+    SupportedFeature.LOGIVOICE_COMPRESSOR: "comp",
+    SupportedFeature.LOGIVOICE_DE_ESSER: "deesser",
+    SupportedFeature.LOGIVOICE_DE_POPPER: "depopper",
+    SupportedFeature.LOGIVOICE_LIMITER: "limiter",
+    SupportedFeature.LOGIVOICE_HIGH_PASS_FILTER: "hpf",
+}
+
+
+class Field:
+    """Metadata for one decoded Parameters field.
+
+    offset:     byte offset within the GetParameters payload.
+    byte_count: width (1 or 2 for fields we currently decode).
+    signed:     whether to interpret as signed int.
+    min_value/max_value: range for the Solaar slider validator. For opaque
+                fields, use the full representable range (0..255 or 0..65535).
+    label:      human-readable name for UI.
+    opaque:     True if the field's wire encoding isn't pinned down — label
+                shows raw units and the caller should treat as round-trip.
+    """
+
+    def __init__(self, name, offset, byte_count, signed, min_value, max_value, label, opaque=False):
+        self.name = name
+        self.offset = offset
+        self.byte_count = byte_count
+        self.signed = signed
+        self.min_value = min_value
+        self.max_value = max_value
+        self.label = label
+        self.opaque = opaque
+
+
+# Per-module field layout for GetParameters / SetParameters payload. Each
+# module's struct is the union of named fields below; there is no separate
+# "state" byte at offset 0 — that toggle is only on fn 0x00/0x10. Field
+# encodings (signedness, byte order, units) and value ranges come from the
+# device's GetInfo response (see parse_info) and are confirmed against
+# captured bring-up bytes; ranges hardcoded here are the bounds the device
+# reports and the values it ships as factory defaults.
+#
+# `opaque=True` is reserved for fields whose unit scale isn't pinned down
+# (currently width_q on De-esser / De-popper — the host-side scale constant
+# is loaded at runtime and not statically resolvable). Treat opaque values
+# as monotonic raw integers until a live probe anchors the units.
+PARAMETERS_FIELDS: dict[SupportedFeature, list[Field]] = {
+    SupportedFeature.LOGIVOICE_NOISE_REDUCTION: [
+        Field("sensitivity", 0, 1, False, 0, 40, "Sensitivity"),
+        Field("release", 1, 2, False, 1, 1000, "Release (ms)"),
+        Field("bias", 3, 1, False, 0, 5, "Bias"),
+        Field("attenuation", 4, 1, True, -20, 0, "Attenuation (dB)"),
+    ],
+    SupportedFeature.LOGIVOICE_NOISE_GATE: [
+        Field("threshold", 0, 1, True, -60, -35, "Threshold (dB)"),
+        Field("attenuation", 1, 1, True, -50, -3, "Attenuation (dB)"),
+        Field("attack", 2, 2, False, 1, 200, "Attack (ms)"),
+        Field("hold", 4, 2, False, 1, 1000, "Hold (ms)"),
+        Field("release", 6, 2, False, 1, 1000, "Release (ms)"),
+    ],
+    SupportedFeature.LOGIVOICE_COMPRESSOR: [
+        Field("threshold", 0, 1, True, -40, 0, "Threshold (dB)"),
+        Field("attack", 1, 2, False, 1, 200, "Attack (ms)"),
+        Field("release", 3, 2, False, 50, 1000, "Release (ms)"),
+        Field("post_gain", 5, 1, True, -12, 12, "Post Gain (dB)"),
+        Field("pre_gain", 6, 1, True, -12, 12, "Pre Gain (dB)"),
+        # Ratio reports min=1 max=20 from GetInfo; whether the device interprets
+        # it as a literal X:1 ratio or a curve-table index is unconfirmed.
+        Field("ratio", 7, 1, False, 1, 20, "Ratio"),
+    ],
+    SupportedFeature.LOGIVOICE_DE_ESSER: [
+        Field("threshold", 0, 1, True, -50, 0, "Threshold (dB)"),
+        Field("frequency", 1, 2, False, 1000, 10000, "Frequency (Hz)"),
+        # width_q is a Q-format quantization with a device-loaded scale we
+        # don't know; range/default come straight from GetInfo.
+        Field("width_q", 3, 1, False, 2, 120, "Width/Q", opaque=True),
+        Field("attack", 4, 2, False, 1, 200, "Attack (ms)"),
+        Field("release", 6, 2, False, 20, 1000, "Release (ms)"),
+        Field("attenuation", 8, 1, True, -40, 0, "Attenuation (dB)"),
+    ],
+    SupportedFeature.LOGIVOICE_DE_POPPER: [
+        Field("threshold", 0, 1, True, -50, 0, "Threshold (dB)"),
+        Field("frequency", 1, 2, False, 60, 500, "Frequency (Hz)"),
+        Field("width_q", 3, 1, False, 2, 120, "Width/Q", opaque=True),
+        Field("attack", 4, 2, False, 1, 200, "Attack (ms)"),
+        Field("release", 6, 2, False, 20, 1000, "Release (ms)"),
+        Field("attenuation", 8, 1, True, -40, 0, "Attenuation (dB)"),
+    ],
+    SupportedFeature.LOGIVOICE_LIMITER: [
+        Field("boost", 0, 1, True, -128, 127, "Boost (dB)"),
+        Field("attack", 1, 2, False, 1, 65535, "Attack (ms)"),
+        Field("release", 3, 2, False, 1, 65535, "Release (ms)"),
+    ],
+    SupportedFeature.LOGIVOICE_HIGH_PASS_FILTER: [
+        Field("frequency", 0, 2, False, 60, 300, "Cutoff (Hz)"),
+    ],
+}
+
+
+def expected_payload_length(feature: SupportedFeature) -> int:
+    fields = PARAMETERS_FIELDS.get(feature)
+    if not fields:
+        return 0
+    return max(f.offset + f.byte_count for f in fields)
+
+
+def get_state(device, feature: SupportedFeature):
+    """Read the module's on/off state via fn 1. Returns int 0-255 or None."""
+    result = device.feature_request(feature, FN_GET_STATE)
+    if result is None or len(result) < 1:
+        return None
+    return result[0]
+
+
+def get_parameters(device, feature: SupportedFeature):
+    """Read the module's Parameters struct via fn 3. Returns raw bytes or None."""
+    result = device.feature_request(feature, FN_GET_PARAMETERS)
+    if result is None:
+        return None
+    return bytes(result)
+
+
+def get_info(device, feature: SupportedFeature):
+    """Read module capability info via fn 4. Returns raw bytes or None.
+
+    Decoded per-field bounds are available via parse_info().
+    """
+    result = device.feature_request(feature, FN_GET_INFO)
+    if result is None:
+        return None
+    return bytes(result)
+
+
+def _decode_field(chunk: bytes, byte_count: int, signed: bool) -> int:
+    """Decode `byte_count` bytes from `chunk` as an integer per the field's wire
+    encoding. Multi-byte values are big-endian (matches Parameters)."""
+    if byte_count == 1:
+        return struct.unpack("b" if signed else "B", chunk[:1])[0]
+    if byte_count == 2:
+        return struct.unpack(">h" if signed else ">H", chunk[:2])[0]
+    return int.from_bytes(chunk[:byte_count], "big", signed=signed)
+
+
+def parse_info(feature: SupportedFeature, payload: bytes) -> dict:
+    """Decode a GetInfo response into per-field {min, max} bounds.
+
+    Layout: for each field in PARAMETERS_FIELDS in order, the payload carries
+    [min_value, max_value] back-to-back using the field's wire encoding (so
+    a u16 field contributes 4 bytes — 2 for min, 2 for max). Trailing bytes
+    in the response are pad/zero.
+
+    Returns a dict mapping field name to {"min": int, "max": int}. Fields
+    that don't fit in the payload are omitted.
+    """
+    fields = PARAMETERS_FIELDS.get(feature)
+    if not fields or not payload:
+        return {}
+    out = {}
+    offset = 0
+    for f in fields:
+        end = offset + 2 * f.byte_count
+        if end > len(payload):
+            break
+        min_val = _decode_field(payload[offset : offset + f.byte_count], f.byte_count, f.signed)
+        max_val = _decode_field(payload[offset + f.byte_count : end], f.byte_count, f.signed)
+        out[f.name] = {"min": min_val, "max": max_val}
+        offset = end
+    return out
+
+
+def parse_parameters(feature: SupportedFeature, payload: bytes) -> dict:
+    """Decode Parameters bytes into a dict per the per-module field table.
+
+    Returns {} on unknown feature or short payload — caller still has the raw
+    hex via get_parameters() for corpus logging.
+    """
+    fields = PARAMETERS_FIELDS.get(feature)
+    if not fields or payload is None:
+        return {}
+    parsed = {}
+    for f in fields:
+        end = f.offset + f.byte_count
+        if end > len(payload):
+            continue
+        chunk = payload[f.offset : end]
+        if f.byte_count == 1:
+            val = struct.unpack("b" if f.signed else "B", chunk)[0]
+        elif f.byte_count == 2:
+            val = struct.unpack(">h" if f.signed else ">H", chunk)[0]
+        else:
+            val = int.from_bytes(chunk, "big", signed=f.signed)
+        parsed[f.name] = val
+    return parsed
+
+
+def probe_module(device, feature: SupportedFeature) -> None:
+    """One-shot corpus probe. Logs state + raw parameters + parsed + raw info
+    + decoded info bounds."""
+    name = MODULE_NAMES.get(feature, f"0x{int(feature):04X}")
+    state = get_state(device, feature)
+    params = get_parameters(device, feature)
+    info = get_info(device, feature)
+    logger.debug(
+        "LogiVoice %s [0x%04X]: state=%s parameters=%s info=%s",
+        name,
+        int(feature),
+        state,
+        params.hex() if params else None,
+        info.hex() if info else None,
+    )
+    parsed = parse_parameters(feature, params) if params else {}
+    if parsed:
+        logger.debug("LogiVoice %s parsed: %s", name, parsed)
+    bounds = parse_info(feature, info) if info else {}
+    if bounds:
+        logger.debug("LogiVoice %s info bounds: %s", name, bounds)
+
+
+def probe_all_modules(device, features: Iterable[SupportedFeature]) -> None:
+    """Probe every LogiVoice module present on the device.
+
+    Call once at device-bring-up so the -dd corpus has a full snapshot.
+    Caller passes whichever subset of LogiVoice features are actually
+    discovered (usually derived from device.features).
+    """
+    for feature in features:
+        if feature not in PARAMETERS_FIELDS and feature != SupportedFeature.LOGIVOICE:
+            continue
+        try:
+            probe_module(device, feature)
+        except Exception as e:
+            logger.debug("LogiVoice probe_module(%s) raised %s", feature, e)

--- a/lib/logitech_receiver/notifications.py
+++ b/lib/logitech_receiver/notifications.py
@@ -436,6 +436,47 @@ def _process_feature_notification(device: Device, notification: HIDPPNotificatio
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("%s: RGB_EFFECTS notification addr=%02x: %s", device, notification.address, notification)
 
+    elif feature == SupportedFeature.HEADSET_ADVANCED_PARA_EQ:
+        # G522 emits change events with the same payload shape as the
+        # corresponding setter request:
+        #   fn 0 — band change       (3-byte header [dir, slot, pad] + bands)
+        #   fn 2 — friendly-name change (header + nameLen + name)
+        #   fn 3 — UUID change          (header + 16-byte UUID)
+        # Low nibble of `address` is the swid the firmware echoes back —
+        # match on the function index only.
+        fn = notification.address >> 4
+        if fn == 0:
+            info = getattr(device, "_advanced_eq_info", None)
+            payload = notification.data[3:] if notification.data else b""
+            if info and len(payload) >= 5:
+                bands = hidpp20.parse_v2_bands(b"\x00" + payload, info)
+                if bands and device.setting_callback:
+                    band_map = {i: int(round(g)) for i, (_t, _f, g) in enumerate(bands)}
+                    device.setting_callback(device, settings_templates.HeadsetAdvancedEQ, [band_map])
+            elif logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "%s: HEADSET_ADVANCED_PARA_EQ band-change event with no parseable payload %s", device, notification
+                )
+        elif fn in (2, 3) and logger.isEnabledFor(logging.DEBUG):
+            logger.debug("%s: HEADSET_ADVANCED_PARA_EQ fn=%d change event %s", device, fn, notification)
+        elif logger.isEnabledFor(logging.DEBUG):
+            logger.debug("%s: unknown HEADSET_ADVANCED_PARA_EQ %s", device, notification)
+
+    elif feature == SupportedFeature.HEADSET_MIC_MUTE:
+        # G522 emits state-change events on two function indices, both carrying
+        # the new state in data[0] (0 = unmuted, 1 = muted):
+        #   fn 0 — physical mute switch press
+        #   fn 1 — echo following a host-driven SetState (fn 2) write
+        # Low nibble of `address` is the swid the firmware echoes back, which
+        # varies with the request — match on the function index only.
+        fn = notification.address >> 4
+        if fn in (0, 1) and notification.data:
+            muted = bool(notification.data[0])
+            if device.setting_callback:
+                device.setting_callback(device, settings_templates.HeadsetMicMute, [muted])
+        elif logger.isEnabledFor(logging.DEBUG):
+            logger.debug("%s: unknown HEADSET_MIC_MUTE %s", device, notification)
+
     diversion.process_notification(device, notification, feature)
     return True
 

--- a/lib/logitech_receiver/onboard_eq.py
+++ b/lib/logitech_receiver/onboard_eq.py
@@ -27,11 +27,9 @@ import struct
 
 from .hidpp20_constants import SupportedFeature
 
-# Mystery bytes observed in every LGHUB pcap EQ write between band params
-# and coefficient header.  Purpose not fully understood — possibly a null-band
-# terminator for DSPs that support >5 bands (advanced 10-band mode).
-# First byte matches band_count; bytes 2-3 look like LE16 coeff blob size.
-# Hardcoded from pcap for initial bring-up; revisit once device-tested.
+# Opaque bytes observed between band params and coefficient header. First
+# byte matches band_count; bytes 2-3 look like LE16 coeff blob size. Keep
+# verbatim until a device counter-example forces a re-derivation.
 _EQ_MYSTERY_BYTES = b"\x05\x5a\xe3\x00"
 
 
@@ -85,7 +83,7 @@ def _build_coeff_section(bands, sample_rate, section_type=1):
     coefficients (a1, a2) are left unchanged. The DSP multiplies the output by
     rescale to restore correct gain.
     """
-    _HEADROOM = 1.19  # 19% headroom margin (matches LGHUB)
+    _HEADROOM = 1.19  # 19% headroom margin before quantization
     num_bands = len(bands)
     all_words = [num_bands]  # first uint16 = num_bands
 

--- a/lib/logitech_receiver/rgb_effects_probe.py
+++ b/lib/logitech_receiver/rgb_effects_probe.py
@@ -1,8 +1,7 @@
-"""Read-only corpus probe for the headset RGB feature triplet:
+"""Read-only corpus probe for the headset RGB feature pair:
 
   - HEADSET_RGB_ONBOARD_EFFECTS  (0x0621)
   - HEADSET_RGB_SIGNATURE_EFFECTS (0x0622)
-  - HEADSET_RGB_0623             (0x0623, function set unmapped)
 
 Logs raw response bytes and lengths at INFO so field testers without
 ``-dd`` can still capture the data. All calls are strictly read-side —
@@ -180,24 +179,6 @@ def probe_onboard_effects(device) -> None:
     _call(device, feature, 0x40)
 
 
-def probe_unknown_0623(device) -> None:
-    """Probe 0x0623 (purpose unmapped) — present on G522 sub-device.
-
-    Function set unknown. Try a small window of low function indexes to
-    capture whatever responds. Strictly read-side; we don't know what
-    arguments the functions take so we just call each with no payload
-    and let the device 0x0A any function that needs args.
-    """
-    feature = SupportedFeature.HEADSET_RGB_0623
-    if not device.features or feature not in device.features:
-        return
-    logger.debug("RGB probe: 0x0623 HEADSET_RGB_0623 present on %s", device)
-    # Functions 0..7 covers the typical "info / get* / get*" range; if
-    # anything responds we'll have first bytes to triangulate against.
-    for fn_idx in range(8):
-        _call(device, feature, fn_idx << 4)
-
-
 def probe_signature_effects(device) -> None:
     """Probe 0x0622 RGBSignatureEffects read-side functions."""
     feature = SupportedFeature.HEADSET_RGB_SIGNATURE_EFFECTS
@@ -236,7 +217,3 @@ def probe(device) -> None:
         probe_signature_effects(device)
     except Exception as e:
         logger.debug("RGB probe: signature-effects probe raised %r", e)
-    try:
-        probe_unknown_0623(device)
-    except Exception as e:
-        logger.debug("RGB probe: 0x0623 probe raised %r", e)

--- a/lib/logitech_receiver/rgb_effects_probe.py
+++ b/lib/logitech_receiver/rgb_effects_probe.py
@@ -1,0 +1,242 @@
+"""Read-only corpus probe for the headset RGB feature triplet:
+
+  - HEADSET_RGB_ONBOARD_EFFECTS  (0x0621)
+  - HEADSET_RGB_SIGNATURE_EFFECTS (0x0622)
+  - HEADSET_RGB_0623             (0x0623, function set unmapped)
+
+Logs raw response bytes and lengths at INFO so field testers without
+``-dd`` can still capture the data. All calls are strictly read-side —
+no setters are invoked. If a feature isn't present the probe
+short-circuits cleanly.
+
+Pcap analysis of G HUB's color-set traffic confirmed that on 0x0621,
+``setRGBClusterEffect`` (fn 0x30) takes a 10-byte payload
+``[cluster, effect_id_BE_u16, R, G, B, ...]`` where ``effect_id=0x0000``
+means "Static (with RGB)" — this is also the slot-0 entry in the
+fn 0x10 ``getRGBClusterInfo`` reply, which we decode structurally so
+the test corpus shows effect-id semantics in plaintext.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from . import exceptions
+from .hidpp20_constants import SupportedFeature
+
+logger = logging.getLogger(__name__)
+
+
+def _hex_or_none(data) -> str | None:
+    return data.hex() if data else None
+
+
+def _format_feature(feat) -> str:
+    """Render a feature for the log: 0x{id:04X}{:NAME} when known, else raw.
+
+    Unknown features are stored as the string "unknown:HHHH" by the feature
+    discovery code, so handle that shape explicitly — int(feat) on those
+    raises ValueError. Wrap the rest in a broad except so a future unhandled
+    feature shape can't kill the whole table dump.
+    """
+    if feat is None:
+        return "?"
+    if isinstance(feat, str):
+        if feat.startswith("unknown:") and len(feat) > 8:
+            return f"0x{feat[8:].upper()}"
+        return feat
+    try:
+        return f"0x{int(feat):04X}:{feat.name}"
+    except (AttributeError, TypeError, ValueError):
+        try:
+            return f"0x{int(feat):04X}"
+        except (TypeError, ValueError):
+            return repr(feat)
+
+
+def _log_feature_table(device) -> None:
+    if not device.features:
+        return
+    try:
+        # Parent features live in FeaturesArray.inverse, indexed by their
+        # parent feature-set position. On Centurion devices these are the
+        # ones the dongle itself exposes (typically 5-6 entries).
+        parent = []
+        for idx in range(len(device.features)):
+            parent.append(f"{idx}:{_format_feature(device.features[idx])}")
+        logger.debug("RGB probe: parent features for %s: %s", device, ", ".join(parent))
+
+        # Centurion sub-device features live in FeaturesArray.sub_inverse,
+        # keyed by sub-device feature index. These are where the actual
+        # headset features (0x0620/0x0621/0x0622, LogiVoice, EQ, mic mute,
+        # …) live — without dumping them the log shows only the dongle's
+        # parent features and gives the wrong impression that the device
+        # has nothing else.
+        sub_inverse = getattr(device.features, "sub_inverse", None)
+        if sub_inverse:
+            sub = [f"{idx}:{_format_feature(feat)}" for idx, feat in sorted(sub_inverse.items())]
+            logger.debug("RGB probe: sub-device features for %s: %s", device, ", ".join(sub))
+    except Exception as e:
+        logger.debug("RGB probe: feature-table dump failed: %s", e)
+
+
+def _call(device, feature: SupportedFeature, fn: int, *params):
+    """Wrap feature_request with uniform INFO logging.
+
+    Returns the raw bytes on success, None on transport/no-feature, and
+    doesn't raise — FeatureCallError is caught and logged as an error code.
+    """
+    label = f"0x{int(feature):04X}.fn{fn:02X}"
+    if params:
+        label += "(" + ",".join(f"{b:02X}" for b in params) + ")"
+    try:
+        resp = device.feature_request(feature, fn, *params)
+    except exceptions.FeatureCallError as e:
+        logger.debug("RGB probe: %s err=0x%02X", label, getattr(e, "error", 0) & 0xFF)
+        return None
+    except Exception as e:
+        logger.debug("RGB probe: %s raised %r", label, e)
+        return None
+    if resp is None:
+        logger.debug("RGB probe: %s no reply (feature unsupported or transport failure)", label)
+        return None
+    logger.debug("RGB probe: %s resp=%s len=%d", label, _hex_or_none(resp), len(resp))
+    return resp
+
+
+# Names for known effect_ids on the headset RGB cluster. Confirmed via
+# pcap analysis of G HUB color-set traffic: setRGBClusterEffect with
+# effect_id=0x0000 + RGB writes a static color, so 0x0000 is "Static"
+# rather than the "Off / Disabled" we'd guessed from cluster ordering.
+# Other ids haven't been observed on the wire yet — names are placeholder
+# until further pcap traffic confirms them.
+_EFFECT_ID_NAMES = {
+    0x0000: "Static",
+    0x0001: "Effect 0x0001",
+    0x0006: "Effect 0x0006",
+    0x0007: "Effect 0x0007",
+    0x000F: "Effect 0x000F",
+    0x007F: "Effect 0x007F",
+}
+
+
+def _decode_cluster_info(resp) -> str | None:
+    """Decode a 0x0621 fn 0x10 getRGBClusterInfo reply into a readable
+    summary. Best-effort — returns None on unexpected length/shape.
+
+    Observed shape on G522: 4-byte records (effect_id LE u16, slot_idx
+    LE u16). The effect_id at slot 0 is 0x0000 = "Static" (with RGB),
+    confirmed by pcap of G HUB color-set traffic. Records continue
+    until trailing-zero padding.
+
+    Note: most HID++ multi-byte fields are BE, but this particular
+    response uses LE — confirmed against captured factory-default bytes
+    on G522 where the values 0x0001 / 0x000F / 0x007F appear at byte 0
+    of each record with byte 1 = 0x00 (consistent with LE u16).
+    """
+    if not resp or len(resp) < 4:
+        return None
+    effects = []
+    seen_static = False
+    for i in range(0, len(resp) - 3, 4):
+        eid = resp[i] | (resp[i + 1] << 8)
+        slot = resp[i + 2] | (resp[i + 3] << 8)
+        # Skip purely-zero padding once we've seen the (effect=0, slot=0) entry.
+        if eid == 0 and slot == 0:
+            if seen_static:
+                continue
+            seen_static = True
+        name = _EFFECT_ID_NAMES.get(eid, f"0x{eid:04X}")
+        effects.append(f"slot={slot}:{name}")
+    return ", ".join(effects) if effects else None
+
+
+def probe_onboard_effects(device) -> None:
+    """Probe 0x0621 RGBOnboardEffects read-side functions."""
+    feature = SupportedFeature.HEADSET_RGB_ONBOARD_EFFECTS
+    if not device.features or feature not in device.features:
+        return
+    logger.debug("RGB probe: 0x0621 HEADSET_RGB_ONBOARD_EFFECTS present on %s", device)
+
+    # fn 0x00 getInfo — empty payload
+    _call(device, feature, 0x00)
+
+    # fn 0x10 getRGBClusterInfo — iterate cluster indexes 0..7, stop on error.
+    for cluster_idx in range(8):
+        resp = _call(device, feature, 0x10, cluster_idx)
+        if resp is None:
+            break
+        decoded = _decode_cluster_info(resp)
+        if decoded:
+            logger.debug("RGB probe: 0x0621.fn10(%02X) decoded: %s", cluster_idx, decoded)
+
+    # fn 0x20 getRGBClusterEffect — current state per cluster.
+    for cluster_idx in range(8):
+        resp = _call(device, feature, 0x20, cluster_idx)
+        if resp is None:
+            break
+
+    # fn 0x40 getRGBCustomEffectName — single call, documented.
+    _call(device, feature, 0x40)
+
+
+def probe_unknown_0623(device) -> None:
+    """Probe 0x0623 (purpose unmapped) — present on G522 sub-device.
+
+    Function set unknown. Try a small window of low function indexes to
+    capture whatever responds. Strictly read-side; we don't know what
+    arguments the functions take so we just call each with no payload
+    and let the device 0x0A any function that needs args.
+    """
+    feature = SupportedFeature.HEADSET_RGB_0623
+    if not device.features or feature not in device.features:
+        return
+    logger.debug("RGB probe: 0x0623 HEADSET_RGB_0623 present on %s", device)
+    # Functions 0..7 covers the typical "info / get* / get*" range; if
+    # anything responds we'll have first bytes to triangulate against.
+    for fn_idx in range(8):
+        _call(device, feature, fn_idx << 4)
+
+
+def probe_signature_effects(device) -> None:
+    """Probe 0x0622 RGBSignatureEffects read-side functions."""
+    feature = SupportedFeature.HEADSET_RGB_SIGNATURE_EFFECTS
+    if not device.features or feature not in device.features:
+        return
+    logger.debug("RGB probe: 0x0622 HEADSET_RGB_SIGNATURE_EFFECTS present on %s", device)
+
+    # fn 0x00 getSignatureEffectsInfo.
+    _call(device, feature, 0x00)
+
+    # fn 0x10 getSignatureEffectParams — iterate effectId 0..2 (Startup/Shutdown/Passive).
+    # effectId is u16 BE.
+    for eid in range(3):
+        _call(device, feature, 0x10, (eid >> 8) & 0xFF, eid & 0xFF)
+
+    # fn 0x30 getSignatureEffectState — same effectId range.
+    for eid in range(3):
+        _call(device, feature, 0x30, (eid >> 8) & 0xFF, eid & 0xFF)
+
+
+def probe(device) -> None:
+    """Run both read-only RGB-effects probes once per device.
+
+    Gated via ``_rgb_effects_probed`` so re-entry on reconnect / setting
+    rebuild doesn't spam the log with duplicate corpus dumps.
+    """
+    if getattr(device, "_rgb_effects_probed", False):
+        return
+    device._rgb_effects_probed = True
+    _log_feature_table(device)
+    try:
+        probe_onboard_effects(device)
+    except Exception as e:
+        logger.debug("RGB probe: onboard-effects probe raised %r", e)
+    try:
+        probe_signature_effects(device)
+    except Exception as e:
+        logger.debug("RGB probe: signature-effects probe raised %r", e)
+    try:
+        probe_unknown_0623(device)
+    except Exception as e:
+        logger.debug("RGB probe: 0x0623 probe raised %r", e)

--- a/lib/logitech_receiver/settings.py
+++ b/lib/logitech_receiver/settings.py
@@ -172,8 +172,16 @@ class Setting:
                     logger.debug("%s: prepare write(%s) => %r", self.name, value, data_bytes)
 
                 reply = self._rw.write(self._device, data_bytes)
-                if not reply:
-                    # tell whomever is calling that the write failed
+                # HID++ 2.0 "set" operations often return an empty ACK (b"").
+                # Treating empty bytes as failure (`not reply`) would misreport
+                # successful writes as errors to the GUI. Only report failure
+                # when the transport actually returned None (error or timeout).
+                if reply is None:
+                    logger.info(
+                        "%s: write on %s returned no reply (transport error/timeout)",
+                        self.name,
+                        self._device,
+                    )
                     return None
 
             return value

--- a/lib/logitech_receiver/settings.py
+++ b/lib/logitech_receiver/settings.py
@@ -181,8 +181,16 @@ class Setting:
                     logger.debug("%s: prepare write(%s) => %r", self.name, value, data_bytes)
 
                 reply = self._rw.write(self._device, data_bytes)
-                if not reply:
-                    # tell whomever is calling that the write failed
+                # HID++ 2.0 "set" operations often return an empty ACK (b"").
+                # Treating empty bytes as failure (`not reply`) would misreport
+                # successful writes as errors to the GUI. Only report failure
+                # when the transport actually returned None (error or timeout).
+                if reply is None:
+                    logger.info(
+                        "%s: write on %s returned no reply (transport error/timeout)",
+                        self.name,
+                        self._device,
+                    )
                     return None
 
             return value

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1706,8 +1706,8 @@ class HeadsetMicGain(settings.Setting):
                     info.hex(),
                 )
                 min_gain, max_gain = cls.min_value, cls.max_value
-            else:
-                logger.info(
+            elif logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
                     "HeadsetMicGain: device reports gain range [%d, %d]",
                     min_gain,
                     max_gain,
@@ -1992,25 +1992,6 @@ class HeadsetRGBHostMode(settings.Setting):
     rw_options = {"read_fnid": 0x70, "write_fnid": 0x80}
     validator_class = settings_validator.BooleanValidator
 
-    def write(self, value, save=True):
-        # Diagnostic wrapper: log what GetHostModeState returns immediately
-        # before AND after the SetHostModeState write, so we can see whether
-        # (a) the write takes effect on the device or (b) our decoding of the
-        # response is wrong. solaar show has been reporting this value as
-        # False even after writes we believed succeeded.
-        try:
-            before = self._device.feature_request(self.feature, 0x70)
-        except Exception as e:
-            before = f"<err:{e}>"
-        logger.info("HeadsetRGBHostMode.write: before=%s requested=%s", before, value)
-        result = super().write(value, save=save)
-        try:
-            after = self._device.feature_request(self.feature, 0x70)
-        except Exception as e:
-            after = f"<err:{e}>"
-        logger.info("HeadsetRGBHostMode.write: after=%s write_returned=%s", after, result)
-        return result
-
 
 class HeadsetRGBColor(settings.Setting):
     """Pick a color from the shared `special_keys.COLORS` palette and apply it
@@ -2137,23 +2118,23 @@ class HeadsetRGBColor(settings.Setting):
         # the device to report sane zone IDs and let the device reject nonsense.
         tight = list(resp[1 : 1 + zone_count]) if 1 <= zone_count <= len(resp) - 1 else []
         if tight and len(tight) == zone_count:
-            logger.info(
-                "HeadsetRGBColor: discovered %d zone(s) %s (tight format, raw resp=%s)",
-                len(tight),
-                [f"0x{z:02X}" for z in tight],
-                resp.hex(),
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "HeadsetRGBColor: discovered %d zone(s) %s (tight format)",
+                    len(tight),
+                    [f"0x{z:02X}" for z in tight],
+                )
             device._headset_rgb_zone_ids = tight
             return tight
         # Try the doc's format (with reserved gap) as fallback
         gap = list(resp[5 : 5 + zone_count]) if len(resp) >= 5 + zone_count else []
         if gap and len(gap) == zone_count:
-            logger.info(
-                "HeadsetRGBColor: discovered %d zone(s) %s (doc format, raw resp=%s)",
-                len(gap),
-                [f"0x{z:02X}" for z in gap],
-                resp.hex(),
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "HeadsetRGBColor: discovered %d zone(s) %s (doc format)",
+                    len(gap),
+                    [f"0x{z:02X}" for z in gap],
+                )
             device._headset_rgb_zone_ids = gap
             return gap
         # Neither format parsed cleanly; don't cache so next write retries.

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1768,6 +1768,79 @@ class HeadsetOnboardEQ(settings.RangeFieldSetting):
         return result
 
 
+class HeadsetAdvancedEQ(settings.RangeFieldSetting):
+    """Read-only display of the headset's active AdvancedParaEQ (0x020D) bands.
+
+    Writes are intentionally disabled for now — we want to verify the wire
+    format matches the protocol doc on real hardware before allowing any
+    changes that could misconfigure the device DSP. Once confirmed working
+    we'll wire up write() to call setCustomEQ.
+
+    Bands come from getActiveEQ → getCustomEQ on the playback direction.
+    Each band entry is [freq_hi, freq_lo, gain_db] (3-byte stride). Unlike
+    OnboardEQ (0x0636), the device handles biquad coefficient computation
+    — we just send frequency and gain.
+    """
+
+    name = "headset-advanced-eq"
+    label = _("Headset Advanced EQ (read-only)")
+    description = _("Display the headset's active parametric EQ. Writes are disabled pending verification.")
+    feature = _F.HEADSET_ADVANCED_PARA_EQ
+    rw_options = {"read_fnid": 0x10, "write_fnid": 0x20, "read_prefix": b"\x00\x00"}
+    keys_universe = []
+
+    class validator_class(settings_validator.PackedRangeValidator):
+        kind = settings.Kind.GRAPHIC_EQ
+
+        @classmethod
+        def build(cls, setting_class, device):
+            info = hidpp20.get_advanced_eq_info(device)
+            if not info:
+                return None
+            band_count, _db_range, _caps, db_min, db_max = info
+            # Use the active slot on playback direction so the displayed EQ
+            # matches what the user is actually hearing.
+            active_slot = hidpp20.get_advanced_eq_active_slot(device, direction=0) or 0
+            bands = hidpp20.get_advanced_eq_params(device, direction=0, slot=active_slot)
+            if not bands or len(bands) != band_count:
+                return None
+            keys = common.NamedInts()
+            for i, (freq, _gain) in enumerate(bands):
+                keys[i] = str(freq) + _("Hz")
+            v = cls(keys, min_value=db_min, max_value=db_max, count=band_count, byte_count=1)
+            v._band_freqs = [freq for freq, _g in bands]
+            v._active_slot = active_slot
+            return v
+
+        def validate_read(self, reply_bytes):
+            # Response: tight-packed 3-byte entries [freq_hi, freq_lo, gain].
+            if reply_bytes is None:
+                return {}
+            result = {}
+            offset = 0
+            i = 0
+            while offset + 3 <= len(reply_bytes) and i < self.count:
+                freq = struct.unpack(">H", reply_bytes[offset : offset + 2])[0]
+                if freq == 0:
+                    break
+                gain = struct.unpack("b", bytes([reply_bytes[offset + 2]]))[0]
+                result[i] = gain
+                if hasattr(self, "_band_freqs") and i < len(self._band_freqs):
+                    self._band_freqs[i] = freq
+                offset += 3
+                i += 1
+            return result
+
+        def prepare_write(self, new_values):
+            # Read-only mode: never actually build a write payload.
+            return None
+
+    def write(self, map, save=True):
+        # Read-only for now — log attempted writes but don't transmit anything.
+        logger.info("HeadsetAdvancedEQ: write ignored (read-only mode); requested=%s", map)
+        return None
+
+
 class HeadsetRGBHostMode(settings.Setting):
     """Toggle host control of headset RGB lighting.
 
@@ -2396,6 +2469,7 @@ SETTINGS: list[settings.Setting] = [
     HeadsetMixBalance,
     HeadsetAutoSleep,
     HeadsetOnboardEQ,
+    HeadsetAdvancedEQ,
     HeadsetRGBHostMode,
     HeadsetRGBColor,
 ]

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1748,25 +1748,23 @@ class HeadsetAutoSleep(settings.Setting):
     rw_options = {"read_fnid": 0x00, "write_fnid": 0x10}
     validator_class = settings_validator.RangeValidator
     min_value = 0
-    # Timer byte count depends on feature version:
-    #   V<3 : 1 byte (0-255)
-    #   V=3 : 2 bytes (0-65535)
-    #   V>=4: 3 bytes (0-16777215)
-    # build() picks the correct width based on the device's reported version.
-    max_value = 0xFFFFFF
+    # Wire format byte count depends on feature version (V<3: 1B, V=3: 2B, V>=4: 3B).
+    # UI slider is capped at 240 min regardless — firmware accepts larger values, but
+    # a 31-year slider (24-bit max) is not useful.
+    max_value = 240
     validator_options = {"byte_count": 1}
 
     @classmethod
     def build(cls, device):
         version = device.features.get_feature_version(cls.feature) or 0
         if version >= 4:
-            byte_count, max_value = 3, 0xFFFFFF
+            byte_count = 3
         elif version >= 3:
-            byte_count, max_value = 2, 0xFFFF
+            byte_count = 2
         else:
-            byte_count, max_value = 1, 0xFF
+            byte_count = 1
         rw = settings.FeatureRW(cls.feature, **cls.rw_options)
-        validator = settings_validator.RangeValidator(min_value=0, max_value=max_value, byte_count=byte_count)
+        validator = settings_validator.RangeValidator(min_value=0, max_value=cls.max_value, byte_count=byte_count)
         return cls(device, rw, validator)
 
 
@@ -1785,10 +1783,19 @@ class HeadsetOnboardEQ(settings.RangeFieldSetting):
         def build(cls, setting_class, device):
             info = hidpp20.get_onboard_eq_info(device)
             if not info:
+                logger.info("HeadsetOnboardEQ.build: getEQInfo failed, no panel will be built")
                 return None
             _has_hw_eq, num_bands = info
             bands = hidpp20.get_onboard_eq_params(device, slot=0x00)
-            if not bands or len(bands) != num_bands:
+            if not bands:
+                logger.info("HeadsetOnboardEQ.build: getEQParameters returned no bands, no panel will be built")
+                return None
+            if len(bands) != num_bands:
+                logger.info(
+                    "HeadsetOnboardEQ.build: band count mismatch — EQInfo=%d getEQParameters=%d; skipping",
+                    num_bands,
+                    len(bands),
+                )
                 return None
             keys = common.NamedInts()
             for i, (freq, _gain, _q) in enumerate(bands):
@@ -1796,6 +1803,7 @@ class HeadsetOnboardEQ(settings.RangeFieldSetting):
             v = cls(keys, min_value=-12, max_value=12, count=num_bands, byte_count=1)
             v._band_freqs = [freq for freq, _g, _q in bands]
             v._band_qs = [q for _f, _g, q in bands]
+            logger.info("HeadsetOnboardEQ.build: panel built with %d band(s)", num_bands)
             return v
 
         def validate_read(self, reply_bytes):
@@ -1872,13 +1880,22 @@ class HeadsetAdvancedEQ(settings.RangeFieldSetting):
         def build(cls, setting_class, device):
             info = hidpp20.get_advanced_eq_info(device)
             if not info:
+                logger.info("HeadsetAdvancedEQ.build: getEQInfos failed, no panel will be built")
                 return None
             band_count, _db_range, _caps, db_min, db_max = info
             # Use the active slot on playback direction so the displayed EQ
             # matches what the user is actually hearing.
             active_slot = hidpp20.get_advanced_eq_active_slot(device, direction=0) or 0
             bands = hidpp20.get_advanced_eq_params(device, direction=0, slot=active_slot)
-            if not bands or len(bands) != band_count:
+            if not bands:
+                logger.info("HeadsetAdvancedEQ.build: getCustomEQ returned no bands, no panel will be built")
+                return None
+            if len(bands) != band_count:
+                logger.info(
+                    "HeadsetAdvancedEQ.build: band count mismatch — EQInfos=%d getCustomEQ=%d; skipping",
+                    band_count,
+                    len(bands),
+                )
                 return None
             keys = common.NamedInts()
             for i, (freq, _gain) in enumerate(bands):
@@ -1886,6 +1903,13 @@ class HeadsetAdvancedEQ(settings.RangeFieldSetting):
             v = cls(keys, min_value=db_min, max_value=db_max, count=band_count, byte_count=1)
             v._band_freqs = [freq for freq, _g in bands]
             v._active_slot = active_slot
+            logger.info(
+                "HeadsetAdvancedEQ.build: panel built with %d band(s), slot=%d, range=[%d,%d]",
+                band_count,
+                active_slot,
+                db_min,
+                db_max,
+            )
             return v
 
         def validate_read(self, reply_bytes):
@@ -2697,8 +2721,22 @@ def check_feature(device, settings_class: SettingsProtocol) -> None | bool | Set
     if settings_class.feature not in device.features:
         return
     if settings_class.min_version > device.features.get_feature_version(settings_class.feature):
+        logger.info(
+            "check_feature %s [%s]: min_version=%d > device feature version=%d; skipping",
+            settings_class.name,
+            settings_class.feature,
+            settings_class.min_version,
+            device.features.get_feature_version(settings_class.feature) or 0,
+        )
         return
     if device.features.get_hidden(settings_class.feature):
+        flags = device.features.flags.get(settings_class.feature, 0)
+        logger.info(
+            "check_feature %s [%s]: feature has INTERNAL flag set (flags=0x%02X); skipping",
+            settings_class.name,
+            settings_class.feature,
+            flags,
+        )
         return
     try:
         detected = settings_class.build(device)

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -2028,7 +2028,11 @@ class HeadsetRGBColor(settings.Setting):
                 resp.hex() if resp else resp,
             )
             # FrameEnd: commit the frame.
-            resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x60, b"\x00\x00\x00\x00")
+            # Byte 0 is frame_type: 0x01 = transient commit, 0x02 = persistent/final
+            # flush. The firmware silently discards frames when byte 0 is 0x00 —
+            # canonical protocol doc was wrong on this point. See
+            # HEADSET_RGB_HOSTMODE_WIRE_PROTOCOL.md.
+            resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x60, b"\x01\x00\x00\x00")
             logger.info("HeadsetRGBColor: FrameEnd resp=%s", resp.hex() if resp else resp)
         except Exception as e:
             logger.warning("HeadsetRGBColor write failed for %s: %s", name, e)

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -33,6 +33,7 @@ from . import descriptors
 from . import desktop_notifications
 from . import diversion
 from . import exceptions
+from . import headset_rgb
 from . import hidpp20
 from . import hidpp20_constants
 from . import logivoice
@@ -1979,172 +1980,241 @@ class HeadsetAdvancedEQ(settings.RangeFieldSetting):
         return None
 
 
-class HeadsetRGBHostMode(settings.Setting):
-    """Toggle host control of headset RGB lighting.
+_NO_CHANGE_COLOR = int(special_keys.COLORSPLUS["No change"])
 
-    When enabled, solaar drives the LEDs via HeadsetRGBColor. When disabled,
-    firmware-driven onboard/signature effects resume.
+
+def _headset_setting_by_name(device, name):
+    for s in getattr(device, "settings", None) or []:
+        if getattr(s, "name", None) == name:
+            return s
+    return None
+
+
+def _headset_primary_color(device, default=0xFFFFFF):
+    """Resolve the currently-saved Primary color, or `default` if absent."""
+    s = _headset_setting_by_name(device, HeadsetLEDsPrimary.name)
+    if s is None:
+        return default
+    value = getattr(s, "_value", None)
+    color = getattr(value, "color", None) if value is not None else None
+    return int(color) if color is not None else default
+
+
+def _headset_per_zone_overrides(device):
+    """Return `{zone_id: color_int}` for zones with explicit (non-'No change')
+    colors set via the Per-zone Lighting setting, or `None` if the setting
+    isn't built/present."""
+    s = _headset_setting_by_name(device, HeadsetPerZoneLighting.name)
+    if s is None:
+        return None
+    value = getattr(s, "_value", None)
+    if not isinstance(value, dict):
+        return None
+    overrides = {}
+    for zone, color in value.items():
+        try:
+            color_int = int(color)
+        except (TypeError, ValueError):
+            continue
+        if color_int != _NO_CHANGE_COLOR:
+            overrides[int(zone)] = color_int
+    return overrides
+
+
+class _HeadsetStaticEffectOption:
+    """Minimal stand-in for `hidpp20.LEDEffectInfo`.
+
+    `HeteroValidator` only inspects `.ID` and `.index` on its `options`
+    list; we don't need the full device-query machinery here because the
+    headset wire protocol is handled by `headset_rgb.write_zone_map`.
     """
 
-    name = "headset-rgb-hostmode"
-    label = _("Headset RGB Host Control")
-    description = _("Enable software control of headset RGB lighting.")
+    ID = 0x01  # matches hidpp20.LEDEffects[0x01] = Static
+    index = 0x01
+
+
+class HeadsetLEDControl(settings.Setting):
+    """Switch headset LED control between device and Solaar.
+
+    Mirrors the `LEDControl` / `RGBControl` pattern used for keyboards and
+    mice. When set to Solaar, the `LEDs Primary` and `Per-zone Lighting`
+    settings drive the LEDs; when set to Device, firmware-driven onboard
+    and signature effects resume.
+    """
+
+    name = "headset_led_control"
+    label = _("LED Control")
+    description = _("Switch control of LED zones between device and Solaar")
     feature = _F.HEADSET_RGB_HOSTMODE
     rw_options = {"read_fnid": 0x70, "write_fnid": 0x80}
-    validator_class = settings_validator.BooleanValidator
+    choices_universe = common.NamedInts(Device=0, Solaar=1)
+    validator_class = settings_validator.ChoicesValidator
+    validator_options = {"choices": choices_universe}
 
 
-class HeadsetRGBColor(settings.Setting):
-    """Pick a color from the shared `special_keys.COLORS` palette and apply it
-    to all headset RGB zones via HeadsetRGBHostmode (0x0620).
+class HeadsetLEDsPrimary(settings.Setting):
+    """Primary headset LED color, rendered as a GTK color picker.
 
-    On write: enables host mode, queries zone IDs via GetRGBZoneInfo, sets
-    them all to the chosen RGB color via SetRgbZonesSingleValue, commits via
-    FrameEnd. Picking `black` effectively turns the LEDs off; fully disabling
-    host control is done through the separate headset-rgb-hostmode toggle.
+    Mirrors the `LEDZoneSetting` / `RGBEffectSetting` shape: a
+    `HeteroValidator` with a single "Static" effect whose only visible
+    field is the color. Write applies the chosen color across all zones
+    discovered at build time, then re-applies any per-zone overrides on
+    top so they aren't clobbered.
+
+    Read support is deliberately disabled — the feature exposes no "get
+    current color" function, so we rely on the persister.
     """
 
-    name = "headset-rgb-color"
-    label = _("Headset RGB Color")
-    description = _("Set headset LED color (all zones, from the shared color palette).")
+    name = "headset_leds_primary"
+    label = _("LEDs") + " " + _("Primary")
+    description = _(
+        "Set the primary color applied to every headset LED zone.\n" "LED Control needs to be set to Solaar to be effective."
+    )
     feature = _F.HEADSET_RGB_HOSTMODE
-    choices_universe = special_keys.COLORS
-    validator_class = settings_validator.ChoicesValidator
     persist = True
-    # Write-only: we don't read back the current color (0x0620 doesn't expose it).
     rw_options = {"read_fnid": None, "write_fnid": None}
+
+    # HeteroKeyControl renders exactly these fields; ID is hidden
+    # (`label=None`) but kept so setup_visibles can key off it.
+    color_field = {"name": hidpp20.LEDParam.color, "kind": settings.Kind.COLOR, "label": _("Color")}
+    possible_fields = [
+        {
+            "name": "ID",
+            "kind": settings.Kind.CHOICE,
+            "label": None,
+            "choices": [common.NamedInt(0x01, _("Static"))],
+        },
+        color_field,
+    ]
+    # HeteroKeyControl.setup_visibles looks up fields_map[effect_id][1] to
+    # decide which fields to show — we only expose the color.
+    fields_map = {0x01: [common.NamedInt(0x01, _("Static")), {hidpp20.LEDParam.color: 0}]}
 
     @classmethod
     def build(cls, device):
+        zones = headset_rgb.discover_zones(device)
+        if not zones:
+            return None
         rw = settings.FeatureRW(cls.feature)
-        validator = settings_validator.ChoicesValidator(choices=cls.choices_universe)
+        validator = settings_validator.HeteroValidator(
+            data_class=hidpp20.LEDEffectSetting,
+            options=[_HeadsetStaticEffectOption()],
+            readable=False,
+        )
         return cls(device, rw, validator)
 
     def read(self, cached=True):
-        # Write-only; return persisted/cached value if we have one.
-        if cached and getattr(self, "_value", None) is not None:
+        # Feature 0x0620 doesn't expose a "current primary color" read —
+        # pull from the persister via _pre_read, fall back to white so
+        # the picker opens on a sane starting color.
+        self._pre_read(cached)
+        if self._value is not None:
             return self._value
-        return None
+        self._value = hidpp20.LEDEffectSetting(ID=common.NamedInt(0x01, _("Static")), color=0xFFFFFF)
+        return self._value
 
     def write(self, value, save=True):
-        if value is None:
+        color = getattr(value, "color", None)
+        if color is None:
             return None
-        try:
-            color_int = int(value)
-        except (TypeError, ValueError):
-            return None
-        if color_int not in special_keys.COLORS:
-            return None
-        name = str(special_keys.COLORS[color_int])
-        r = (color_int >> 16) & 0xFF
-        g = (color_int >> 8) & 0xFF
-        b = color_int & 0xFF
         device = self._device
         if not device.online:
-            logger.info("HeadsetRGBColor: device offline, skipping write of %s", name)
             return None
-        try:
-            # Order per protocol doc: claim host mode FIRST, then enumerate zones,
-            # then set colors, then commit. GetRGBZoneInfo returns zero counts if
-            # we query before claiming control.
-            resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x80, b"\x01")
-            logger.info("HeadsetRGBColor: SetHostModeState(1) resp=%s", resp.hex() if resp else resp)
-            zone_ids = self._zone_ids(device)
-            if not zone_ids:
-                logger.warning("HeadsetRGBColor: no zones available; cannot set color %s", name)
+        zones = headset_rgb.discover_zones(device)
+        if not zones:
+            return None
+        primary = int(color)
+        zone_map = {int(z): primary for z in zones}
+        # Re-apply any non-"No change" per-zone overrides on top of the
+        # fresh Primary baseline so the user's explicit zone choices stick
+        # when they change the bulk color.
+        overrides = _headset_per_zone_overrides(device) or {}
+        zone_map.update(overrides)
+        if headset_rgb.write_zone_map(device, zone_map):
+            self.update(value, save)
+            return value
+        return None
+
+
+class HeadsetPerZoneLighting(settings.Settings):
+    """Per-zone LED color overrides.
+
+    Mirrors `PerKeyLighting`'s `Settings` + `ChoicesMapValidator` style —
+    one dropdown per discovered zone with the `COLORSPLUS` palette. The
+    "No change" entry means "inherit the current `LEDs Primary` color",
+    so users can paint individual zones without losing the base setup.
+    """
+
+    name = "headset_per_zone_lighting"
+    label = _("Per-zone Lighting")
+    description = _(
+        "Override individual zone colors. 'No change' inherits the LEDs Primary color.\n"
+        "LED Control needs to be set to Solaar to be effective."
+    )
+    feature = _F.HEADSET_RGB_HOSTMODE
+    persist = True
+    choices_universe = special_keys.COLORSPLUS
+
+    class rw_class(settings.FeatureRWMap):
+        pass
+
+    class validator_class(settings_validator.ChoicesMapValidator):
+        @classmethod
+        def build(cls, setting_class, device):
+            zones = headset_rgb.discover_zones(device)
+            if not zones:
                 return None
-            logger.info(
-                "HeadsetRGBColor: setting color %s RGB=(%02X,%02X,%02X) on %d zone(s): %s",
-                name,
-                r,
-                g,
-                b,
-                len(zone_ids),
-                [f"0x{z:02X}" for z in zone_ids],
-            )
-            # SetRgbZonesSingleValue: [R, G, B, count, zone_ids...]
-            payload = bytes([r, g, b, len(zone_ids)]) + bytes(zone_ids)
-            resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x50, payload)
-            logger.info(
-                "HeadsetRGBColor: SetRgbZonesSingleValue payload=%s resp=%s",
-                payload.hex(),
-                resp.hex() if resp else resp,
-            )
-            # FrameEnd: commit the frame.
-            # Byte 0 is frame_type: 0x01 = transient commit, 0x02 = persistent.
-            # G522 firmware rejects 0x02 with LOGITECH_INTERNAL (0x05) — the
-            # persistent commit path may require additional state (e.g. onboard
-            # profile activation) that isn't mapped yet. Stick with 0x01 so the
-            # LEDs refresh visually; revisit persistence once the preconditions
-            # are known.
-            resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x60, bytes([0x01, 0x00, 0x00, 0x00]))
-            frame_type = 0x01
-            logger.info(
-                "HeadsetRGBColor: FrameEnd frame_type=0x%02X resp=%s",
-                frame_type,
-                resp.hex() if resp else resp,
-            )
-        except Exception as e:
-            logger.warning("HeadsetRGBColor write failed for %s: %s", name, e)
+            choices_map = {
+                common.NamedInt(int(z), _("Zone") + " " + str(int(z))): setting_class.choices_universe for z in zones
+            }
+            return cls(choices_map) if choices_map else None
+
+    def read(self, cached=True):
+        self._pre_read(cached)
+        if cached and self._value is not None:
+            return self._value
+        # Device doesn't expose current per-zone state; default every
+        # zone to "No change" so the primary color shows through.
+        reply_map = {int(key): _NO_CHANGE_COLOR for key in self._validator.choices}
+        self._value = reply_map
+        return reply_map
+
+    def _resolve_zone_map(self, map_, primary):
+        """Substitute 'No change' entries with the primary color."""
+        resolved = {}
+        for key, value in map_.items():
+            try:
+                v = int(value)
+            except (TypeError, ValueError):
+                continue
+            resolved[int(key)] = primary if v == _NO_CHANGE_COLOR else v
+        return resolved
+
+    def write(self, map_, save=True):
+        device = self._device
+        if not device.online:
             return None
-        self.update(value, save)
-        return value
+        self.update(map_, save)
+        primary = _headset_primary_color(device)
+        zone_map = self._resolve_zone_map(map_, primary)
+        if not zone_map:
+            return None
+        if headset_rgb.write_zone_map(device, zone_map):
+            return map_
+        return None
 
-    @staticmethod
-    def _zone_ids(device):
-        """Query GetRGBZoneInfo (function 1) and return list of zone IDs.
-
-        Caller must have enabled host mode first — querying before SetHostModeState
-        has been observed to return all zeros on the G522.
-        """
-        cached = getattr(device, "_headset_rgb_zone_ids", None)
-        if cached:
-            return cached
+    def write_key_value(self, key, value, save=True):
+        result = super().write_key_value(int(key), value, save)
+        device = self._device
+        if not device.online:
+            return result
         try:
-            resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x10)
-        except Exception as e:
-            logger.warning("HeadsetRGBColor: GetRGBZoneInfo raised %s", e)
-            resp = None
-        if not resp or len(resp) < 1:
-            logger.warning(
-                "HeadsetRGBColor: GetRGBZoneInfo returned %s; NOT caching so we retry next write",
-                resp,
-            )
-            return []
-        zone_count = resp[0]
-        # Tight format observed on G522: [count, zone_ids...] with no reserved gap.
-        # The protocol doc shows 3-byte + 1-byte reserved gaps before zone IDs, but
-        # the G522 sub-device packs them immediately after the count.
-        # Don't filter zone_id==0 — on some devices 0 is a valid zone ID. We trust
-        # the device to report sane zone IDs and let the device reject nonsense.
-        tight = list(resp[1 : 1 + zone_count]) if 1 <= zone_count <= len(resp) - 1 else []
-        if tight and len(tight) == zone_count:
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(
-                    "HeadsetRGBColor: discovered %d zone(s) %s (tight format)",
-                    len(tight),
-                    [f"0x{z:02X}" for z in tight],
-                )
-            device._headset_rgb_zone_ids = tight
-            return tight
-        # Try the doc's format (with reserved gap) as fallback
-        gap = list(resp[5 : 5 + zone_count]) if len(resp) >= 5 + zone_count else []
-        if gap and len(gap) == zone_count:
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(
-                    "HeadsetRGBColor: discovered %d zone(s) %s (doc format)",
-                    len(gap),
-                    [f"0x{z:02X}" for z in gap],
-                )
-            device._headset_rgb_zone_ids = gap
-            return gap
-        # Neither format parsed cleanly; don't cache so next write retries.
-        logger.warning(
-            "HeadsetRGBColor: GetRGBZoneInfo ambiguous count=%d resp=%s; not caching",
-            zone_count,
-            resp.hex(),
-        )
-        return []
+            v = int(value)
+        except (TypeError, ValueError):
+            return result
+        effective = _headset_primary_color(device) if v == _NO_CHANGE_COLOR else v
+        headset_rgb.write_zone_map(device, {int(key): int(effective)})
+        return result
 
 
 # ----------------------------------------------------------------------------
@@ -2822,8 +2892,9 @@ SETTINGS: list[settings.Setting] = [
     HeadsetAutoSleep,
     HeadsetOnboardEQ,
     HeadsetAdvancedEQ,
-    HeadsetRGBHostMode,
-    HeadsetRGBColor,
+    HeadsetLEDControl,
+    HeadsetLEDsPrimary,
+    HeadsetPerZoneLighting,
     *_LOGIVOICE_SETTINGS,
 ]
 

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1690,8 +1690,26 @@ class HeadsetAutoSleep(settings.Setting):
     rw_options = {"read_fnid": 0x00, "write_fnid": 0x10}
     validator_class = settings_validator.RangeValidator
     min_value = 0
-    max_value = 255
+    # Timer byte count depends on feature version:
+    #   V<3 : 1 byte (0-255)
+    #   V=3 : 2 bytes (0-65535)
+    #   V>=4: 3 bytes (0-16777215)
+    # build() picks the correct width based on the device's reported version.
+    max_value = 0xFFFFFF
     validator_options = {"byte_count": 1}
+
+    @classmethod
+    def build(cls, device):
+        version = device.features.get_feature_version(cls.feature) or 0
+        if version >= 4:
+            byte_count, max_value = 3, 0xFFFFFF
+        elif version >= 3:
+            byte_count, max_value = 2, 0xFFFF
+        else:
+            byte_count, max_value = 1, 0xFF
+        rw = settings.FeatureRW(cls.feature, **cls.rw_options)
+        validator = settings_validator.RangeValidator(min_value=0, max_value=max_value, byte_count=byte_count)
+        return cls(device, rw, validator)
 
 
 class HeadsetOnboardEQ(settings.RangeFieldSetting):

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1680,12 +1680,19 @@ class HeadsetMicGain(settings.Setting):
         # LGHUB caches these once at startup to rescale SetMicGain writes.
         try:
             info = device.feature_request(cls.feature, 0x00)
-        except Exception:
+        except Exception as e:
+            logger.info("HeadsetMicGain: GetInfo raised %s, using fallback int8 range", e)
             info = None
         if info and len(info) >= 2:
             min_gain = struct.unpack("b", bytes([info[0]]))[0]
             max_gain = struct.unpack("b", bytes([info[1]]))[0]
             if max_gain <= min_gain:  # sanity — fall back to class defaults
+                logger.info(
+                    "HeadsetMicGain: GetInfo returned nonsense range [%d, %d] (hex=%s), using fallback int8 range",
+                    min_gain,
+                    max_gain,
+                    info.hex(),
+                )
                 min_gain, max_gain = cls.min_value, cls.max_value
             else:
                 logger.info(
@@ -1694,6 +1701,10 @@ class HeadsetMicGain(settings.Setting):
                     max_gain,
                 )
         else:
+            logger.info(
+                "HeadsetMicGain: GetInfo returned %s, using fallback int8 range",
+                info.hex() if info else info,
+            )
             min_gain, max_gain = cls.min_value, cls.max_value
         rw = settings.FeatureRW(cls.feature, **cls.rw_options)
         validator = settings_validator.RangeValidator(min_value=min_gain, max_value=max_gain, byte_count=1, signed=True)

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -2052,19 +2052,14 @@ class HeadsetRGBColor(settings.Setting):
                 resp.hex() if resp else resp,
             )
             # FrameEnd: commit the frame.
-            # Byte 0 is frame_type: 0x01 = transient commit, 0x02 = persistent
-            # (saves to onboard NVS as baseline; survives the firmware's
-            # host-mode self-release window). 0x00 is silently discarded by
-            # firmware — canonical protocol doc was wrong. See
-            # HEADSET_RGB_HOSTMODE_WIRE_PROTOCOL.md.
-            #
-            # Use 0x02 for user-visible color picks so the color sticks even
-            # after the firmware releases host mode. Use 0x01 when setting
-            # black (lights off) — mirroring LGHUB's turn_off_lighting so we
-            # don't overwrite the NVS baseline with all-zeros.
-            is_off = r == 0 and g == 0 and b == 0
-            frame_type = 0x01 if is_off else 0x02
-            resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x60, bytes([frame_type, 0x00, 0x00, 0x00]))
+            # Byte 0 is frame_type: 0x01 = transient commit, 0x02 = persistent.
+            # G522 firmware rejects 0x02 with LOGITECH_INTERNAL (0x05) — the
+            # persistent commit path may require additional state (e.g. onboard
+            # profile activation) we haven't mapped yet. Stick with 0x01 for
+            # now so the LEDs at least refresh visually; we can revisit 0x02
+            # once a wireshark capture of the LGHUB sequence is available.
+            resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x60, bytes([0x01, 0x00, 0x00, 0x00]))
+            frame_type = 0x01
             logger.info(
                 "HeadsetRGBColor: FrameEnd frame_type=0x%02X resp=%s",
                 frame_type,
@@ -2767,34 +2762,46 @@ def check_feature_settings(device, already_known) -> bool:
     for sclass in SETTINGS:
         if sclass.feature:
             known_present = device.persister and sclass.name in device.persister
-            if not any(s.name == sclass.name for s in already_known) and (known_present or sclass.name not in absent):
-                try:
-                    setting = check_feature(device, sclass)
-                except Exception as err:
-                    # on an internal HID++ error, assume offline and stop further checking
-                    if (
-                        isinstance(err, exceptions.FeatureCallError)
-                        and err.error == hidpp20_constants.ErrorCode.LOGITECH_ERROR
-                    ):
-                        logger.warning(f"HID++ internal error checking feature {sclass.name}: make device not present")
-                        device.online = False
-                        device.present = False
-                        return False
-                    else:
-                        logger.warning(f"ignore feature {sclass.name} because of error {err}")
+            already = any(s.name == sclass.name for s in already_known)
+            if already:
+                continue
+            if not known_present and sclass.name in absent:
+                # Silent-skip cache from an earlier run's failed build(). Log at
+                # INFO so field diagnostics reveal when a setting is suppressed
+                # this way — users can clear stale entries by deleting their
+                # solaar config or we can add retry logic later.
+                if sclass.feature in device.features:
+                    logger.info(
+                        "check_feature_settings: skipping %s — cached in _absent despite feature %s being present; "
+                        "delete the setting from ~/.config/solaar/config.yaml to retry",
+                        sclass.name,
+                        sclass.feature,
+                    )
+                continue
+            try:
+                setting = check_feature(device, sclass)
+            except Exception as err:
+                # on an internal HID++ error, assume offline and stop further checking
+                if isinstance(err, exceptions.FeatureCallError) and err.error == hidpp20_constants.ErrorCode.LOGITECH_ERROR:
+                    logger.warning(f"HID++ internal error checking feature {sclass.name}: make device not present")
+                    device.online = False
+                    device.present = False
+                    return False
+                else:
+                    logger.warning(f"ignore feature {sclass.name} because of error {err}")
 
-                if isinstance(setting, list):
-                    for s in setting:
-                        already_known.append(s)
-                    if sclass.name in new_absent:
-                        new_absent.remove(sclass.name)
-                elif setting:
-                    already_known.append(setting)
-                    if sclass.name in new_absent:
-                        new_absent.remove(sclass.name)
-                elif setting is None:
-                    if sclass.name not in new_absent and sclass.name not in absent and sclass.name not in device.persister:
-                        new_absent.append(sclass.name)
+            if isinstance(setting, list):
+                for s in setting:
+                    already_known.append(s)
+                if sclass.name in new_absent:
+                    new_absent.remove(sclass.name)
+            elif setting:
+                already_known.append(setting)
+                if sclass.name in new_absent:
+                    new_absent.remove(sclass.name)
+            elif setting is None:
+                if sclass.name not in new_absent and sclass.name not in absent and sclass.name not in device.persister:
+                    new_absent.append(sclass.name)
     if device.persister and new_absent:
         absent.extend(new_absent)
         device.persister["_absent"] = absent

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -2077,9 +2077,9 @@ class HeadsetRGBColor(settings.Setting):
         # Tight format observed on G522: [count, zone_ids...] with no reserved gap.
         # The protocol doc shows 3-byte + 1-byte reserved gaps before zone IDs, but
         # the G522 sub-device packs them immediately after the count.
+        # Don't filter zone_id==0 — on some devices 0 is a valid zone ID. We trust
+        # the device to report sane zone IDs and let the device reject nonsense.
         tight = list(resp[1 : 1 + zone_count]) if 1 <= zone_count <= len(resp) - 1 else []
-        # Filter out zero bytes that are just padding (zone IDs should be non-zero).
-        tight = [z for z in tight if z != 0]
         if tight and len(tight) == zone_count:
             logger.info(
                 "HeadsetRGBColor: discovered %d zone(s) %s (tight format, raw resp=%s)",
@@ -2091,7 +2091,6 @@ class HeadsetRGBColor(settings.Setting):
             return tight
         # Try the doc's format (with reserved gap) as fallback
         gap = list(resp[5 : 5 + zone_count]) if len(resp) >= 5 + zone_count else []
-        gap = [z for z in gap if z != 0]
         if gap and len(gap) == zone_count:
             logger.info(
                 "HeadsetRGBColor: discovered %d zone(s) %s (doc format, raw resp=%s)",

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1666,9 +1666,38 @@ class HeadsetMicGain(settings.Setting):
     feature = _F.HEADSET_MIC_GAIN
     rw_options = {"read_fnid": 0x10, "write_fnid": 0x20}
     validator_class = settings_validator.RangeValidator
+    # Fallback range covers int8; build() overrides with device-reported bounds
+    # from GetInfo (fn 0) so SetMicGain doesn't get device-specific
+    # out-of-range NACK (error 0x0B) on devices that use a small signed range
+    # (e.g. G522 reports a narrow window like -12..+12).
     min_value = -128
     max_value = 127
     validator_options = {"byte_count": 1, "signed": True}
+
+    @classmethod
+    def build(cls, device):
+        # GetInfo (function 0) returns [min_gain (int8), max_gain (int8)].
+        # LGHUB caches these once at startup to rescale SetMicGain writes.
+        try:
+            info = device.feature_request(cls.feature, 0x00)
+        except Exception:
+            info = None
+        if info and len(info) >= 2:
+            min_gain = struct.unpack("b", bytes([info[0]]))[0]
+            max_gain = struct.unpack("b", bytes([info[1]]))[0]
+            if max_gain <= min_gain:  # sanity — fall back to class defaults
+                min_gain, max_gain = cls.min_value, cls.max_value
+            else:
+                logger.info(
+                    "HeadsetMicGain: device reports gain range [%d, %d]",
+                    min_gain,
+                    max_gain,
+                )
+        else:
+            min_gain, max_gain = cls.min_value, cls.max_value
+        rw = settings.FeatureRW(cls.feature, **cls.rw_options)
+        validator = settings_validator.RangeValidator(min_value=min_gain, max_value=max_gain, byte_count=1, signed=True)
+        return cls(device, rw, validator)
 
 
 class HeadsetMixBalance(settings.Setting):

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1591,6 +1591,24 @@ class HeadsetEcoMode(settings.Setting):
     feature = _F.HEADSET_BATTERY_SAVER
     validator_class = settings_validator.BooleanValidator
 
+    @classmethod
+    def build(cls, device):
+        # LGHUB's service layer for 0x0618 HeadsetBatterySaverMode compares
+        # incoming new_state against its cached current_state and SKIPS the
+        # devio SetEcoModeState write when they match (verified in
+        # on_headset_battery_saver_set_handler @ 0x100c21790). The G522
+        # firmware rejects no-op writes with device-specific NACK 0x0B.
+        #
+        # BooleanValidator's prepare_write already has the "skip if same as
+        # current" logic — it just needs needs_current_value=True to make
+        # Setting.write read the device state first. Default-mask (0xFF)
+        # BooleanValidators get needs_current_value=False, so we flip it here
+        # to match LGHUB's guard.
+        rw = settings.FeatureRW(cls.feature)
+        validator = settings_validator.BooleanValidator()
+        validator.needs_current_value = True
+        return cls(device, rw, validator)
+
 
 class HeadsetDoNotDisturb(settings.Setting):
     name = "headset-do-not-disturb"

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -35,6 +35,7 @@ from . import diversion
 from . import exceptions
 from . import hidpp20
 from . import hidpp20_constants
+from . import logivoice
 from . import settings
 from . import settings_new
 from . import settings_validator
@@ -2146,6 +2147,190 @@ class HeadsetRGBColor(settings.Setting):
         return []
 
 
+# ----------------------------------------------------------------------------
+# LogiVoice (0x0900 + 0x0901..0x0907) — read-only presentation pass.
+#
+# Per module we auto-generate two settings:
+#   1. A flat State toggle — reads GetState (fn 1), renders as a boolean.
+#      Top-level so users see a direct on/off indicator at a glance.
+#   2. A collapsible "Parameters" panel — one MULTIPLE_RANGE-kind setting
+#      that reads GetParameters (fn 3) once and distributes the bytes to
+#      per-field sliders. The existing MultipleRangeControl widget is
+#      collapsible by default, so the field-level clutter stays folded.
+#
+# Writes are disabled — the Parameters struct carries fields whose wire
+# encodings are still ambiguous (see logivoice.py) and a SetParameters
+# write must bundle all fields at once. A write pass can be added once
+# each field's encoding is confirmed live.
+# ----------------------------------------------------------------------------
+
+
+class _LogiVoiceStateSetting(settings.Setting):
+    """Base for per-module State read (GetState fn 1). Read-only display."""
+
+    rw_options = {"read_fnid": logivoice.FN_GET_STATE, "write_fnid": logivoice.FN_SET_STATE}
+    validator_class = settings_validator.BooleanValidator
+    persist = False
+
+    @classmethod
+    def build(cls, device):
+        # Corpus probe runs here (once per module) so -dd users get a full
+        # snapshot of state + raw Parameters + raw Info for future decoding.
+        try:
+            logivoice.probe_module(device, cls.feature)
+        except Exception as e:
+            logger.info("LogiVoice probe_module(%s) raised %s", cls.feature, e)
+        return super().build(device)
+
+    def write(self, value, save=True):
+        logger.info("LogiVoice state write ignored (read-only pass): %s requested=%s", self.name, value)
+        return None
+
+
+class _LogiVoiceModuleItem:
+    """Top-level MULTIPLE_RANGE item representing one LogiVoice module.
+
+    One `item` per setting — the module itself. `__int__` returns the feature
+    id so the Setting's reply dict is keyed predictably.
+    """
+
+    def __init__(self, feature: hidpp20_constants.SupportedFeature):
+        self._feature = feature
+        self.id = logivoice.MODULE_SLUGS.get(feature, f"0x{int(feature):04X}")
+        self.index = 0
+
+    def __int__(self):
+        return int(self._feature)
+
+    def __str__(self):
+        return logivoice.MODULE_NAMES.get(self._feature, f"0x{int(self._feature):04X}")
+
+
+class _LogiVoiceFieldSubItem:
+    """MULTIPLE_RANGE sub-item wrapping one decoded Parameters field.
+
+    MultipleRangeControl reads minimum/maximum/length/widget/str(). We pick
+    SpinButton for wide ranges (0..65535) where a 64k-step slider is useless,
+    and Scale for small ranges (e.g. signed int8 thresholds).
+    """
+
+    def __init__(self, field: logivoice.Field):
+        self._field = field
+        self.id = field.name
+        self.minimum = field.min_value
+        self.maximum = field.max_value
+        self.length = field.byte_count
+        self.widget = "SpinButton" if (field.max_value - field.min_value) > 512 else "Scale"
+
+    def __int__(self):
+        return hash(self.id) & 0xFFFFFF
+
+    def __str__(self):
+        return self._field.label + (" (raw)" if self._field.opaque else "")
+
+
+class _LogiVoiceParametersValidator(settings_validator.MultipleRangeValidator):
+    """Reads the whole GetParameters struct once and distributes bytes to fields.
+
+    MULTIPLE_RANGE's default read loop fires prepare_read_item once per top-
+    level item; we have exactly one item (the module), so this issues a single
+    GetParameters call. validate_read_item parses the shared reply into a
+    {field_name: value} dict. Writes are blocked.
+    """
+
+    def __init__(self, feature: hidpp20_constants.SupportedFeature):
+        fields = logivoice.PARAMETERS_FIELDS.get(feature, [])
+        self._fields = list(fields)
+        item = _LogiVoiceModuleItem(feature)
+        sub_items = {item: [_LogiVoiceFieldSubItem(f) for f in fields]}
+        super().__init__(items=[item], sub_items=sub_items)
+
+    def prepare_read_item(self, item):
+        return b""  # GetParameters takes no wire arguments
+
+    def validate_read_item(self, reply_bytes, item):
+        parsed = {}
+        for f in self._fields:
+            end = f.offset + f.byte_count
+            if end > len(reply_bytes):
+                continue
+            chunk = reply_bytes[f.offset : end]
+            if f.byte_count == 1:
+                v = struct.unpack("b" if f.signed else "B", chunk)[0]
+            elif f.byte_count == 2:
+                v = struct.unpack(">h" if f.signed else ">H", chunk)[0]
+            else:
+                v = int.from_bytes(chunk, "big", signed=f.signed)
+            parsed[f.name] = v
+        return parsed
+
+    def prepare_write_item(self, item, value):
+        return None
+
+    def prepare_write(self, value):
+        return None
+
+
+class _LogiVoiceParametersSetting(settings.Setting):
+    """Collapsible read-only display of one module's GetParameters struct."""
+
+    rw_options = {"read_fnid": logivoice.FN_GET_PARAMETERS}
+    persist = False
+    kind = settings.Kind.MULTIPLE_RANGE
+
+    @classmethod
+    def build(cls, device):
+        if not logivoice.PARAMETERS_FIELDS.get(cls.feature):
+            return None
+        rw = settings.FeatureRW(cls.feature, **cls.rw_options)
+        validator = _LogiVoiceParametersValidator(cls.feature)
+        return cls(device, rw, validator)
+
+    def write(self, map, save=True):
+        return None
+
+
+def _logivoice_make_state_class(feature: hidpp20_constants.SupportedFeature):
+    slug = logivoice.MODULE_SLUGS.get(feature)
+    if not slug:
+        return None
+    module_name = logivoice.MODULE_NAMES.get(feature, f"0x{int(feature):04X}")
+    attrs = {
+        "name": f"logivoice-{slug}-state",
+        "label": f"LogiVoice {module_name}: State (read-only)",
+        "description": f"Current on/off state of the headset {module_name} processing block.",
+        "feature": feature,
+    }
+    return type(f"LogiVoice_{slug}_State", (_LogiVoiceStateSetting,), attrs)
+
+
+def _logivoice_make_parameters_class(feature: hidpp20_constants.SupportedFeature):
+    slug = logivoice.MODULE_SLUGS.get(feature)
+    if not slug or not logivoice.PARAMETERS_FIELDS.get(feature):
+        return None
+    module_name = logivoice.MODULE_NAMES.get(feature, f"0x{int(feature):04X}")
+    attrs = {
+        "name": f"logivoice-{slug}-parameters",
+        "label": f"LogiVoice {module_name}: Parameters (read-only)",
+        "description": (
+            f"Decoded {module_name} GetParameters fields. "
+            "Opaque raw values shown where the wire encoding isn't confirmed yet."
+        ),
+        "feature": feature,
+    }
+    return type(f"LogiVoice_{slug}_Parameters", (_LogiVoiceParametersSetting,), attrs)
+
+
+_LOGIVOICE_SETTINGS: list[type] = []
+for _feature in logivoice.PARAMETERS_FIELDS:
+    _state_cls = _logivoice_make_state_class(_feature)
+    if _state_cls is not None:
+        _LOGIVOICE_SETTINGS.append(_state_cls)
+    _params_cls = _logivoice_make_parameters_class(_feature)
+    if _params_cls is not None:
+        _LOGIVOICE_SETTINGS.append(_params_cls)
+
+
 class BrightnessControl(settings.Setting):
     name = "brightness_control"
     label = _("Brightness Control")
@@ -2639,6 +2824,7 @@ SETTINGS: list[settings.Setting] = [
     HeadsetAdvancedEQ,
     HeadsetRGBHostMode,
     HeadsetRGBColor,
+    *_LOGIVOICE_SETTINGS,
 ]
 
 

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1855,15 +1855,15 @@ class HeadsetOnboardEQ(settings.RangeFieldSetting):
 class HeadsetAdvancedEQ(settings.RangeFieldSetting):
     """Read-only display of the headset's active AdvancedParaEQ (0x020D) bands.
 
-    Writes are intentionally disabled for now — we want to verify the wire
-    format matches the protocol doc on real hardware before allowing any
-    changes that could misconfigure the device DSP. Once confirmed working
-    we'll wire up write() to call setCustomEQ.
+    Writes are intentionally disabled for now — V2's frequency and Q encodings
+    are still opaque u16 round-trip values (confirmed via LGHUB RE, see
+    HEADSET_ADVANCED_PARA_EQ_WIRE_PROTOCOL.md), so we can show the current
+    EQ but can't safely author a write until we have a LGHUB pcap that pins
+    down the u16→Hz and u16→Q mappings.
 
-    Bands come from getActiveEQ → getCustomEQ on the playback direction.
-    Each band entry is [freq_hi, freq_lo, gain_db] (3-byte stride). Unlike
-    OnboardEQ (0x0636), the device handles biquad coefficient computation
-    — we just send frequency and gain.
+    V0/V1: 3-byte band stride [freq_hi, freq_lo, gain_i8], gain is whole dB.
+    V2:    5-byte band stride [freq_hi, freq_lo, gain_i8, q_hi, q_lo], gain
+           is `signed_byte × step_db` where step_db comes from getEQInfos.
     """
 
     name = "headset-advanced-eq"
@@ -1882,40 +1882,80 @@ class HeadsetAdvancedEQ(settings.RangeFieldSetting):
             if not info:
                 logger.info("HeadsetAdvancedEQ.build: getEQInfos failed, no panel will be built")
                 return None
-            band_count, _db_range, _caps, db_min, db_max = info
-            # Use the active slot on playback direction so the displayed EQ
-            # matches what the user is actually hearing.
+            # Cache so get_advanced_eq_params can look up step_db.
+            device._advanced_eq_info = info
+            version = info["version"]
+            gain_min = info["gain_min_db"]
+            gain_max = info["gain_max_db"]
+            step_db = info["step_db"]
+
             active_slot = hidpp20.get_advanced_eq_active_slot(device, direction=0) or 0
             bands = hidpp20.get_advanced_eq_params(device, direction=0, slot=active_slot)
             if not bands:
                 logger.info("HeadsetAdvancedEQ.build: getCustomEQ returned no bands, no panel will be built")
                 return None
-            if len(bands) != band_count:
+            band_count = len(bands)
+            # V0/V1 advertises band_count in getEQInfos — cross-check if we have it.
+            expected = info.get("band_count")
+            if expected is not None and expected != band_count:
                 logger.info(
-                    "HeadsetAdvancedEQ.build: band count mismatch — EQInfos=%d getCustomEQ=%d; skipping",
+                    "HeadsetAdvancedEQ.build: V%d band count mismatch — EQInfos=%d getCustomEQ=%d; " "trusting getCustomEQ",
+                    version,
+                    expected,
                     band_count,
-                    len(bands),
                 )
-                return None
+
             keys = common.NamedInts()
-            for i, (freq, _gain) in enumerate(bands):
-                keys[i] = str(freq) + _("Hz")
-            v = cls(keys, min_value=db_min, max_value=db_max, count=band_count, byte_count=1)
-            v._band_freqs = [freq for freq, _g in bands]
+            for i, band in enumerate(bands):
+                freq = band[0]
+                if version >= 2:
+                    # V2 freq is an opaque u16 bin index — Hz mapping unconfirmed.
+                    keys[i] = _("Band ") + str(i + 1)
+                else:
+                    keys[i] = str(freq) + _("Hz")
+            v = cls(
+                keys,
+                min_value=int(round(gain_min)),
+                max_value=int(round(gain_max)),
+                count=band_count,
+                byte_count=1,
+            )
+            v._version = version
+            v._step_db = step_db
+            v._band_freqs = [band[0] for band in bands]
+            v._band_qs = [band[2] if len(band) >= 3 else 0 for band in bands]
             v._active_slot = active_slot
             logger.info(
-                "HeadsetAdvancedEQ.build: panel built with %d band(s), slot=%d, range=[%d,%d]",
+                "HeadsetAdvancedEQ.build: panel built V%d with %d band(s), slot=%d, range=[%d,%d], step_db=%.4f",
+                version,
                 band_count,
                 active_slot,
-                db_min,
-                db_max,
+                gain_min,
+                gain_max,
+                step_db,
             )
             return v
 
         def validate_read(self, reply_bytes):
-            # Response: tight-packed 3-byte entries [freq_hi, freq_lo, gain].
             if reply_bytes is None:
                 return {}
+            version = getattr(self, "_version", 0)
+            step_db = getattr(self, "_step_db", 1.0)
+            if version >= 2:
+                bands, _header_len = hidpp20.parse_v2_bands(reply_bytes, step_db)
+                if bands is None:
+                    return {}
+                result = {}
+                for i, (freq, gain_db, q_u16) in enumerate(bands):
+                    if i >= self.count:
+                        break
+                    result[i] = int(round(gain_db))
+                    if hasattr(self, "_band_freqs") and i < len(self._band_freqs):
+                        self._band_freqs[i] = freq
+                    if hasattr(self, "_band_qs") and i < len(self._band_qs):
+                        self._band_qs[i] = q_u16
+                return result
+            # V0/V1: 3-byte stride.
             result = {}
             offset = 0
             i = 0

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1768,6 +1768,123 @@ class HeadsetOnboardEQ(settings.RangeFieldSetting):
         return result
 
 
+class HeadsetRGBHostMode(settings.Setting):
+    """Toggle host control of headset RGB lighting.
+
+    When enabled, solaar drives the LEDs via HeadsetRGBColor. When disabled,
+    firmware-driven onboard/signature effects resume.
+    """
+
+    name = "headset-rgb-hostmode"
+    label = _("Headset RGB Host Control")
+    description = _("Enable software control of headset RGB lighting.")
+    feature = _F.HEADSET_RGB_HOSTMODE
+    rw_options = {"read_fnid": 0x70, "write_fnid": 0x80}
+    validator_class = settings_validator.BooleanValidator
+
+
+# Preset RGB colors for headset-rgb-color. Name → (R, G, B).
+# "Off" disables host mode and returns control to firmware.
+_HEADSET_RGB_COLORS = [
+    ("Off", None),
+    ("Red", (0xFF, 0x00, 0x00)),
+    ("Green", (0x00, 0xFF, 0x00)),
+    ("Blue", (0x00, 0x00, 0xFF)),
+    ("White", (0xFF, 0xFF, 0xFF)),
+    ("Yellow", (0xFF, 0xFF, 0x00)),
+    ("Cyan", (0x00, 0xFF, 0xFF)),
+    ("Magenta", (0xFF, 0x00, 0xFF)),
+    ("Orange", (0xFF, 0x80, 0x00)),
+    ("Purple", (0x80, 0x00, 0xFF)),
+]
+
+
+class HeadsetRGBColor(settings.Setting):
+    """Set headset RGB zones to a preset color.
+
+    Drives HeadsetRGBHostmode (0x0620). On write, enables host mode, queries
+    available zones, sets them all to the chosen RGB color, and commits via
+    FrameEnd. "Off" disables host mode to return control to firmware.
+    """
+
+    name = "headset-rgb-color"
+    label = _("Headset RGB Color")
+    description = _("Set headset LED color (zones set to a single preset).")
+    feature = _F.HEADSET_RGB_HOSTMODE
+    choices_universe = common.NamedInts(**{name: idx for idx, (name, _rgb) in enumerate(_HEADSET_RGB_COLORS)})
+    validator_class = settings_validator.ChoicesValidator
+    persist = True
+    # Write-only: we don't read back the current color (host mode just reports on/off).
+    rw_options = {"read_fnid": None, "write_fnid": None}
+
+    @classmethod
+    def build(cls, device):
+        rw = settings.FeatureRW(cls.feature)
+        validator = settings_validator.ChoicesValidator(choices=cls.choices_universe)
+        return cls(device, rw, validator)
+
+    def read(self, cached=True):
+        # Write-only; return persisted/cached value if we have one.
+        if cached and getattr(self, "_value", None) is not None:
+            return self._value
+        return None
+
+    def write(self, value, save=True):
+        if value is None:
+            return None
+        idx = int(value)
+        if not (0 <= idx < len(_HEADSET_RGB_COLORS)):
+            return None
+        _name, rgb = _HEADSET_RGB_COLORS[idx]
+        device = self._device
+        if not device.online:
+            return None
+        try:
+            if rgb is None:
+                # "Off" → disable host mode, return to firmware control.
+                device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x80, b"\x00")
+            else:
+                zone_ids = self._zone_ids(device)
+                if not zone_ids:
+                    logger.warning("HeadsetRGBColor: no zones discovered; cannot set color")
+                    return None
+                # Enable host mode first.
+                device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x80, b"\x01")
+                # SetRgbZonesSingleValue: [R, G, B, count, zone_ids...]
+                r, g, b = rgb
+                payload = bytes([r, g, b, len(zone_ids)]) + bytes(zone_ids)
+                device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x50, payload)
+                # FrameEnd: commit the frame.
+                device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x60, b"\x00\x00\x00\x00")
+        except Exception as e:
+            logger.warning("HeadsetRGBColor write failed: %s", e)
+            return None
+        self.update(value, save)
+        return value
+
+    @staticmethod
+    def _zone_ids(device):
+        """Query GetRGBZoneInfo (function 1) and return list of zone IDs."""
+        cached = getattr(device, "_headset_rgb_zone_ids", None)
+        if cached is not None:
+            return cached
+        try:
+            resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x10)
+        except Exception:
+            resp = None
+        if not resp or len(resp) < 1:
+            device._headset_rgb_zone_ids = []
+            return []
+        zone_count = resp[0]
+        # Response: [count, 3 reserved, reserved, zone_ids...]
+        zone_ids = list(resp[5 : 5 + zone_count]) if len(resp) >= 5 + zone_count else []
+        # Fallback to typical left/right earcup zone IDs if response format differs.
+        if not zone_ids:
+            zone_ids = [0x01, 0x02]
+        device._headset_rgb_zone_ids = zone_ids
+        return zone_ids
+
+
 class BrightnessControl(settings.Setting):
     name = "brightness_control"
     label = _("Brightness Control")
@@ -2258,6 +2375,8 @@ SETTINGS: list[settings.Setting] = [
     HeadsetMixBalance,
     HeadsetAutoSleep,
     HeadsetOnboardEQ,
+    HeadsetRGBHostMode,
+    HeadsetRGBColor,
 ]
 
 

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1931,6 +1931,25 @@ class HeadsetRGBHostMode(settings.Setting):
     rw_options = {"read_fnid": 0x70, "write_fnid": 0x80}
     validator_class = settings_validator.BooleanValidator
 
+    def write(self, value, save=True):
+        # Diagnostic wrapper: log what GetHostModeState returns immediately
+        # before AND after the SetHostModeState write, so we can see whether
+        # (a) the write takes effect on the device or (b) our decoding of the
+        # response is wrong. solaar show has been reporting this value as
+        # False even after writes we believed succeeded.
+        try:
+            before = self._device.feature_request(self.feature, 0x70)
+        except Exception as e:
+            before = f"<err:{e}>"
+        logger.info("HeadsetRGBHostMode.write: before=%s requested=%s", before, value)
+        result = super().write(value, save=save)
+        try:
+            after = self._device.feature_request(self.feature, 0x70)
+        except Exception as e:
+            after = f"<err:{e}>"
+        logger.info("HeadsetRGBHostMode.write: after=%s write_returned=%s", after, result)
+        return result
+
 
 class HeadsetRGBColor(settings.Setting):
     """Pick a color from the shared `special_keys.COLORS` palette and apply it

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1835,29 +1835,48 @@ class HeadsetRGBColor(settings.Setting):
         idx = int(value)
         if not (0 <= idx < len(_HEADSET_RGB_COLORS)):
             return None
-        _name, rgb = _HEADSET_RGB_COLORS[idx]
+        name, rgb = _HEADSET_RGB_COLORS[idx]
         device = self._device
         if not device.online:
+            logger.info("HeadsetRGBColor: device offline, skipping write of %s", name)
             return None
         try:
             if rgb is None:
                 # "Off" → disable host mode, return to firmware control.
-                device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x80, b"\x00")
+                logger.info("HeadsetRGBColor: disabling host mode (SetHostModeState 0x00)")
+                resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x80, b"\x00")
+                logger.info("HeadsetRGBColor: SetHostModeState resp=%s", resp.hex() if resp else resp)
             else:
                 zone_ids = self._zone_ids(device)
                 if not zone_ids:
-                    logger.warning("HeadsetRGBColor: no zones discovered; cannot set color")
+                    logger.warning("HeadsetRGBColor: no zones available; cannot set color %s", name)
                     return None
-                # Enable host mode first.
-                device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x80, b"\x01")
-                # SetRgbZonesSingleValue: [R, G, B, count, zone_ids...]
                 r, g, b = rgb
+                logger.info(
+                    "HeadsetRGBColor: setting color %s RGB=(%02X,%02X,%02X) on %d zone(s): %s",
+                    name,
+                    r,
+                    g,
+                    b,
+                    len(zone_ids),
+                    [f"0x{z:02X}" for z in zone_ids],
+                )
+                # Enable host mode first.
+                resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x80, b"\x01")
+                logger.info("HeadsetRGBColor: SetHostModeState(1) resp=%s", resp.hex() if resp else resp)
+                # SetRgbZonesSingleValue: [R, G, B, count, zone_ids...]
                 payload = bytes([r, g, b, len(zone_ids)]) + bytes(zone_ids)
-                device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x50, payload)
+                resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x50, payload)
+                logger.info(
+                    "HeadsetRGBColor: SetRgbZonesSingleValue payload=%s resp=%s",
+                    payload.hex(),
+                    resp.hex() if resp else resp,
+                )
                 # FrameEnd: commit the frame.
-                device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x60, b"\x00\x00\x00\x00")
+                resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x60, b"\x00\x00\x00\x00")
+                logger.info("HeadsetRGBColor: FrameEnd resp=%s", resp.hex() if resp else resp)
         except Exception as e:
-            logger.warning("HeadsetRGBColor write failed: %s", e)
+            logger.warning("HeadsetRGBColor write failed for %s: %s", name, e)
             return None
         self.update(value, save)
         return value
@@ -1870,17 +1889,34 @@ class HeadsetRGBColor(settings.Setting):
             return cached
         try:
             resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x10)
-        except Exception:
+        except Exception as e:
+            logger.warning("HeadsetRGBColor: GetRGBZoneInfo raised %s", e)
             resp = None
         if not resp or len(resp) < 1:
-            device._headset_rgb_zone_ids = []
-            return []
+            logger.warning(
+                "HeadsetRGBColor: GetRGBZoneInfo returned %s, falling back to zones [0x01, 0x02]",
+                resp,
+            )
+            device._headset_rgb_zone_ids = [0x01, 0x02]
+            return device._headset_rgb_zone_ids
         zone_count = resp[0]
         # Response: [count, 3 reserved, reserved, zone_ids...]
         zone_ids = list(resp[5 : 5 + zone_count]) if len(resp) >= 5 + zone_count else []
         # Fallback to typical left/right earcup zone IDs if response format differs.
         if not zone_ids:
+            logger.warning(
+                "HeadsetRGBColor: GetRGBZoneInfo unexpected format count=%d resp=%s, falling back to [0x01, 0x02]",
+                zone_count,
+                resp.hex(),
+            )
             zone_ids = [0x01, 0x02]
+        else:
+            logger.info(
+                "HeadsetRGBColor: discovered %d zone(s) %s (raw resp=%s)",
+                len(zone_ids),
+                [f"0x{z:02X}" for z in zone_ids],
+                resp.hex(),
+            )
         device._headset_rgb_zone_ids = zone_ids
         return zone_ids
 

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1855,15 +1855,15 @@ class HeadsetOnboardEQ(settings.RangeFieldSetting):
 class HeadsetAdvancedEQ(settings.RangeFieldSetting):
     """Read-only display of the headset's active AdvancedParaEQ (0x020D) bands.
 
-    Writes are intentionally disabled for now — V2's frequency and Q encodings
-    are still opaque u16 round-trip values (confirmed via LGHUB RE, see
-    HEADSET_ADVANCED_PARA_EQ_WIRE_PROTOCOL.md), so we can show the current
-    EQ but can't safely author a write until we have a LGHUB pcap that pins
-    down the u16→Hz and u16→Q mappings.
+    Writes are intentionally disabled for now. We now know the V2 wire format
+    (see HEADSET_ADVANCED_PARA_EQ_WIRE_PROTOCOL.md) so a write path is
+    buildable, but we still want a round-trip test on real hardware before
+    enabling user-facing writes that could misconfigure the DSP.
 
     V0/V1: 3-byte band stride [freq_hi, freq_lo, gain_i8], gain is whole dB.
-    V2:    5-byte band stride [freq_hi, freq_lo, gain_i8, q_hi, q_lo], gain
-           is `signed_byte × step_db` where step_db comes from getEQInfos.
+    V2:    5-byte band stride [filter_type, freq_hi, freq_lo, gain_hi, gain_lo],
+           filter_type 0x00=HP 0x78=peaking, freq is raw Hz, gain is signed
+           int16 × step_db (step_db from getEQInfos).
     """
 
     name = "headset-advanced-eq"
@@ -1882,7 +1882,6 @@ class HeadsetAdvancedEQ(settings.RangeFieldSetting):
             if not info:
                 logger.info("HeadsetAdvancedEQ.build: getEQInfos failed, no panel will be built")
                 return None
-            # Cache so get_advanced_eq_params can look up step_db.
             device._advanced_eq_info = info
             version = info["version"]
             gain_min = info["gain_min_db"]
@@ -1895,24 +1894,21 @@ class HeadsetAdvancedEQ(settings.RangeFieldSetting):
                 logger.info("HeadsetAdvancedEQ.build: getCustomEQ returned no bands, no panel will be built")
                 return None
             band_count = len(bands)
-            # V0/V1 advertises band_count in getEQInfos — cross-check if we have it.
             expected = info.get("band_count")
             if expected is not None and expected != band_count:
                 logger.info(
-                    "HeadsetAdvancedEQ.build: V%d band count mismatch — EQInfos=%d getCustomEQ=%d; " "trusting getCustomEQ",
+                    "HeadsetAdvancedEQ.build: V%d band count mismatch — EQInfos=%d getCustomEQ=%d; trusting getCustomEQ",
                     version,
                     expected,
                     band_count,
                 )
 
             keys = common.NamedInts()
-            for i, band in enumerate(bands):
-                freq = band[0]
-                if version >= 2:
-                    # V2 freq is an opaque u16 bin index — Hz mapping unconfirmed.
-                    keys[i] = _("Band ") + str(i + 1)
+            for i, (filter_type, freq_hz, _gain_db) in enumerate(bands):
+                if filter_type == hidpp20.FILTER_TYPE_HP:
+                    keys[i] = "HP " + str(freq_hz) + _("Hz")
                 else:
-                    keys[i] = str(freq) + _("Hz")
+                    keys[i] = str(freq_hz) + _("Hz")
             v = cls(
                 keys,
                 min_value=int(round(gain_min)),
@@ -1922,8 +1918,8 @@ class HeadsetAdvancedEQ(settings.RangeFieldSetting):
             )
             v._version = version
             v._step_db = step_db
-            v._band_freqs = [band[0] for band in bands]
-            v._band_qs = [band[2] if len(band) >= 3 else 0 for band in bands]
+            v._band_types = [band[0] for band in bands]
+            v._band_freqs = [band[1] for band in bands]
             v._active_slot = active_slot
             logger.info(
                 "HeadsetAdvancedEQ.build: panel built V%d with %d band(s), slot=%d, range=[%d,%d], step_db=%.4f",
@@ -1934,10 +1930,9 @@ class HeadsetAdvancedEQ(settings.RangeFieldSetting):
                 gain_max,
                 step_db,
             )
-            # One-shot corpus probe: read every factory/custom preset's name
-            # and band data. Comparing freq_u16 and q_u16 values across named
-            # presets ("Flat" vs "Bass Boost" etc.) may reveal the u16->Hz
-            # and u16->Q scalings without requiring a LGHUB pcap.
+            # One-shot corpus probe — logs every factory + custom preset's
+            # band data at INFO. Useful diagnostic if a device turns up with
+            # filter types beyond the observed 0x00/0x78 pair.
             if version >= 2:
                 try:
                     hidpp20.probe_advanced_eq_presets(device, direction=0)
@@ -1951,18 +1946,18 @@ class HeadsetAdvancedEQ(settings.RangeFieldSetting):
             version = getattr(self, "_version", 0)
             step_db = getattr(self, "_step_db", 1.0)
             if version >= 2:
-                bands, _header_len = hidpp20.parse_v2_bands(reply_bytes, step_db)
+                bands = hidpp20.parse_v2_bands(reply_bytes, step_db)
                 if bands is None:
                     return {}
                 result = {}
-                for i, (freq, gain_db, q_u16) in enumerate(bands):
+                for i, (filter_type, freq_hz, gain_db) in enumerate(bands):
                     if i >= self.count:
                         break
                     result[i] = int(round(gain_db))
+                    if hasattr(self, "_band_types") and i < len(self._band_types):
+                        self._band_types[i] = filter_type
                     if hasattr(self, "_band_freqs") and i < len(self._band_freqs):
-                        self._band_freqs[i] = freq
-                    if hasattr(self, "_band_qs") and i < len(self._band_qs):
-                        self._band_qs[i] = q_u16
+                        self._band_freqs[i] = freq_hz
                 return result
             # V0/V1: 3-byte stride.
             result = {}

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1906,6 +1906,11 @@ class HeadsetRGBColor(settings.Setting):
             logger.info("HeadsetRGBColor: device offline, skipping write of %s", name)
             return None
         try:
+            # Order per protocol doc: claim host mode FIRST, then enumerate zones,
+            # then set colors, then commit. GetRGBZoneInfo returns zero counts if
+            # we query before claiming control.
+            resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x80, b"\x01")
+            logger.info("HeadsetRGBColor: SetHostModeState(1) resp=%s", resp.hex() if resp else resp)
             zone_ids = self._zone_ids(device)
             if not zone_ids:
                 logger.warning("HeadsetRGBColor: no zones available; cannot set color %s", name)
@@ -1919,9 +1924,6 @@ class HeadsetRGBColor(settings.Setting):
                 len(zone_ids),
                 [f"0x{z:02X}" for z in zone_ids],
             )
-            # Enable host mode first.
-            resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x80, b"\x01")
-            logger.info("HeadsetRGBColor: SetHostModeState(1) resp=%s", resp.hex() if resp else resp)
             # SetRgbZonesSingleValue: [R, G, B, count, zone_ids...]
             payload = bytes([r, g, b, len(zone_ids)]) + bytes(zone_ids)
             resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x50, payload)
@@ -1941,9 +1943,13 @@ class HeadsetRGBColor(settings.Setting):
 
     @staticmethod
     def _zone_ids(device):
-        """Query GetRGBZoneInfo (function 1) and return list of zone IDs."""
+        """Query GetRGBZoneInfo (function 1) and return list of zone IDs.
+
+        Caller must have enabled host mode first — querying before SetHostModeState
+        has been observed to return all zeros on the G522.
+        """
         cached = getattr(device, "_headset_rgb_zone_ids", None)
-        if cached is not None:
+        if cached:
             return cached
         try:
             resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x10)
@@ -1952,31 +1958,45 @@ class HeadsetRGBColor(settings.Setting):
             resp = None
         if not resp or len(resp) < 1:
             logger.warning(
-                "HeadsetRGBColor: GetRGBZoneInfo returned %s, falling back to zones [0x01, 0x02]",
+                "HeadsetRGBColor: GetRGBZoneInfo returned %s; NOT caching so we retry next write",
                 resp,
             )
-            device._headset_rgb_zone_ids = [0x01, 0x02]
-            return device._headset_rgb_zone_ids
+            return []
         zone_count = resp[0]
-        # Response: [count, 3 reserved, reserved, zone_ids...]
-        zone_ids = list(resp[5 : 5 + zone_count]) if len(resp) >= 5 + zone_count else []
-        # Fallback to typical left/right earcup zone IDs if response format differs.
-        if not zone_ids:
-            logger.warning(
-                "HeadsetRGBColor: GetRGBZoneInfo unexpected format count=%d resp=%s, falling back to [0x01, 0x02]",
-                zone_count,
-                resp.hex(),
-            )
-            zone_ids = [0x01, 0x02]
-        else:
+        # Tight format observed on G522: [count, zone_ids...] with no reserved gap.
+        # The protocol doc shows 3-byte + 1-byte reserved gaps before zone IDs, but
+        # the G522 sub-device packs them immediately after the count.
+        tight = list(resp[1 : 1 + zone_count]) if 1 <= zone_count <= len(resp) - 1 else []
+        # Filter out zero bytes that are just padding (zone IDs should be non-zero).
+        tight = [z for z in tight if z != 0]
+        if tight and len(tight) == zone_count:
             logger.info(
-                "HeadsetRGBColor: discovered %d zone(s) %s (raw resp=%s)",
-                len(zone_ids),
-                [f"0x{z:02X}" for z in zone_ids],
+                "HeadsetRGBColor: discovered %d zone(s) %s (tight format, raw resp=%s)",
+                len(tight),
+                [f"0x{z:02X}" for z in tight],
                 resp.hex(),
             )
-        device._headset_rgb_zone_ids = zone_ids
-        return zone_ids
+            device._headset_rgb_zone_ids = tight
+            return tight
+        # Try the doc's format (with reserved gap) as fallback
+        gap = list(resp[5 : 5 + zone_count]) if len(resp) >= 5 + zone_count else []
+        gap = [z for z in gap if z != 0]
+        if gap and len(gap) == zone_count:
+            logger.info(
+                "HeadsetRGBColor: discovered %d zone(s) %s (doc format, raw resp=%s)",
+                len(gap),
+                [f"0x{z:02X}" for z in gap],
+                resp.hex(),
+            )
+            device._headset_rgb_zone_ids = gap
+            return gap
+        # Neither format parsed cleanly; don't cache so next write retries.
+        logger.warning(
+            "HeadsetRGBColor: GetRGBZoneInfo ambiguous count=%d resp=%s; not caching",
+            zone_count,
+            resp.hex(),
+        )
+        return []
 
 
 class BrightnessControl(settings.Setting):

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1934,6 +1934,15 @@ class HeadsetAdvancedEQ(settings.RangeFieldSetting):
                 gain_max,
                 step_db,
             )
+            # One-shot corpus probe: read every factory/custom preset's name
+            # and band data. Comparing freq_u16 and q_u16 values across named
+            # presets ("Flat" vs "Bass Boost" etc.) may reveal the u16->Hz
+            # and u16->Q scalings without requiring a LGHUB pcap.
+            if version >= 2:
+                try:
+                    hidpp20.probe_advanced_eq_presets(device, direction=0)
+                except Exception as e:
+                    logger.info("HeadsetAdvancedEQ.build: preset corpus probe failed: %s", e)
             return v
 
         def validate_read(self, reply_bytes):

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1783,38 +1783,24 @@ class HeadsetRGBHostMode(settings.Setting):
     validator_class = settings_validator.BooleanValidator
 
 
-# Preset RGB colors for headset-rgb-color. Name → (R, G, B).
-# "Off" disables host mode and returns control to firmware.
-_HEADSET_RGB_COLORS = [
-    ("Off", None),
-    ("Red", (0xFF, 0x00, 0x00)),
-    ("Green", (0x00, 0xFF, 0x00)),
-    ("Blue", (0x00, 0x00, 0xFF)),
-    ("White", (0xFF, 0xFF, 0xFF)),
-    ("Yellow", (0xFF, 0xFF, 0x00)),
-    ("Cyan", (0x00, 0xFF, 0xFF)),
-    ("Magenta", (0xFF, 0x00, 0xFF)),
-    ("Orange", (0xFF, 0x80, 0x00)),
-    ("Purple", (0x80, 0x00, 0xFF)),
-]
-
-
 class HeadsetRGBColor(settings.Setting):
-    """Set headset RGB zones to a preset color.
+    """Pick a color from the shared `special_keys.COLORS` palette and apply it
+    to all headset RGB zones via HeadsetRGBHostmode (0x0620).
 
-    Drives HeadsetRGBHostmode (0x0620). On write, enables host mode, queries
-    available zones, sets them all to the chosen RGB color, and commits via
-    FrameEnd. "Off" disables host mode to return control to firmware.
+    On write: enables host mode, queries zone IDs via GetRGBZoneInfo, sets
+    them all to the chosen RGB color via SetRgbZonesSingleValue, commits via
+    FrameEnd. Picking `black` effectively turns the LEDs off; fully disabling
+    host control is done through the separate headset-rgb-hostmode toggle.
     """
 
     name = "headset-rgb-color"
     label = _("Headset RGB Color")
-    description = _("Set headset LED color (zones set to a single preset).")
+    description = _("Set headset LED color (all zones, from the shared color palette).")
     feature = _F.HEADSET_RGB_HOSTMODE
-    choices_universe = common.NamedInts(**{name: idx for idx, (name, _rgb) in enumerate(_HEADSET_RGB_COLORS)})
+    choices_universe = special_keys.COLORS
     validator_class = settings_validator.ChoicesValidator
     persist = True
-    # Write-only: we don't read back the current color (host mode just reports on/off).
+    # Write-only: we don't read back the current color (0x0620 doesn't expose it).
     rw_options = {"read_fnid": None, "write_fnid": None}
 
     @classmethod
@@ -1832,49 +1818,48 @@ class HeadsetRGBColor(settings.Setting):
     def write(self, value, save=True):
         if value is None:
             return None
-        idx = int(value)
-        if not (0 <= idx < len(_HEADSET_RGB_COLORS)):
+        try:
+            color_int = int(value)
+        except (TypeError, ValueError):
             return None
-        name, rgb = _HEADSET_RGB_COLORS[idx]
+        if color_int not in special_keys.COLORS:
+            return None
+        name = str(special_keys.COLORS[color_int])
+        r = (color_int >> 16) & 0xFF
+        g = (color_int >> 8) & 0xFF
+        b = color_int & 0xFF
         device = self._device
         if not device.online:
             logger.info("HeadsetRGBColor: device offline, skipping write of %s", name)
             return None
         try:
-            if rgb is None:
-                # "Off" → disable host mode, return to firmware control.
-                logger.info("HeadsetRGBColor: disabling host mode (SetHostModeState 0x00)")
-                resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x80, b"\x00")
-                logger.info("HeadsetRGBColor: SetHostModeState resp=%s", resp.hex() if resp else resp)
-            else:
-                zone_ids = self._zone_ids(device)
-                if not zone_ids:
-                    logger.warning("HeadsetRGBColor: no zones available; cannot set color %s", name)
-                    return None
-                r, g, b = rgb
-                logger.info(
-                    "HeadsetRGBColor: setting color %s RGB=(%02X,%02X,%02X) on %d zone(s): %s",
-                    name,
-                    r,
-                    g,
-                    b,
-                    len(zone_ids),
-                    [f"0x{z:02X}" for z in zone_ids],
-                )
-                # Enable host mode first.
-                resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x80, b"\x01")
-                logger.info("HeadsetRGBColor: SetHostModeState(1) resp=%s", resp.hex() if resp else resp)
-                # SetRgbZonesSingleValue: [R, G, B, count, zone_ids...]
-                payload = bytes([r, g, b, len(zone_ids)]) + bytes(zone_ids)
-                resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x50, payload)
-                logger.info(
-                    "HeadsetRGBColor: SetRgbZonesSingleValue payload=%s resp=%s",
-                    payload.hex(),
-                    resp.hex() if resp else resp,
-                )
-                # FrameEnd: commit the frame.
-                resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x60, b"\x00\x00\x00\x00")
-                logger.info("HeadsetRGBColor: FrameEnd resp=%s", resp.hex() if resp else resp)
+            zone_ids = self._zone_ids(device)
+            if not zone_ids:
+                logger.warning("HeadsetRGBColor: no zones available; cannot set color %s", name)
+                return None
+            logger.info(
+                "HeadsetRGBColor: setting color %s RGB=(%02X,%02X,%02X) on %d zone(s): %s",
+                name,
+                r,
+                g,
+                b,
+                len(zone_ids),
+                [f"0x{z:02X}" for z in zone_ids],
+            )
+            # Enable host mode first.
+            resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x80, b"\x01")
+            logger.info("HeadsetRGBColor: SetHostModeState(1) resp=%s", resp.hex() if resp else resp)
+            # SetRgbZonesSingleValue: [R, G, B, count, zone_ids...]
+            payload = bytes([r, g, b, len(zone_ids)]) + bytes(zone_ids)
+            resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x50, payload)
+            logger.info(
+                "HeadsetRGBColor: SetRgbZonesSingleValue payload=%s resp=%s",
+                payload.hex(),
+                resp.hex() if resp else resp,
+            )
+            # FrameEnd: commit the frame.
+            resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x60, b"\x00\x00\x00\x00")
+            logger.info("HeadsetRGBColor: FrameEnd resp=%s", resp.hex() if resp else resp)
         except Exception as e:
             logger.warning("HeadsetRGBColor write failed for %s: %s", name, e)
             return None

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1593,17 +1593,10 @@ class HeadsetEcoMode(settings.Setting):
 
     @classmethod
     def build(cls, device):
-        # LGHUB's service layer for 0x0618 HeadsetBatterySaverMode compares
-        # incoming new_state against its cached current_state and SKIPS the
-        # devio SetEcoModeState write when they match (verified in
-        # on_headset_battery_saver_set_handler @ 0x100c21790). The G522
-        # firmware rejects no-op writes with device-specific NACK 0x0B.
-        #
-        # BooleanValidator's prepare_write already has the "skip if same as
-        # current" logic — it just needs needs_current_value=True to make
-        # Setting.write read the device state first. Default-mask (0xFF)
-        # BooleanValidators get needs_current_value=False, so we flip it here
-        # to match LGHUB's guard.
+        # G522 firmware rejects no-op writes with device-specific NACK 0x0B.
+        # BooleanValidator.prepare_write already skips writes that match the
+        # current value when needs_current_value=True; default-mask (0xFF)
+        # BooleanValidators get needs_current_value=False, so flip it here.
         rw = settings.FeatureRW(cls.feature)
         validator = settings_validator.BooleanValidator()
         validator.needs_current_value = True
@@ -1695,7 +1688,8 @@ class HeadsetMicGain(settings.Setting):
     @classmethod
     def build(cls, device):
         # GetInfo (function 0) returns [min_gain (int8), max_gain (int8)].
-        # LGHUB caches these once at startup to rescale SetMicGain writes.
+        # Query once at build time so the slider range reflects the device's
+        # actual supported range rather than a generic int8 window.
         try:
             info = device.feature_request(cls.feature, 0x00)
         except Exception as e:
@@ -1855,10 +1849,9 @@ class HeadsetOnboardEQ(settings.RangeFieldSetting):
 class HeadsetAdvancedEQ(settings.RangeFieldSetting):
     """Read-only display of the headset's active AdvancedParaEQ (0x020D) bands.
 
-    Writes are intentionally disabled for now. We now know the V2 wire format
-    (see HEADSET_ADVANCED_PARA_EQ_WIRE_PROTOCOL.md) so a write path is
-    buildable, but we still want a round-trip test on real hardware before
-    enabling user-facing writes that could misconfigure the DSP.
+    Writes are intentionally disabled for now. The V2 wire format is known
+    (see advanced_para_eq.py) but we want a round-trip test on real hardware
+    before enabling user-facing writes that could misconfigure the DSP.
 
     V0/V1: 3-byte band stride [freq_hi, freq_lo, gain_i8], gain is whole dB.
     V2:    5-byte band stride [filter_type, freq_hi, freq_lo, gain_hi, gain_lo],
@@ -2099,9 +2092,9 @@ class HeadsetRGBColor(settings.Setting):
             # Byte 0 is frame_type: 0x01 = transient commit, 0x02 = persistent.
             # G522 firmware rejects 0x02 with LOGITECH_INTERNAL (0x05) — the
             # persistent commit path may require additional state (e.g. onboard
-            # profile activation) we haven't mapped yet. Stick with 0x01 for
-            # now so the LEDs at least refresh visually; we can revisit 0x02
-            # once a wireshark capture of the LGHUB sequence is available.
+            # profile activation) that isn't mapped yet. Stick with 0x01 so the
+            # LEDs refresh visually; revisit persistence once the preconditions
+            # are known.
             resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x60, bytes([0x01, 0x00, 0x00, 0x00]))
             frame_type = 0x01
             logger.info(

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -2028,12 +2028,24 @@ class HeadsetRGBColor(settings.Setting):
                 resp.hex() if resp else resp,
             )
             # FrameEnd: commit the frame.
-            # Byte 0 is frame_type: 0x01 = transient commit, 0x02 = persistent/final
-            # flush. The firmware silently discards frames when byte 0 is 0x00 —
-            # canonical protocol doc was wrong on this point. See
+            # Byte 0 is frame_type: 0x01 = transient commit, 0x02 = persistent
+            # (saves to onboard NVS as baseline; survives the firmware's
+            # host-mode self-release window). 0x00 is silently discarded by
+            # firmware — canonical protocol doc was wrong. See
             # HEADSET_RGB_HOSTMODE_WIRE_PROTOCOL.md.
-            resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x60, b"\x01\x00\x00\x00")
-            logger.info("HeadsetRGBColor: FrameEnd resp=%s", resp.hex() if resp else resp)
+            #
+            # Use 0x02 for user-visible color picks so the color sticks even
+            # after the firmware releases host mode. Use 0x01 when setting
+            # black (lights off) — mirroring LGHUB's turn_off_lighting so we
+            # don't overwrite the NVS baseline with all-zeros.
+            is_off = r == 0 and g == 0 and b == 0
+            frame_type = 0x01 if is_off else 0x02
+            resp = device.feature_request(_F.HEADSET_RGB_HOSTMODE, 0x60, bytes([frame_type, 0x00, 0x00, 0x00]))
+            logger.info(
+                "HeadsetRGBColor: FrameEnd frame_type=0x%02X resp=%s",
+                frame_type,
+                resp.hex() if resp else resp,
+            )
         except Exception as e:
             logger.warning("HeadsetRGBColor write failed for %s: %s", name, e)
             return None

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -2687,15 +2687,41 @@ class _HeadsetOnboardEffect:
     leading clusterIndex). intensity is a 0-100 percent; saturation is a raw
     0-255 byte (same as the keyboard RGB effects)."""
 
+    # Per-effect default parameter values, applied to any field the effect
+    # uses that would otherwise be 0. Picking an effect in the UI rebuilds
+    # this object from the (initially zeroed) field widgets, so without
+    # seeding the picker emits an all-zero frame: the firmware rejects
+    # ColorCycle/ColorWave outright and renders Breathing/DualColor/Static
+    # as black or zero-intensity. intensity 0 in particular reads as "LEDs
+    # off". Defaults confirmed against the LGHUB binary decode of 0x0621.
+    _DEFAULTS = {
+        0: {"color1": 0xFFFFFF},  # Static / Fixed
+        1: {"intensity": 100, "saturation": 255, "period": 5000},  # Color Cycle
+        2: {"intensity": 100, "saturation": 255, "period": 5000},  # Color Wave
+        3: {"color1": 0xFFFFFF, "intensity": 100, "period": 5000},  # Breathing
+        4: {"color1": 0xFFFFFF, "color2": 0x0000FF, "intensity": 100},  # Dual Color
+    }
+
+    # speed is accepted only to load configs persisted before the 0x0621
+    # decode (DualColor byte 6 was mislabelled "speed"; it is intensity).
     def __init__(self, ID=0, color1=0, color2=0, intensity=0, saturation=0, period=0, speed=0, direction=0):
         self.ID = int(ID)
         self.intensity = max(0, min(100, int(intensity)))
         self.saturation = max(0, min(255, int(saturation)))
         self.period = max(0, min(0xFFFF, int(period)))
-        self.speed = max(0, min(0xFF, int(speed)))
         self.direction = max(0, min(3, int(direction)))
         for k, v in (("color1", color1), ("color2", color2)):
             setattr(self, k, common.ColorInt(int(v) & 0xFFFFFF))
+        # Seed any field the selected effect uses that arrived as 0 so the
+        # picker never sends an all-zero (rejected / black) frame. An effect
+        # actually active on the device reports non-zero values, so reads
+        # via from_bytes are unaffected.
+        for field, default in self._DEFAULTS.get(self.ID, {}).items():
+            if not getattr(self, field):
+                if field.startswith("color"):
+                    setattr(self, field, common.ColorInt(default & 0xFFFFFF))
+                else:
+                    setattr(self, field, default)
 
     @classmethod
     def from_bytes(cls, data, options=None):
@@ -2712,13 +2738,14 @@ class _HeadsetOnboardEffect:
             kw["saturation"] = p[3]
             if eid == 2:
                 kw["direction"] = p[4]
-        elif eid == 3:  # Breathing
+        elif eid == 3:  # Breathing: R, G, B, intensity, period u16 BE
             kw["color1"] = (p[0] << 16) | (p[1] << 8) | p[2]
+            kw["intensity"] = p[3]
             kw["period"] = (p[4] << 8) | p[5]
-        elif eid == 4:  # DualColor
+        elif eid == 4:  # DualColor: R1, G1, B1, R2, G2, B2, intensity
             kw["color1"] = (p[0] << 16) | (p[1] << 8) | p[2]
             kw["color2"] = (p[3] << 16) | (p[4] << 8) | p[5]
-            kw["speed"] = p[6]
+            kw["intensity"] = p[6]
         return cls(**kw)
 
     def to_bytes(self, options=None):
@@ -2733,14 +2760,14 @@ class _HeadsetOnboardEffect:
             p[3] = self.saturation
             if eid == 2:
                 p[4] = self.direction
-        elif eid == 3:  # Breathing: R, G, B, CE[6]=0, period u16 BE
+        elif eid == 3:  # Breathing: R, G, B, intensity, period u16 BE, pad
             p[0], p[1], p[2] = (c1 >> 16) & 0xFF, (c1 >> 8) & 0xFF, c1 & 0xFF
+            p[3] = self.intensity
             p[4], p[5] = (self.period >> 8) & 0xFF, self.period & 0xFF
-        elif eid == 4:  # DualColor: R1,G1,B1, R2,G2,B2, speed
+        elif eid == 4:  # DualColor: R1,G1,B1, R2,G2,B2, intensity
             p[0], p[1], p[2] = (c1 >> 16) & 0xFF, (c1 >> 8) & 0xFF, c1 & 0xFF
             p[3], p[4], p[5] = (c2 >> 16) & 0xFF, (c2 >> 8) & 0xFF, c2 & 0xFF
-            p[6] = self.speed
-        # eid 5 Custom: no inline parameters
+            p[6] = self.intensity
         return bytes([(eid >> 8) & 0xFF, eid & 0xFF]) + bytes(p)
 
     def __eq__(self, other):
@@ -2776,21 +2803,21 @@ class HeadsetOnboardEffect(settings.Setting):
     feature = _F.HEADSET_RGB_ONBOARD_EFFECTS
 
     _CLUSTER = 0
+    # Custom (5) is intentionally absent — it is a stored card-reference
+    # effect, not a parametric one; it cannot be set via setRGBClusterEffect.
     _ALL_EFFECTS = (
         ("Static", 0),
         ("Color Cycle", 1),
         ("Color Wave", 2),
         ("Breathing", 3),
         ("Dual Color", 4),
-        ("Custom", 5),
     )
     _EFFECT_FIELDS = {
         0: ("color1",),
         1: ("intensity", "period", "saturation"),
         2: ("intensity", "period", "saturation", "direction"),
-        3: ("color1", "period"),
-        4: ("color1", "color2", "speed"),
-        5: (),
+        3: ("color1", "intensity", "period"),
+        4: ("color1", "color2", "intensity"),
     }
     _DIRECTIONS = common.NamedInts(**{"Horizontal": 0, "Vertical": 1, "Reverse Horizontal": 2, "Reverse Vertical": 3})
 
@@ -2831,12 +2858,13 @@ class HeadsetOnboardEffect(settings.Setting):
             if off + 2 > len(info):
                 break
             eid = (info[off] << 8) | info[off + 1]
-            if 0 <= eid <= 5 and eid not in supported:
+            if 0 <= eid <= 4 and eid not in supported:
                 supported.append(eid)
         if not supported:
-            # Unparseable reply — offer all six; the firmware rejects any it
-            # doesn't support. See the 0x0621 fallback note in protocol RE.
-            supported = [0, 1, 2, 3, 4, 5]
+            # Unparseable reply — offer the five parametric effects; the
+            # firmware rejects any it doesn't support. Custom (5) is never
+            # offered here. See the 0x0621 fallback note in protocol RE.
+            supported = [0, 1, 2, 3, 4]
         rw = cls.rw_class(cls.feature, cls._CLUSTER)
         validator = settings_validator.HeteroValidator(data_class=_HeadsetOnboardEffect, options=None)
         setting = cls(device, rw, validator)
@@ -2848,8 +2876,14 @@ class HeadsetOnboardEffect(settings.Setting):
             {"name": "color2", "kind": settings.Kind.COLOR, "label": _("Secondary")},
             {"name": "intensity", "kind": settings.Kind.RANGE, "label": _("Intensity"), "min": 0, "max": 100},
             {"name": "saturation", "kind": settings.Kind.RANGE, "label": _("Saturation"), "min": 0, "max": 255},
-            {"name": "period", "kind": settings.Kind.RANGE, "label": _("Period"), "min": 0, "max": 0xFFFF},
-            {"name": "speed", "kind": settings.Kind.RANGE, "label": _("Speed"), "min": 0, "max": 0xFF},
+            {
+                "name": "period",
+                "kind": settings.Kind.RANGE,
+                "label": _("Period"),
+                "min": 1000,
+                "max": 20000,
+                "display_seconds": True,
+            },
             {"name": "direction", "kind": settings.Kind.CHOICE, "label": _("Direction"), "choices": cls._DIRECTIONS},
         ]
         setting.fields_map = {eid: (id_choices[eid], {field: 1 for field in cls._EFFECT_FIELDS[eid]}) for eid in supported}

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -37,9 +37,12 @@ from . import desktop_notifications
 from . import device_quirks
 from . import diversion
 from . import exceptions
+from . import headset_rgb
 from . import hidpp10_constants
 from . import hidpp20
 from . import hidpp20_constants
+from . import logivoice
+from . import rgb_effects_probe
 from . import rgb_power
 from . import settings
 from . import settings_new
@@ -1633,6 +1636,17 @@ class HeadsetEcoMode(settings.Setting):
     feature = _F.HEADSET_BATTERY_SAVER
     validator_class = settings_validator.BooleanValidator
 
+    @classmethod
+    def build(cls, device):
+        # G522 firmware rejects no-op writes with device-specific NACK 0x0B.
+        # BooleanValidator.prepare_write already skips writes that match the
+        # current value when needs_current_value=True; default-mask (0xFF)
+        # BooleanValidators get needs_current_value=False, so flip it here.
+        rw = settings.FeatureRW(cls.feature)
+        validator = settings_validator.BooleanValidator()
+        validator.needs_current_value = True
+        return cls(device, rw, validator)
+
 
 class HeadsetDoNotDisturb(settings.Setting):
     name = "headset-do-not-disturb"
@@ -1648,6 +1662,18 @@ class HeadsetMicMute(settings.Setting):
     description = _("Mute the microphone.")
     feature = _F.HEADSET_MIC_MUTE
     validator_class = settings_validator.BooleanValidator
+    # HEADSET_MIC_MUTE (0x0601) doesn't follow the typical fn 0 GetState /
+    # fn 1 SetState pattern that BooleanValidator defaults to. Function
+    # layout (confirmed via G HUB pcap on G522):
+    #   fn 0 — physical-mute-switch state-change events from the device
+    #   fn 1 — state-change events emitted as the device's echo of a
+    #          host-driven SetState; also serves as the host-callable
+    #          GetState read
+    #   fn 2 — host-callable SetState (single byte: 0=unmuted, 1=muted)
+    # The standard fn 0/1 write path returns 0x0A UNSUPPORTED. State-change
+    # events from both fn 0 and fn 1 are handled by _process_feature_notification
+    # so the toggle reflects physical mute presses too.
+    rw_options = {"read_fnid": 0x10, "write_fnid": 0x20}
 
 
 class HeadsetMicSNR(settings.Setting):
@@ -1708,9 +1734,50 @@ class HeadsetMicGain(settings.Setting):
     feature = _F.HEADSET_MIC_GAIN
     rw_options = {"read_fnid": 0x10, "write_fnid": 0x20}
     validator_class = settings_validator.RangeValidator
+    # Fallback range covers int8; build() overrides with device-reported bounds
+    # from GetInfo (fn 0) so SetMicGain doesn't get device-specific
+    # out-of-range NACK (error 0x0B) on devices that use a small signed range
+    # (e.g. G522 reports a narrow window like -12..+12).
     min_value = -128
     max_value = 127
     validator_options = {"byte_count": 1, "signed": True}
+
+    @classmethod
+    def build(cls, device):
+        # GetInfo (function 0) returns [min_gain (int8), max_gain (int8)].
+        # Query once at build time so the slider range reflects the device's
+        # actual supported range rather than a generic int8 window.
+        try:
+            info = device.feature_request(cls.feature, 0x00)
+        except Exception as e:
+            logger.debug("HeadsetMicGain: GetInfo raised %s, using fallback int8 range", e)
+            info = None
+        if info and len(info) >= 2:
+            min_gain = struct.unpack("b", bytes([info[0]]))[0]
+            max_gain = struct.unpack("b", bytes([info[1]]))[0]
+            if max_gain <= min_gain:  # sanity — fall back to class defaults
+                logger.debug(
+                    "HeadsetMicGain: GetInfo returned nonsense range [%d, %d] (hex=%s), using fallback int8 range",
+                    min_gain,
+                    max_gain,
+                    info.hex(),
+                )
+                min_gain, max_gain = cls.min_value, cls.max_value
+            elif logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "HeadsetMicGain: device reports gain range [%d, %d]",
+                    min_gain,
+                    max_gain,
+                )
+        else:
+            logger.debug(
+                "HeadsetMicGain: GetInfo returned %s, using fallback int8 range",
+                info.hex() if info else info,
+            )
+            min_gain, max_gain = cls.min_value, cls.max_value
+        rw = settings.FeatureRW(cls.feature, **cls.rw_options)
+        validator = settings_validator.RangeValidator(min_value=min_gain, max_value=max_gain, byte_count=1, signed=True)
+        return cls(device, rw, validator)
 
 
 class HeadsetMixBalance(settings.Setting):
@@ -1724,16 +1791,70 @@ class HeadsetMixBalance(settings.Setting):
     validator_options = {"byte_count": 1}
 
 
+class _AutoSleepRangeValidator(settings_validator.RangeValidator):
+    """Single-slot read-modify-write validator for HID++ 0x0108 AutoSleep.
+
+    0x0108 is not a single timer: V3 has two uint8 bytes, V4+ has three. Each
+    byte is an independent timer slot. Solaar exposes only the user-facing slot
+    today and preserves the others via RMW; writing zero into the other slots
+    causes the firmware to reject the request.
+
+    Wire byte layout per feature version:
+      V<3: [timer]
+      V3:  [reserved, timer]            — preserve byte[0]
+      V4+: [timer_a, timer_b, timer_c]  — preserve byte[1], byte[2]
+    """
+
+    def __init__(self, byte_count, **kwargs):
+        super().__init__(byte_count=byte_count, **kwargs)
+        # V3 sources the user-controllable timer from byte[1] per LGHUB.
+        self._slot = 1 if byte_count == 2 else 0
+
+    def validate_read(self, reply_bytes):
+        if len(reply_bytes) <= self._slot:
+            raise AssertionError(
+                f"{self.__class__.__name__}: read returned {len(reply_bytes)} bytes, expected ≥ {self._slot + 1}"
+            )
+        return reply_bytes[self._slot]
+
+    def prepare_write(self, new_value, current_value=None):
+        if new_value < self.min_value or new_value > self.max_value:
+            raise ValueError(f"invalid choice {new_value!r}")
+        if current_value is None:
+            payload = bytearray(self._byte_count)
+        else:
+            payload = bytearray(current_value[: self._byte_count])
+            if len(payload) < self._byte_count:
+                payload.extend(b"\x00" * (self._byte_count - len(payload)))
+        if payload[self._slot] == new_value:
+            return None
+        payload[self._slot] = new_value
+        return bytes(payload)
+
+
 class HeadsetAutoSleep(settings.Setting):
     name = "headset-auto-sleep"
     label = _("Auto Sleep Timeout")
     description = _("Idle time in minutes before the headset enters sleep mode (0 = disabled).")
     feature = _F.CENTURION_AUTO_SLEEP
     rw_options = {"read_fnid": 0x00, "write_fnid": 0x10}
-    validator_class = settings_validator.RangeValidator
+    validator_class = _AutoSleepRangeValidator
     min_value = 0
-    max_value = 255
+    max_value = 255  # uint8 slot
     validator_options = {"byte_count": 1}
+
+    @classmethod
+    def build(cls, device):
+        version = device.features.get_feature_version(cls.feature) or 0
+        if version >= 4:
+            byte_count = 3
+        elif version >= 3:
+            byte_count = 2
+        else:
+            byte_count = 1
+        rw = settings.FeatureRW(cls.feature, **cls.rw_options)
+        validator = _AutoSleepRangeValidator(min_value=0, max_value=cls.max_value, byte_count=byte_count)
+        return cls(device, rw, validator)
 
 
 class HeadsetOnboardEQ(settings.RangeFieldSetting):
@@ -1751,10 +1872,19 @@ class HeadsetOnboardEQ(settings.RangeFieldSetting):
         def build(cls, setting_class, device):
             info = hidpp20.get_onboard_eq_info(device)
             if not info:
+                logger.debug("HeadsetOnboardEQ.build: getEQInfo failed, no panel will be built")
                 return None
             _has_hw_eq, num_bands = info
             bands = hidpp20.get_onboard_eq_params(device, slot=0x00)
-            if not bands or len(bands) != num_bands:
+            if not bands:
+                logger.debug("HeadsetOnboardEQ.build: getEQParameters returned no bands, no panel will be built")
+                return None
+            if len(bands) != num_bands:
+                logger.debug(
+                    "HeadsetOnboardEQ.build: band count mismatch — EQInfo=%d getEQParameters=%d; skipping",
+                    num_bands,
+                    len(bands),
+                )
                 return None
             keys = common.NamedInts()
             for i, (freq, _gain, _q) in enumerate(bands):
@@ -1762,6 +1892,7 @@ class HeadsetOnboardEQ(settings.RangeFieldSetting):
             v = cls(keys, min_value=-12, max_value=12, count=num_bands, byte_count=1)
             v._band_freqs = [freq for freq, _g, _q in bands]
             v._band_qs = [q for _f, _g, q in bands]
+            logger.debug("HeadsetOnboardEQ.build: panel built with %d band(s)", num_bands)
             return v
 
         def validate_read(self, reply_bytes):
@@ -1808,6 +1939,728 @@ class HeadsetOnboardEQ(settings.RangeFieldSetting):
             except Exception:
                 logger.warning("HeadsetOnboardEQ: failed to persist EQ to slot 0x80")
         return result
+
+
+class HeadsetAdvancedEQ(settings.RangeFieldSetting):
+    """Per-band gain editor for the headset's active AdvancedParaEQ (0x020D) slot.
+
+    V2 wire format (pcap-verified against G522 LIGHTSPEED):
+      getCustomEQ  response: [dir_echo] + N × [freq_hi, freq_lo, filter, gain_hi, gain_lo]
+      setCustomEQ  request:  [dir, slot, pad=0] + N × [freq_hi, freq_lo, filter, gain_hi, gain_lo]
+    Gain is offset-binary against gain_min..gain_max with `gain_steps`
+    discrete positions (raw=120 ≈ 0 dB on G522's [-6, +6] / 241-step
+    grid). Frequency and filter type are read at build time and not
+    user-editable today — UI only exposes per-band gain.
+    """
+
+    name = "headset-advanced-eq"
+    label = _("Headset Advanced EQ")
+    description = _("Per-band gain for the headset's active parametric EQ.")
+    feature = _F.HEADSET_ADVANCED_PARA_EQ
+    rw_options = {"read_fnid": 0x10, "write_fnid": 0x20}
+    keys_universe = []
+
+    class rw_class(settings.FeatureRW):
+        """get/setCustomEQ both take [direction, slot]; on writes the
+        device additionally expects a single 0x00 padding byte before
+        the band payload. The slot is the *active* EQ preset, which the
+        device may have switched while we weren't looking — re-query it
+        on every read and write instead of caching at build time.
+        Direction is hardcoded to 0 (playback); mic-side EQ isn't
+        exposed yet.
+        """
+
+        def read(self, device, data_bytes=b""):
+            active_slot = hidpp20.get_advanced_eq_active_slot(device, direction=0)
+            self.read_prefix = bytes([0, active_slot if active_slot is not None else 0])
+            return super().read(device, data_bytes)
+
+        def write(self, device, data_bytes):
+            active_slot = hidpp20.get_advanced_eq_active_slot(device, direction=0)
+            slot = active_slot if active_slot is not None else 0
+            write_bytes = bytes([0, slot, 0]) + data_bytes
+            return device.feature_request(self.feature, self.write_fnid, write_bytes)
+
+    class validator_class(settings_validator.PackedRangeValidator):
+        kind = settings.Kind.GRAPHIC_EQ
+
+        @classmethod
+        def build(cls, setting_class, device):
+            info = hidpp20.get_advanced_eq_info(device)
+            if not info:
+                logger.debug("HeadsetAdvancedEQ.build: getEQInfos failed, no panel will be built")
+                return None
+            device._advanced_eq_info = info
+            version = info["version"]
+            gain_min = info["gain_min_db"]
+            gain_max = info["gain_max_db"]
+            step_db = info["step_db"]
+
+            active_slot = hidpp20.get_advanced_eq_active_slot(device, direction=0) or 0
+            bands = hidpp20.get_advanced_eq_params(device, direction=0, slot=active_slot)
+            if not bands:
+                logger.debug("HeadsetAdvancedEQ.build: getCustomEQ returned no bands, no panel will be built")
+                return None
+            band_count = len(bands)
+            expected = info.get("band_count")
+            if expected is not None and expected != band_count:
+                logger.debug(
+                    "HeadsetAdvancedEQ.build: V%d band count mismatch — EQInfos=%d getCustomEQ=%d; trusting getCustomEQ",
+                    version,
+                    expected,
+                    band_count,
+                )
+
+            keys = common.NamedInts()
+            for i, (filter_type, freq_hz, _gain_db) in enumerate(bands):
+                if filter_type == hidpp20.FILTER_TYPE_HP:
+                    keys[i] = "HP " + str(freq_hz) + _("Hz")
+                else:
+                    keys[i] = str(freq_hz) + _("Hz")
+            v = cls(
+                keys,
+                min_value=int(round(gain_min)),
+                max_value=int(round(gain_max)),
+                count=band_count,
+                byte_count=1,
+            )
+            v._version = version
+            v._step_db = step_db
+            v._gain_min = gain_min
+            v._gain_max = gain_max
+            v._gain_steps = info.get("gain_steps", 241)
+            v._band_types = [band[0] for band in bands]
+            v._band_freqs = [band[1] for band in bands]
+            v._active_slot = active_slot
+            logger.debug(
+                "HeadsetAdvancedEQ.build: panel built V%d with %d band(s), slot=%d, range=[%d,%d], step_db=%.4f",
+                version,
+                band_count,
+                active_slot,
+                gain_min,
+                gain_max,
+                step_db,
+            )
+            # One-shot per-slot probe — logs band data for each slot the
+            # firmware actually honors and caches the working-slot list on
+            # `device._advanced_eq_working_slots`. Cheap if HeadsetActiveEQPreset
+            # already populated the cache (it usually has at this point);
+            # otherwise this is the first-time probe.
+            if version >= 2:
+                try:
+                    hidpp20.probe_advanced_eq_slots(device, direction=0, info=info)
+                except Exception as e:
+                    logger.debug("HeadsetAdvancedEQ.build: preset corpus probe failed: %s", e)
+            return v
+
+        def validate_read(self, reply_bytes):
+            if reply_bytes is None:
+                return {}
+            version = getattr(self, "_version", 0)
+            if version >= 2:
+                info = {
+                    "gain_min_db": getattr(self, "_gain_min", -6),
+                    "gain_max_db": getattr(self, "_gain_max", 6),
+                    "gain_steps": getattr(self, "_gain_steps", 241),
+                    "step_db": getattr(self, "_step_db", 0.05),
+                }
+                bands = hidpp20.parse_v2_bands(reply_bytes, info)
+                if bands is None:
+                    return {}
+                result = {}
+                for i, (filter_type, freq_hz, gain_db) in enumerate(bands):
+                    if i >= self.count:
+                        break
+                    result[i] = int(round(gain_db))
+                    if hasattr(self, "_band_types") and i < len(self._band_types):
+                        self._band_types[i] = filter_type
+                    if hasattr(self, "_band_freqs") and i < len(self._band_freqs):
+                        self._band_freqs[i] = freq_hz
+                return result
+            # V0/V1: 3-byte stride.
+            result = {}
+            offset = 0
+            i = 0
+            while offset + 3 <= len(reply_bytes) and i < self.count:
+                freq = struct.unpack(">H", reply_bytes[offset : offset + 2])[0]
+                if freq == 0:
+                    break
+                gain = struct.unpack("b", bytes([reply_bytes[offset + 2]]))[0]
+                result[i] = gain
+                if hasattr(self, "_band_freqs") and i < len(self._band_freqs):
+                    self._band_freqs[i] = freq
+                offset += 3
+                i += 1
+            return result
+
+        def prepare_write(self, new_values):
+            """Encode N × [freq_hi, freq_lo, filter, gain_hi, gain_lo].
+
+            new_values is {band_idx: int_gain_dB}. freq and filter type
+            come from the cache captured at build time; gain is mapped
+            from integer dB back to the device's offset-binary raw u16
+            against the [_gain_min, _gain_max] / _gain_steps grid.
+            """
+            version = getattr(self, "_version", 0)
+            if version < 2:
+                return None
+            gain_min = getattr(self, "_gain_min", -6)
+            gain_max = getattr(self, "_gain_max", 6)
+            steps = getattr(self, "_gain_steps", 241)
+            freqs = getattr(self, "_band_freqs", None) or []
+            types = getattr(self, "_band_types", None) or []
+            if not freqs or not types:
+                return None
+            span = gain_max - gain_min
+            payload = bytearray()
+            for i in range(self.count):
+                freq = freqs[i] if i < len(freqs) else 0
+                filt = types[i] if i < len(types) else hidpp20.FILTER_TYPE_PEAKING_G522
+                gain_db = new_values.get(i, 0)
+                if steps > 1 and span > 0:
+                    raw = int(round((gain_db - gain_min) / span * (steps - 1)))
+                else:
+                    raw = 0
+                raw = max(0, min(steps - 1, raw))
+                payload += bytes([(freq >> 8) & 0xFF, freq & 0xFF, filt & 0xFF, (raw >> 8) & 0xFF, raw & 0xFF])
+            return bytes(payload)
+
+    def write(self, map, save=True):
+        # RangeFieldSetting.write treats an empty-bytes reply (`not reply`)
+        # as failure, but setCustomEQ returns an empty ACK on success.
+        # Override to treat only `reply is None` (transport error/timeout)
+        # as failure.
+        assert hasattr(self, "_value")
+        assert hasattr(self, "_device")
+        assert map is not None
+        if self._device.online:
+            self.update(map, save)
+            data_bytes = self._validator.prepare_write(self._value)
+            if data_bytes is not None:
+                reply = self._rw.write(self._device, data_bytes)
+                if reply is None:
+                    return None
+            return map
+
+
+class HeadsetActiveEQPreset(settings.Setting):
+    """Choose which AdvancedParaEQ slot drives live audio.
+
+    Activation works for any slot — read-only factory presets and
+    user-custom slots alike. The "(factory)" tag in the slot label
+    distinguishes the read-only ones; that distinction matters for
+    band-editing (not supported yet), not for activation today.
+    """
+
+    name = "headset-eq-active-preset"
+    label = _("EQ Preset")
+    description = _("Switch the active EQ preset. Factory presets are read-only.")
+    feature = _F.HEADSET_ADVANCED_PARA_EQ
+    rw_options = {"read_fnid": 0x30, "write_fnid": 0x40, "prefix": b"\x00"}
+    validator_class = settings_validator.ChoicesValidator
+
+    @classmethod
+    def build(cls, device):
+        info = getattr(device, "_advanced_eq_info", None) or hidpp20.get_advanced_eq_info(device)
+        if not info:
+            return None
+        ro_count = info.get("onboard_ro_preset_count", 0) or 0
+        # Probe each advertised slot — getEQInfos may report capacity that
+        # the firmware doesn't actually back (G522 advertises 16 slots but
+        # only honors slot 0). Only include slots that responded with band
+        # data; the result is cached on device._advanced_eq_working_slots
+        # so HeadsetAdvancedEQ.build can reuse it without re-probing.
+        working = hidpp20.probe_advanced_eq_slots(device, direction=0, info=info)
+        if len(working) <= 1:
+            # One option (or zero) is meaningless as a selector — there's
+            # nothing for the user to choose between. The active EQ is
+            # whatever slot 0 has, no preset switching is available.
+            return None
+        choices = common.NamedInts()
+        for slot, slot_name, _bands in working:
+            if not slot_name:
+                slot_name = _("Slot") + " " + str(slot)
+            if slot < ro_count:
+                slot_name = slot_name + " " + _("(factory)")
+            choices[slot] = slot_name
+        rw = settings.FeatureRW(cls.feature, **cls.rw_options)
+        validator = settings_validator.ChoicesValidator(choices=choices)
+        return cls(device, rw, validator)
+
+    def write(self, value, save=True):
+        result = super().write(value, save)
+        if result is not None:
+            # After setActiveEQ, repopulate the AdvancedParaEQ band-display
+            # cache so the panel reflects the newly-active slot. Force a
+            # fresh read so _value is a real dict — leaving it as None
+            # would let a UI band-click hit `_value[item]` on None and
+            # crash (config_panel.py:589 'NoneType' is not subscriptable).
+            # The visible widget redraw still waits for a manual refresh /
+            # panel reopen — auto-redraw would need UI-side plumbing.
+            eq_panel = _headset_setting_by_name(self._device, HeadsetAdvancedEQ.name)
+            if eq_panel is not None:
+                try:
+                    eq_panel._value = None
+                    eq_panel.read(cached=False)
+                except Exception as e:
+                    logger.debug("HeadsetActiveEQPreset: failed to refresh EQ panel: %s", e)
+        return result
+
+
+_NO_CHANGE_COLOR = int(special_keys.COLORSPLUS["No change"])
+
+
+def _headset_setting_by_name(device, name):
+    for s in getattr(device, "settings", None) or []:
+        if getattr(s, "name", None) == name:
+            return s
+    return None
+
+
+def _headset_primary_color(device, default=0xFFFFFF):
+    """Resolve the currently-saved Primary color, or `default` if absent."""
+    s = _headset_setting_by_name(device, HeadsetLEDsPrimary.name)
+    if s is None:
+        return default
+    value = getattr(s, "_value", None)
+    color = getattr(value, "color", None) if value is not None else None
+    return int(color) if color is not None else default
+
+
+def _headset_per_zone_overrides(device):
+    """Return `{zone_id: color_int}` for zones with explicit (non-'No change')
+    colors set via the Per-zone Lighting setting, or `None` if the setting
+    isn't built/present."""
+    s = _headset_setting_by_name(device, HeadsetPerZoneLighting.name)
+    if s is None:
+        return None
+    value = getattr(s, "_value", None)
+    if not isinstance(value, dict):
+        return None
+    overrides = {}
+    for zone, color in value.items():
+        try:
+            color_int = int(color)
+        except (TypeError, ValueError):
+            continue
+        if color_int != _NO_CHANGE_COLOR:
+            overrides[int(zone)] = color_int
+    return overrides
+
+
+class _HeadsetStaticEffectOption:
+    """Minimal stand-in for `hidpp20.LEDEffectInfo`.
+
+    `HeteroValidator` only inspects `.ID` and `.index` on its `options`
+    list; we don't need the full device-query machinery here because the
+    headset wire protocol is handled by `headset_rgb.write_zone_map`.
+    """
+
+    ID = 0x01  # matches hidpp20.LEDEffects[0x01] = Static
+    index = 0x01
+
+
+class HeadsetLEDControl(settings.Setting):
+    """Switch headset LED control between device and Solaar.
+
+    Mirrors the `LEDControl` / `RGBControl` pattern used for keyboards and
+    mice. When set to Solaar, the `LEDs Primary` and `Per-zone Lighting`
+    settings drive the LEDs; when set to Device, firmware-driven onboard
+    and signature effects resume.
+    """
+
+    name = "headset_led_control"
+    label = _("LED Control")
+    description = _("Switch control of LED zones between device and Solaar")
+    feature = _F.HEADSET_RGB_HOSTMODE
+    rw_options = {"read_fnid": 0x70, "write_fnid": 0x80}
+    choices_universe = common.NamedInts(Device=0, Solaar=1)
+    validator_class = settings_validator.ChoicesValidator
+    validator_options = {"choices": choices_universe}
+
+    @classmethod
+    def build(cls, device):
+        # One-shot read-only probe of 0x0621 / 0x0622 — logs the data the RE
+        # pass needs to pin down RGB onboard/signature effect structures.
+        # Skip cleanly if neither feature is exposed.
+        try:
+            rgb_effects_probe.probe(device)
+        except Exception as e:
+            logger.debug("RGB effects probe raised %r", e)
+        return super().build(device)
+
+    def write(self, value, save=True):
+        # After switching to Solaar control, the firmware drops whatever
+        # colors we'd programmed — so reassert the saved Primary + per-zone
+        # overrides immediately. Otherwise the LEDs stay on whatever
+        # device-driven effect was last shown until the user edits a color.
+        result = super().write(value, save)
+        if result is not None and int(value) == 1 and self._device.online:
+            primary = _headset_primary_color(self._device)
+            zones = headset_rgb.discover_zones(self._device)
+            if zones:
+                zone_map = {int(z): primary for z in zones}
+                zone_map.update(_headset_per_zone_overrides(self._device) or {})
+                headset_rgb.write_zone_map(self._device, zone_map)
+        return result
+
+
+class HeadsetLEDsPrimary(settings.Setting):
+    """Primary headset LED color, rendered as a GTK color picker.
+
+    Mirrors the `LEDZoneSetting` / `RGBEffectSetting` shape: a
+    `HeteroValidator` with a single "Static" effect whose only visible
+    field is the color. Write applies the chosen color across all zones
+    discovered at build time, then re-applies any per-zone overrides on
+    top so they aren't clobbered.
+
+    Read support is deliberately disabled — the feature exposes no "get
+    current color" function, so we rely on the persister.
+    """
+
+    name = "headset_leds_primary"
+    label = _("LEDs") + " " + _("Primary")
+    description = _(
+        "Set the primary color applied to every headset LED zone.\n" "LED Control needs to be set to Solaar to be effective."
+    )
+    feature = _F.HEADSET_RGB_HOSTMODE
+    persist = True
+    rw_options = {"read_fnid": None, "write_fnid": None}
+
+    # HeteroKeyControl renders exactly these fields; ID is hidden
+    # (`label=None`) but kept so setup_visibles can key off it.
+    color_field = {"name": hidpp20.LEDParam.color, "kind": settings.Kind.COLOR, "label": _("Color")}
+    possible_fields = [
+        {
+            "name": "ID",
+            "kind": settings.Kind.CHOICE,
+            "label": None,
+            "choices": [common.NamedInt(0x01, _("Static"))],
+        },
+        color_field,
+    ]
+    # HeteroKeyControl.setup_visibles looks up fields_map[effect_id][1] to
+    # decide which fields to show — we only expose the color.
+    fields_map = {0x01: [common.NamedInt(0x01, _("Static")), {hidpp20.LEDParam.color: 0}]}
+
+    @classmethod
+    def build(cls, device):
+        zones = headset_rgb.discover_zones(device)
+        if not zones:
+            return None
+        rw = settings.FeatureRW(cls.feature)
+        validator = settings_validator.HeteroValidator(
+            data_class=hidpp20.LEDEffectSetting,
+            options=[_HeadsetStaticEffectOption()],
+            readable=False,
+        )
+        return cls(device, rw, validator)
+
+    def read(self, cached=True):
+        # Feature 0x0620 doesn't expose a "current primary color" read —
+        # pull from the persister via _pre_read, fall back to white so
+        # the picker opens on a sane starting color.
+        self._pre_read(cached)
+        if self._value is not None:
+            return self._value
+        self._value = hidpp20.LEDEffectSetting(ID=common.NamedInt(0x01, _("Static")), color=0xFFFFFF)
+        return self._value
+
+    def write(self, value, save=True):
+        color = getattr(value, "color", None)
+        if color is None:
+            return None
+        device = self._device
+        if not device.online:
+            return None
+        zones = headset_rgb.discover_zones(device)
+        if not zones:
+            return None
+        primary = int(color)
+        zone_map = {int(z): primary for z in zones}
+        # Re-apply any non-"No change" per-zone overrides on top of the
+        # fresh Primary baseline so the user's explicit zone choices stick
+        # when they change the bulk color.
+        overrides = _headset_per_zone_overrides(device) or {}
+        zone_map.update(overrides)
+        if headset_rgb.write_zone_map(device, zone_map):
+            self.update(value, save)
+            return value
+        return None
+
+
+class HeadsetPerZoneLighting(settings.Settings):
+    """Per-zone LED color overrides.
+
+    Mirrors `PerKeyLighting` — keys are firmware zone IDs, values are
+    24-bit RGB ints with the `-1` sentinel meaning "inherit the current
+    `LEDs Primary` color." Surfaces in the UI via the per-key painter.
+    """
+
+    name = "headset_per_zone_lighting"
+    label = _("Per-zone Lighting")
+    description = _(
+        "Override individual zone colors. 'No change' inherits the LEDs Primary color.\n"
+        "LED Control needs to be set to Solaar to be effective."
+    )
+    feature = _F.HEADSET_RGB_HOSTMODE
+    persist = True
+    editor_class = "solaar.ui.perkey.control:PerKeyControl"
+
+    class rw_class(settings.FeatureRWMap):
+        pass
+
+    class validator_class(settings_validator.MapRangeValidator):
+        _COLOR_RANGE = settings_validator.Range(min=0, max=0xFFFFFF, byte_count=3)
+
+        @classmethod
+        def build(cls, setting_class, device):
+            zones = headset_rgb.discover_zones(device)
+            if not zones:
+                return None
+            choices_map = {common.NamedInt(int(z), _("Zone") + " " + str(int(z))): cls._COLOR_RANGE for z in zones}
+            return cls(choices_map) if choices_map else None
+
+    def read(self, cached=True):
+        self._pre_read(cached)
+        if cached and self._value is not None:
+            return self._value
+        # Device doesn't expose current per-zone state; default every
+        # zone to "No change" so the primary color shows through.
+        reply_map = {int(key): _NO_CHANGE_COLOR for key in self._validator.choices}
+        self._value = reply_map
+        return reply_map
+
+    def _resolve_zone_map(self, map_, primary):
+        """Substitute 'No change' entries with the primary color."""
+        resolved = {}
+        for key, value in map_.items():
+            try:
+                v = int(value)
+            except (TypeError, ValueError):
+                continue
+            resolved[int(key)] = primary if v == _NO_CHANGE_COLOR else v
+        return resolved
+
+    def write(self, map_, save=True):
+        device = self._device
+        if not device.online:
+            return None
+        self.update(map_, save)
+        primary = _headset_primary_color(device)
+        zone_map = self._resolve_zone_map(map_, primary)
+        if not zone_map:
+            return None
+        if headset_rgb.write_zone_map(device, zone_map):
+            return map_
+        return None
+
+    def write_key_value(self, key, value, save=True):
+        result = super().write_key_value(int(key), value, save)
+        device = self._device
+        if not device.online:
+            return result
+        try:
+            v = int(value)
+        except (TypeError, ValueError):
+            return result
+        effective = _headset_primary_color(device) if v == _NO_CHANGE_COLOR else v
+        headset_rgb.write_zone_map(device, {int(key): int(effective)})
+        return result
+
+
+# ----------------------------------------------------------------------------
+# LogiVoice (0x0900 + 0x0901..0x0907) — read-only presentation pass.
+#
+# Per module we auto-generate two settings:
+#   1. A flat State toggle — reads GetState (fn 1), renders as a boolean.
+#      Top-level so users see a direct on/off indicator at a glance.
+#   2. A collapsible "Parameters" panel — one MULTIPLE_RANGE-kind setting
+#      that reads GetParameters (fn 3) once and distributes the bytes to
+#      per-field sliders. The existing MultipleRangeControl widget is
+#      collapsible by default, so the field-level clutter stays folded.
+#
+# Writes are disabled — the Parameters struct carries fields whose wire
+# encodings are still ambiguous (see logivoice.py) and a SetParameters
+# write must bundle all fields at once. A write pass can be added once
+# each field's encoding is confirmed live.
+# ----------------------------------------------------------------------------
+
+
+class _LogiVoiceStateSetting(settings.Setting):
+    """Per-module State toggle. Reads GetState (fn 1) and writes SetState (fn 0).
+
+    State wire format is unambiguous (one byte: 0 = off, 1 = on), so this is
+    the one piece of the LogiVoice surface we enable for writes. The per-module
+    Parameters struct stays read-only until each field's encoding is confirmed.
+    """
+
+    rw_options = {"read_fnid": logivoice.FN_GET_STATE, "write_fnid": logivoice.FN_SET_STATE}
+    validator_class = settings_validator.BooleanValidator
+
+    @classmethod
+    def build(cls, device):
+        # Corpus probe runs here (once per module) so -dd users get a full
+        # snapshot of state + raw Parameters + raw Info for future decoding.
+        try:
+            logivoice.probe_module(device, cls.feature)
+        except Exception as e:
+            logger.debug("LogiVoice probe_module(%s) raised %s", cls.feature, e)
+        return super().build(device)
+
+
+class _LogiVoiceModuleItem:
+    """Top-level MULTIPLE_RANGE item representing one LogiVoice module.
+
+    One `item` per setting — the module itself. `__int__` returns the feature
+    id so the Setting's reply dict is keyed predictably.
+    """
+
+    def __init__(self, feature: hidpp20_constants.SupportedFeature):
+        self._feature = feature
+        self.id = logivoice.MODULE_SLUGS.get(feature, f"0x{int(feature):04X}")
+        self.index = 0
+
+    def __int__(self):
+        return int(self._feature)
+
+    def __str__(self):
+        return logivoice.MODULE_NAMES.get(self._feature, f"0x{int(self._feature):04X}")
+
+
+class _LogiVoiceFieldSubItem:
+    """MULTIPLE_RANGE sub-item wrapping one decoded Parameters field.
+
+    MultipleRangeControl reads minimum/maximum/length/widget/str(). We pick
+    SpinButton for wide ranges (0..65535) where a 64k-step slider is useless,
+    and Scale for small ranges (e.g. signed int8 thresholds).
+    """
+
+    def __init__(self, field: logivoice.Field):
+        self._field = field
+        self.id = field.name
+        self.minimum = field.min_value
+        self.maximum = field.max_value
+        self.length = field.byte_count
+        self.widget = "SpinButton" if (field.max_value - field.min_value) > 512 else "Scale"
+
+    def __int__(self):
+        return hash(self.id) & 0xFFFFFF
+
+    def __str__(self):
+        return self._field.label + (" (raw)" if self._field.opaque else "")
+
+
+class _LogiVoiceParametersValidator(settings_validator.MultipleRangeValidator):
+    """Reads the whole GetParameters struct once and distributes bytes to fields.
+
+    MULTIPLE_RANGE's default read loop fires prepare_read_item once per top-
+    level item; we have exactly one item (the module), so this issues a single
+    GetParameters call. validate_read_item parses the shared reply into a
+    {field_name: value} dict. Writes are blocked.
+    """
+
+    def __init__(self, feature: hidpp20_constants.SupportedFeature):
+        fields = logivoice.PARAMETERS_FIELDS.get(feature, [])
+        self._fields = list(fields)
+        item = _LogiVoiceModuleItem(feature)
+        sub_items = {item: [_LogiVoiceFieldSubItem(f) for f in fields]}
+        super().__init__(items=[item], sub_items=sub_items)
+
+    def prepare_read_item(self, item):
+        return b""  # GetParameters takes no wire arguments
+
+    def validate_read(self, reply_bytes):
+        # Setting.read() calls validate_read with the raw GetParameters reply.
+        # MultipleRangeValidator only defines validate_read_item, so wrap that
+        # call — we have a single item (the module) so one call suffices.
+        item = self.items[0]
+        return {int(item): self.validate_read_item(reply_bytes, item)}
+
+    def validate_read_item(self, reply_bytes, item):
+        parsed = {}
+        # Key by str(sub_item) so MultipleRangeControl.set_value can look up
+        # values via v[str(sub_item)] — the UI uses the label as the dict key.
+        for sub in self.sub_items[item]:
+            f = sub._field
+            end = f.offset + f.byte_count
+            if end > len(reply_bytes):
+                continue
+            chunk = reply_bytes[f.offset : end]
+            if f.byte_count == 1:
+                v = struct.unpack("b" if f.signed else "B", chunk)[0]
+            elif f.byte_count == 2:
+                v = struct.unpack(">h" if f.signed else ">H", chunk)[0]
+            else:
+                v = int.from_bytes(chunk, "big", signed=f.signed)
+            parsed[str(sub)] = v
+        return parsed
+
+    def prepare_write_item(self, item, value):
+        return None
+
+    def prepare_write(self, value):
+        return None
+
+
+class _LogiVoiceParametersSetting(settings.Setting):
+    """Collapsible read-only display of one module's GetParameters struct."""
+
+    rw_options = {"read_fnid": logivoice.FN_GET_PARAMETERS}
+    persist = False
+    kind = settings.Kind.MULTIPLE_RANGE
+
+    @classmethod
+    def build(cls, device):
+        if not logivoice.PARAMETERS_FIELDS.get(cls.feature):
+            return None
+        rw = settings.FeatureRW(cls.feature, **cls.rw_options)
+        validator = _LogiVoiceParametersValidator(cls.feature)
+        return cls(device, rw, validator)
+
+    def write(self, map, save=True):
+        return None
+
+
+def _logivoice_make_state_class(feature: hidpp20_constants.SupportedFeature):
+    slug = logivoice.MODULE_SLUGS.get(feature)
+    if not slug:
+        return None
+    module_name = logivoice.MODULE_NAMES.get(feature, f"0x{int(feature):04X}")
+    attrs = {
+        "name": f"logivoice-{slug}-state",
+        "label": f"LogiVoice {module_name}",
+        "description": f"Enable the headset {module_name} processing block.",
+        "feature": feature,
+    }
+    return type(f"LogiVoice_{slug}_State", (_LogiVoiceStateSetting,), attrs)
+
+
+def _logivoice_make_parameters_class(feature: hidpp20_constants.SupportedFeature):
+    slug = logivoice.MODULE_SLUGS.get(feature)
+    if not slug or not logivoice.PARAMETERS_FIELDS.get(feature):
+        return None
+    module_name = logivoice.MODULE_NAMES.get(feature, f"0x{int(feature):04X}")
+    attrs = {
+        "name": f"logivoice-{slug}-parameters",
+        "label": f"LogiVoice {module_name}: Parameters (read-only)",
+        "description": (
+            f"Decoded {module_name} GetParameters fields. "
+            "Opaque raw values shown where the wire encoding isn't confirmed yet."
+        ),
+        "feature": feature,
+    }
+    return type(f"LogiVoice_{slug}_Parameters", (_LogiVoiceParametersSetting,), attrs)
+
+
+_LOGIVOICE_SETTINGS: list[type] = []
+for _feature in logivoice.PARAMETERS_FIELDS:
+    _state_cls = _logivoice_make_state_class(_feature)
+    if _state_cls is not None:
+        _LOGIVOICE_SETTINGS.append(_state_cls)
+    _params_cls = _logivoice_make_parameters_class(_feature)
+    if _params_cls is not None:
+        _LOGIVOICE_SETTINGS.append(_params_cls)
 
 
 class BrightnessControl(settings.Setting):
@@ -3178,6 +4031,12 @@ SETTINGS: list[settings.Setting] = [
     HeadsetMixBalance,
     HeadsetAutoSleep,
     HeadsetOnboardEQ,
+    HeadsetActiveEQPreset,
+    HeadsetAdvancedEQ,
+    HeadsetLEDControl,
+    HeadsetLEDsPrimary,
+    HeadsetPerZoneLighting,
+    *_LOGIVOICE_SETTINGS,
 ]
 
 
@@ -3273,8 +4132,22 @@ def check_feature(device, settings_class: SettingsProtocol) -> None | bool | Set
     if settings_class.feature not in device.features:
         return
     if settings_class.min_version > device.features.get_feature_version(settings_class.feature):
+        logger.debug(
+            "check_feature %s [%s]: min_version=%d > device feature version=%d; skipping",
+            settings_class.name,
+            settings_class.feature,
+            settings_class.min_version,
+            device.features.get_feature_version(settings_class.feature) or 0,
+        )
         return
     if device.features.get_hidden(settings_class.feature):
+        flags = device.features.flags.get(settings_class.feature, 0)
+        logger.debug(
+            "check_feature %s [%s]: feature has INTERNAL flag set (flags=0x%02X); skipping",
+            settings_class.name,
+            settings_class.feature,
+            flags,
+        )
         return
     try:
         detected = settings_class.build(device)
@@ -3313,34 +4186,49 @@ def check_feature_settings(device, already_known) -> bool:
                     known_present = sclass.name in device.persister
             else:
                 known_present = False
-            if not any(s.name == sclass.name for s in already_known) and (known_present or sclass.name not in absent):
-                try:
-                    setting = check_feature(device, sclass)
-                except Exception as err:
-                    # on an internal HID++ error, assume offline and stop further checking
-                    if (
-                        isinstance(err, exceptions.FeatureCallError)
-                        and err.error == hidpp20_constants.ErrorCode.LOGITECH_ERROR
-                    ):
-                        logger.warning(f"HID++ internal error checking feature {sclass.name}: make device not present")
-                        device.online = False
-                        device.present = False
-                        return False
-                    else:
-                        logger.warning(f"ignore feature {sclass.name} because of error {err}")
+            already = any(s.name == sclass.name for s in already_known)
+            if already:
+                continue
+            if not known_present and sclass.name in absent:
+                # Silent-skip cache from an earlier run's failed build(). If the
+                # feature is actually present on this device now, the cache is
+                # stale (e.g. from a prior build that returned None for a
+                # feature that currently works) — drop it and retry the probe.
+                if sclass.feature in device.features:
+                    logger.debug(
+                        "check_feature_settings: retrying %s — cached in _absent but feature %s is present now",
+                        sclass.name,
+                        sclass.feature,
+                    )
+                    absent.remove(sclass.name)
+                    if device.persister:
+                        device.persister["_absent"] = absent
+                else:
+                    continue
+            try:
+                setting = check_feature(device, sclass)
+            except Exception as err:
+                # on an internal HID++ error, assume offline and stop further checking
+                if isinstance(err, exceptions.FeatureCallError) and err.error == hidpp20_constants.ErrorCode.LOGITECH_ERROR:
+                    logger.warning(f"HID++ internal error checking feature {sclass.name}: make device not present")
+                    device.online = False
+                    device.present = False
+                    return False
+                else:
+                    logger.warning(f"ignore feature {sclass.name} because of error {err}")
 
-                if isinstance(setting, list):
-                    for s in setting:
-                        already_known.append(s)
-                    if sclass.name in new_absent:
-                        new_absent.remove(sclass.name)
-                elif setting:
-                    already_known.append(setting)
-                    if sclass.name in new_absent:
-                        new_absent.remove(sclass.name)
-                elif setting is None:
-                    if sclass.name not in new_absent and sclass.name not in absent and sclass.name not in device.persister:
-                        new_absent.append(sclass.name)
+            if isinstance(setting, list):
+                for s in setting:
+                    already_known.append(s)
+                if sclass.name in new_absent:
+                    new_absent.remove(sclass.name)
+            elif setting:
+                already_known.append(setting)
+                if sclass.name in new_absent:
+                    new_absent.remove(sclass.name)
+            elif setting is None:
+                if sclass.name not in new_absent and sclass.name not in absent and sclass.name not in device.persister:
+                    new_absent.append(sclass.name)
     if device.persister and new_absent:
         absent.extend(new_absent)
         device.persister["_absent"] = absent

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -2725,6 +2725,177 @@ class HeadsetSignaturePassiveEffect(_HeadsetSignatureEffectSetting):
     effect_id = 2
 
 
+class _HeadsetOnboardEffect:
+    """A 0x0621 onboard RGB effect: an effect ID plus the parameters that
+    effect uses. Synthetic form [effectId_u16_BE, 7 param bytes]; to_bytes /
+    from_bytes encode the per-effect parameter layout (the rw_class adds the
+    leading clusterIndex). intensity is a 0-100 percent; saturation is a raw
+    0-255 byte (same as the keyboard RGB effects)."""
+
+    def __init__(self, ID=0, color1=0, color2=0, intensity=0, saturation=0, period=0, speed=0, direction=0):
+        self.ID = int(ID)
+        self.intensity = max(0, min(100, int(intensity)))
+        self.saturation = max(0, min(255, int(saturation)))
+        self.period = max(0, min(0xFFFF, int(period)))
+        self.speed = max(0, min(0xFF, int(speed)))
+        self.direction = max(0, min(3, int(direction)))
+        for k, v in (("color1", color1), ("color2", color2)):
+            setattr(self, k, common.ColorInt(int(v) & 0xFFFFFF))
+
+    @classmethod
+    def from_bytes(cls, data, options=None):
+        if data is None or len(data) < 9:
+            return cls()
+        eid = (data[0] << 8) | data[1]
+        p = data[2:9]
+        kw = {"ID": eid}
+        if eid == 0:  # Fixed
+            kw["color1"] = (p[0] << 16) | (p[1] << 8) | p[2]
+        elif eid in (1, 2):  # ColorCycle / ColorWave
+            kw["intensity"] = p[0]
+            kw["period"] = (p[1] << 8) | p[2]
+            kw["saturation"] = p[3]
+            if eid == 2:
+                kw["direction"] = p[4]
+        elif eid == 3:  # Breathing
+            kw["color1"] = (p[0] << 16) | (p[1] << 8) | p[2]
+            kw["period"] = (p[4] << 8) | p[5]
+        elif eid == 4:  # DualColor
+            kw["color1"] = (p[0] << 16) | (p[1] << 8) | p[2]
+            kw["color2"] = (p[3] << 16) | (p[4] << 8) | p[5]
+            kw["speed"] = p[6]
+        return cls(**kw)
+
+    def to_bytes(self, options=None):
+        eid = self.ID
+        p = bytearray(7)
+        c1, c2 = int(self.color1), int(self.color2)
+        if eid == 0:  # Fixed: R, G, B
+            p[0], p[1], p[2] = (c1 >> 16) & 0xFF, (c1 >> 8) & 0xFF, c1 & 0xFF
+        elif eid in (1, 2):  # ColorCycle / ColorWave
+            p[0] = self.intensity
+            p[1], p[2] = (self.period >> 8) & 0xFF, self.period & 0xFF
+            p[3] = self.saturation
+            if eid == 2:
+                p[4] = self.direction
+        elif eid == 3:  # Breathing: R, G, B, CE[6]=0, period u16 BE
+            p[0], p[1], p[2] = (c1 >> 16) & 0xFF, (c1 >> 8) & 0xFF, c1 & 0xFF
+            p[4], p[5] = (self.period >> 8) & 0xFF, self.period & 0xFF
+        elif eid == 4:  # DualColor: R1,G1,B1, R2,G2,B2, speed
+            p[0], p[1], p[2] = (c1 >> 16) & 0xFF, (c1 >> 8) & 0xFF, c1 & 0xFF
+            p[3], p[4], p[5] = (c2 >> 16) & 0xFF, (c2 >> 8) & 0xFF, c2 & 0xFF
+            p[6] = self.speed
+        # eid 5 Custom: no inline parameters
+        return bytes([(eid >> 8) & 0xFF, eid & 0xFF]) + bytes(p)
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.to_bytes() == other.to_bytes()
+
+    def __str__(self):
+        return yaml.dump(self, width=float("inf")).rstrip("\n")
+
+    @classmethod
+    def from_yaml(cls, loader, node):
+        return cls(**loader.construct_mapping(node))
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return dumper.represent_mapping("!HeadsetOnboardEffect", data.__dict__, flow_style=True)
+
+
+yaml.SafeLoader.add_constructor("!HeadsetOnboardEffect", _HeadsetOnboardEffect.from_yaml)
+yaml.add_representer(_HeadsetOnboardEffect, _HeadsetOnboardEffect.to_yaml)
+
+
+class HeadsetOnboardEffect(settings.Setting):
+    """The firmware RGB effect a headset runs autonomously on its primary
+    lighting cluster (HEADSET_RGB_ONBOARD_EFFECTS, 0x0621). Build reads the
+    cluster's supported-effect set so the picker offers only those. Like the
+    signature/boot effects this is firmware-driven and not gated on host LED
+    control. Multi-cluster devices (none seen yet) drive only cluster 0."""
+
+    name = "headset-onboard-effect"
+    label = _("Onboard Effect")
+    description = _("Firmware RGB effect the headset plays on its own.")
+    feature = _F.HEADSET_RGB_ONBOARD_EFFECTS
+
+    _CLUSTER = 0
+    _ALL_EFFECTS = (
+        ("Fixed", 0),
+        ("Color Cycle", 1),
+        ("Color Wave", 2),
+        ("Breathing", 3),
+        ("Dual Color", 4),
+        ("Custom", 5),
+    )
+    _EFFECT_FIELDS = {
+        0: ("color1",),
+        1: ("intensity", "period", "saturation"),
+        2: ("intensity", "period", "saturation", "direction"),
+        3: ("color1", "period"),
+        4: ("color1", "color2", "speed"),
+        5: (),
+    }
+    _DIRECTIONS = common.NamedInts(**{"Horizontal": 0, "Vertical": 1, "Reverse Horizontal": 2, "Reverse Vertical": 3})
+
+    class rw_class:
+        kind = settings.FeatureRW.kind
+
+        def __init__(self, feature, cluster):
+            self.feature = feature
+            self._cluster = cluster
+
+        def read(self, device):
+            reply = device.feature_request(self.feature, 0x20, bytes([self._cluster]))  # getRGBClusterEffect
+            if reply is None or len(reply) < 10:
+                return None
+            return reply[1:10]  # strip clusterIndex -> [effectId_u16, 7 param bytes]
+
+        def write(self, device, data_bytes):
+            # data_bytes is [effectId_u16, 7 param bytes]; prepend clusterIndex
+            reply = device.feature_request(self.feature, 0x30, bytes([self._cluster]) + bytes(data_bytes))
+            return data_bytes if reply is not None else None
+
+    @classmethod
+    def build(cls, device):
+        try:
+            info = device.feature_request(cls.feature, 0x10, bytes([cls._CLUSTER]))  # getRGBClusterInfo
+        except exceptions.FeatureCallError:
+            return None
+        if info is None or len(info) < 1:
+            return None
+        # [count, count x {effectId_u16_BE, caps_u16_BE}] — take effectId of each entry
+        supported = []
+        for i in range(info[0]):
+            off = 1 + i * 4
+            if off + 2 > len(info):
+                break
+            eid = (info[off] << 8) | info[off + 1]
+            if 0 <= eid <= 5 and eid not in supported:
+                supported.append(eid)
+        if not supported:
+            # Unparseable reply — offer all six; the firmware rejects any it
+            # doesn't support. See the 0x0621 fallback note in protocol RE.
+            supported = [0, 1, 2, 3, 4, 5]
+        rw = cls.rw_class(cls.feature, cls._CLUSTER)
+        validator = settings_validator.HeteroValidator(data_class=_HeadsetOnboardEffect, options=None)
+        setting = cls(device, rw, validator)
+        id_choices = common.NamedInts(**{name: eid for name, eid in cls._ALL_EFFECTS if eid in supported})
+        id_field = {"name": "ID", "kind": settings.Kind.CHOICE, "label": None, "choices": id_choices}
+        setting.possible_fields = [
+            id_field,
+            {"name": "color1", "kind": settings.Kind.COLOR, "label": _("Primary")},
+            {"name": "color2", "kind": settings.Kind.COLOR, "label": _("Secondary")},
+            {"name": "intensity", "kind": settings.Kind.RANGE, "label": _("Intensity"), "min": 0, "max": 100},
+            {"name": "saturation", "kind": settings.Kind.RANGE, "label": _("Saturation"), "min": 0, "max": 255},
+            {"name": "period", "kind": settings.Kind.RANGE, "label": _("Period"), "min": 0, "max": 0xFFFF},
+            {"name": "speed", "kind": settings.Kind.RANGE, "label": _("Speed"), "min": 0, "max": 0xFF},
+            {"name": "direction", "kind": settings.Kind.CHOICE, "label": _("Direction"), "choices": cls._DIRECTIONS},
+        ]
+        setting.fields_map = {eid: (id_choices[eid], {field: 1 for field in cls._EFFECT_FIELDS[eid]}) for eid in supported}
+        return setting
+
+
 # ----------------------------------------------------------------------------
 # LogiVoice (0x0900 + 0x0901..0x0907) — read-only presentation pass.
 #
@@ -4297,6 +4468,7 @@ SETTINGS: list[settings.Setting] = [
     HeadsetSignatureStartupEffect,
     HeadsetSignatureShutdownEffect,
     HeadsetSignaturePassiveEffect,
+    HeadsetOnboardEffect,
     *_LOGIVOICE_SETTINGS,
 ]
 

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -2635,6 +2635,15 @@ class _HeadsetSignatureEffectSetting(settings.Setting):
             return None
         if state is None or len(state) < 3:
             return None
+        # NVconfig-saved colors are default-DENY: signature effects persist to
+        # device storage, so a slot is shown only on models explicitly known-
+        # good. allowed is None on an unlisted model/slot (suppress the whole
+        # setting), else the set of fields the firmware honors. The G522
+        # passive slot is deliberately unlisted — its behavior is unknown.
+        # SOLAAR_EXPERIMENTAL unmasks everything.
+        allowed = device_quirks.headset_signature_allowed_fields(device, cls.effect_id)
+        if allowed is None:
+            return None
         # Log getSignatureEffectsInfo (fn 0) once per device — its byte layout
         # isn't pinned down, so slot discovery uses per-slot probing for now.
         if not getattr(device, "_headset_sig_info_logged", False):
@@ -2651,7 +2660,7 @@ class _HeadsetSignatureEffectSetting(settings.Setting):
         # speed stay visible in both states so toggling Off keeps them.
         id_field = {"name": "ID", "kind": settings.Kind.TOGGLE, "label": None, "on_value": 1, "off_value": 2}
         setting.possible_fields = [id_field, cls._COLOR1_FIELD, cls._COLOR2_FIELD, cls._SPEED_FIELD]
-        visible = {"color1": 1, "color2": 1, "speed": 1}
+        visible = {f: 1 for f in ("color1", "color2", "speed") if f in allowed}
         setting.fields_map = {
             int(cls._ENABLED_CHOICES["On"]): (cls._ENABLED_CHOICES["On"], visible),
             int(cls._ENABLED_CHOICES["Off"]): (cls._ENABLED_CHOICES["Off"], visible),
@@ -3642,6 +3651,23 @@ class _RgbBootEffectSetting(settings.Setting):
             return None  # device rejects this cap — gate the setting off
         if reply is None or len(reply) < 10:
             return None
+        # Register the firmware shutdown trigger on cap 0x0040 devices so the
+        # animation plays on Solaar exit. This depends only on the device
+        # having the cap (probe above), not on the UI control being shown —
+        # so it runs before the allowlist gate below. rgb_power.cleanup fires
+        # mode 0 at its end when _rgb_has_shutdown_cap is set. See
+        # solaar_shutdown_effect_trigger_spec.md.
+        if cls.cap_id == 0x0040:
+            device._rgb_has_shutdown_cap = True
+            if rgb_power.cleanup not in device.cleanups:
+                device.cleanups.append(rgb_power.cleanup)
+        # NVconfig-saved colors are default-DENY: the boot-effect setting is
+        # shown only on models explicitly known-good. allowed is None on an
+        # unlisted model/cap (suppress), or a (possibly empty) set of color
+        # fields the firmware honors. SOLAAR_EXPERIMENTAL unmasks everything.
+        allowed = device_quirks.rgb_effects_nvconfig_allowed_fields(device, cls.cap_id)
+        if allowed is None:
+            return None
         rw = cls.rw_class(cls.feature, cls.cap_id)
         validator = settings_validator.HeteroValidator(data_class=_RgbBootEffect, options=None)
         setting = cls(device, rw, validator)
@@ -3654,24 +3680,15 @@ class _RgbBootEffectSetting(settings.Setting):
         # them and writes still carry their values — the firmware may store
         # bytes it doesn't visibly use. fields_map controls UI visibility.
         setting.possible_fields = [id_field, cls._COLOR1_FIELD, cls._COLOR2_FIELD]
-        # Default-allow: show both color pickers unless this device model is
-        # known to ignore one or both. Most 0x8071 devices honor the bytes.
-        inert = device_quirks.get(device, "rgb_effects_nvconfig_colors_inert", {}).get(cls.cap_id, set())
-        visible = {n: o for n, o in (("color1", 1), ("color2", 4)) if n not in inert}
+        # An empty allowed set shows the On/Off toggle only (cap works, colors
+        # don't); a non-empty set adds the listed color pickers.
+        visible = {n: o for n, o in (("color1", 1), ("color2", 4)) if n in allowed}
         # Both On/Off map to the same visible field set so colors stay editable
         # when the effect is Off (pre-stages them for next enable).
         setting.fields_map = {
             int(cls._ENABLED_CHOICES["On"]): (cls._ENABLED_CHOICES["On"], visible),
             int(cls._ENABLED_CHOICES["Off"]): (cls._ENABLED_CHOICES["Off"], visible),
         }
-        # Register the firmware shutdown trigger on cap 0x0040 devices so the
-        # animation plays on Solaar exit. rgb_power.cleanup fires mode 0 at
-        # its end when _rgb_has_shutdown_cap is set. See
-        # solaar_shutdown_effect_trigger_spec.md.
-        if cls.cap_id == 0x0040:
-            device._rgb_has_shutdown_cap = True
-            if rgb_power.cleanup not in device.cleanups:
-                device.cleanups.append(rgb_power.cleanup)
         return setting
 
 

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -2723,13 +2723,12 @@ class _HeadsetOnboardEffect:
     leading clusterIndex). intensity is a 0-100 percent; saturation is a raw
     0-255 byte (same as the keyboard RGB effects)."""
 
-    # Per-effect default parameter values, applied to any field the effect
-    # uses that would otherwise be 0. Picking an effect in the UI rebuilds
-    # this object from the (initially zeroed) field widgets, so without
-    # seeding the picker emits an all-zero frame: the firmware rejects
-    # ColorCycle/ColorWave outright and renders Breathing/DualColor/Static
-    # as black or zero-intensity. intensity 0 in particular reads as "LEDs
-    # off". Defaults confirmed against the LGHUB binary decode of 0x0621.
+    # Per-effect default parameter values, applied only to fields left
+    # unset (passed as None). An explicit value is always honored — passing
+    # 0 means the caller chose 0, e.g. a black Static color1 turns the LEDs
+    # off. Only a genuinely absent field falls back to the default (a fresh
+    # effect-pick seeds its RANGE widgets UI-side via _apply_id_defaults).
+    # Defaults confirmed against the LGHUB binary decode of 0x0621.
     _DEFAULTS = {
         0: {"color1": 0xFFFFFF},  # Static / Fixed
         1: {"intensity": 100, "saturation": 255, "period": 5000},  # Color Cycle
@@ -2740,24 +2739,21 @@ class _HeadsetOnboardEffect:
 
     # speed is accepted only to load configs persisted before the 0x0621
     # decode (DualColor byte 6 was mislabelled "speed"; it is intensity).
-    def __init__(self, ID=0, color1=0, color2=0, intensity=0, saturation=0, period=0, speed=0, direction=0):
+    def __init__(self, ID=0, color1=None, color2=None, intensity=None, saturation=None, period=None, speed=0, direction=None):
         self.ID = int(ID)
+        defaults = self._DEFAULTS.get(self.ID, {})
+        color1 = defaults.get("color1", 0) if color1 is None else color1
+        color2 = defaults.get("color2", 0) if color2 is None else color2
+        intensity = defaults.get("intensity", 0) if intensity is None else intensity
+        saturation = defaults.get("saturation", 0) if saturation is None else saturation
+        period = defaults.get("period", 0) if period is None else period
+        direction = defaults.get("direction", 0) if direction is None else direction
         self.intensity = max(0, min(100, int(intensity)))
         self.saturation = max(0, min(255, int(saturation)))
         self.period = max(0, min(0xFFFF, int(period)))
         self.direction = max(0, min(3, int(direction)))
         for k, v in (("color1", color1), ("color2", color2)):
             setattr(self, k, common.ColorInt(int(v) & 0xFFFFFF))
-        # Seed any field the selected effect uses that arrived as 0 so the
-        # picker never sends an all-zero (rejected / black) frame. An effect
-        # actually active on the device reports non-zero values, so reads
-        # via from_bytes are unaffected.
-        for field, default in self._DEFAULTS.get(self.ID, {}).items():
-            if not getattr(self, field):
-                if field.startswith("color"):
-                    setattr(self, field, common.ColorInt(default & 0xFFFFFF))
-                else:
-                    setattr(self, field, default)
 
     @classmethod
     def from_bytes(cls, data, options=None):

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -2658,9 +2658,11 @@ for _feature in logivoice.PARAMETERS_FIELDS:
     _state_cls = _logivoice_make_state_class(_feature)
     if _state_cls is not None:
         _LOGIVOICE_SETTINGS.append(_state_cls)
-    _params_cls = _logivoice_make_parameters_class(_feature)
-    if _params_cls is not None:
-        _LOGIVOICE_SETTINGS.append(_params_cls)
+    # Parameters panels are read-only and the wire encoding is only
+    # partially decoded — hide from the UI until we can write them back.
+    # _params_cls = _logivoice_make_parameters_class(_feature)
+    # if _params_cls is not None:
+    #     _LOGIVOICE_SETTINGS.append(_params_cls)
 
 
 class BrightnessControl(settings.Setting):

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1708,9 +1708,34 @@ class HeadsetSidetone(settings.Setting):
     description = _("Sidetone level (0 = off, 100 = max).")
     feature = _F.HEADSET_AUDIO_SIDETONE
     rw_options = {"read_fnid": 0x00, "write_fnid": 0x10}
-    validator_class = settings_validator.RangeValidator
     min_value = 0
     max_value = 100
+
+    class validator_class(settings_validator.RangeValidator):
+        """UI value is 0-100 percent; the wire level is a gain-step index
+        0..N-1. N (gain_steps) comes from getSidetoneLevelSettings on V2
+        devices, or defaults to 101 on V1 — which makes step == percent, so
+        V1 round-trips unchanged. The firmware silently ignores out-of-range
+        step writes, so writes are clamped to N-1."""
+
+        gain_steps = 101
+
+        def _level_bytes(self, raw):
+            return common.bytes2int(raw[self.read_skip_byte_count : self.read_skip_byte_count + self._byte_count])
+
+        def validate_read(self, reply_bytes):
+            level = self._level_bytes(reply_bytes)
+            steps = self.gain_steps
+            return int(round(level * 100 / (steps - 1))) if steps > 1 else level
+
+        def prepare_write(self, new_value, current_value=None):
+            steps = self.gain_steps
+            level = int(round((steps - 1) * new_value / 100)) if steps > 1 else new_value
+            level = max(0, min((steps - 1) if steps > 1 else self.max_value, level))
+            to_write = self.write_prefix_bytes + common.int2bytes(level, self._byte_count)
+            if current_value is not None and self._level_bytes(current_value) == level:
+                return None
+            return to_write
 
     @classmethod
     def build(cls, device):
@@ -1721,18 +1746,23 @@ class HeadsetSidetone(settings.Setting):
             skip, prefix = 3, b"\x01\xff"
         else:
             skip, prefix = 2, b"\x01"
-        # getSidetoneLevelSettings (fn 2) carries the gain-step count that scales
-        # wire level <-> UI percent; its byte layout is unmapped. Log the raw
-        # reply under -dd so a user log pins it down.
-        if logger.isEnabledFor(logging.DEBUG):
+        # V2 getSidetoneLevelSettings (fn 2) reply byte 2 is the gain-step count N.
+        # V1 has no such call — N stays 101 (step == percent). Raw reply still
+        # logged at debug so a G HUB setpoint correlation can refine the layout.
+        gain_steps = 101
+        if version > 1:
             try:
                 reply = device.feature_request(cls.feature, 0x20)
-                logger.debug("%s: getSidetoneLevelSettings raw reply: %s", cls.name, reply.hex() if reply else reply)
             except Exception as e:
+                reply = None
                 logger.debug("%s: getSidetoneLevelSettings probe raised %s", cls.name, e)
+            logger.debug("%s: getSidetoneLevelSettings raw reply: %s", cls.name, reply.hex() if reply else reply)
+            if reply is not None and len(reply) >= 3 and reply[2] > 1:
+                gain_steps = reply[2]
         rw = settings.FeatureRW(cls.feature, **cls.rw_options)
         validator = cls.validator_class.build(cls, device, read_skip_byte_count=skip, write_prefix_bytes=prefix)
         if validator:
+            validator.gain_steps = gain_steps
             return cls(device, rw, validator)
 
 

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -2662,21 +2662,33 @@ class _HeadsetSignatureEffectSetting(settings.Setting):
 class HeadsetSignatureStartupEffect(_HeadsetSignatureEffectSetting):
     name = "headset-signature-startup"
     label = _("Startup Effect")
-    description = _("Firmware lighting effect played when the headset powers on or wakes.")
+    description = (
+        _("Firmware lighting effect played when the headset powers on or wakes.")
+        + "\n"
+        + _("Device default: Primary #00B8FC, Secondary #FF00AB, Speed 100.")
+    )
     effect_id = 0
 
 
 class HeadsetSignatureShutdownEffect(_HeadsetSignatureEffectSetting):
     name = "headset-signature-shutdown"
     label = _("Shutdown Effect")
-    description = _("Firmware lighting effect played when the headset powers off or sleeps.")
+    description = (
+        _("Firmware lighting effect played when the headset powers off or sleeps.")
+        + "\n"
+        + _("Device default: Primary #00B8FC, Secondary #FF00AB, Speed 100.")
+    )
     effect_id = 1
 
 
 class HeadsetSignaturePassiveEffect(_HeadsetSignatureEffectSetting):
     name = "headset-signature-passive"
     label = _("Passive Effect")
-    description = _("Firmware lighting effect played while the headset is idle.")
+    description = (
+        _("Firmware lighting effect played while the headset is idle.")
+        + "\n"
+        + _("Device default: Primary #00B8FC, Secondary #FF00AB, Speed 75.")
+    )
     effect_id = 2
 
 
@@ -3666,9 +3678,13 @@ class _RgbBootEffectSetting(settings.Setting):
 class RgbStartupAnimation(_RgbBootEffectSetting):
     name = "rgb_startup_animation"
     label = _("Startup Animation")
-    description = _(
-        "Firmware-played animation when the keyboard wakes from deep sleep or powers on.\n"
-        "Setting persists on the device (non-volatile)."
+    description = (
+        _(
+            "Firmware-played animation when the keyboard wakes from deep sleep or powers on.\n"
+            "Setting persists on the device (non-volatile)."
+        )
+        + "\n"
+        + _("Device default: Primary #FF0081, Secondary #80AAFF.")
     )
     cap_id = 0x0001
 
@@ -3676,8 +3692,10 @@ class RgbStartupAnimation(_RgbBootEffectSetting):
 class RgbShutdownAnimation(_RgbBootEffectSetting):
     name = "rgb_shutdown_animation"
     label = _("Shutdown Animation")
-    description = _(
-        "Firmware-played animation when the keyboard powers off.\n" "Setting persists on the device (non-volatile)."
+    description = (
+        _("Firmware-played animation when the keyboard powers off.\n" "Setting persists on the device (non-volatile).")
+        + "\n"
+        + _("Device default: Primary #FF0081, Secondary #80AAFF.")
     )
     cap_id = 0x0040
 

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -2378,6 +2378,26 @@ def _headset_per_zone_overrides(device):
     return overrides
 
 
+def _headset_reassert_zone_layer(device):
+    """Re-paint the per-zone layer: every zone to the LEDs Primary color,
+    then the explicit per-zone overrides on top.
+
+    The headset firmware drops the host-painted per-zone buffer whenever a
+    cluster layer is (re)written — so any path that re-asserts a cluster
+    layer (LED Control re-claim, onboard Static color change) must call this
+    to restore the per-zone paint. No-op unless the onboard effect is Fixed;
+    a non-Static animation owns the LEDs and masks per-zone anyway.
+    """
+    if not _headset_cluster_effect_is_fixed(device):
+        return
+    zones = headset_rgb.discover_zones(device)
+    if not zones:
+        return
+    zone_map = {int(z): _headset_primary_color(device) for z in zones}
+    zone_map.update(_headset_per_zone_overrides(device) or {})
+    headset_rgb.write_zone_map(device, zone_map)
+
+
 def _headset_led_control_on(device):
     """True when the headset LED Control is on (Solaar drives the LEDs).
     When off, the firmware owns the LEDs and host color writes are
@@ -2438,12 +2458,7 @@ class HeadsetLEDControl(settings.Setting):
         result = super().write(value, save)
         if result is not None and value and self._device.online:
             if _headset_cluster_effect_is_fixed(self._device):
-                primary = _headset_primary_color(self._device)
-                zones = headset_rgb.discover_zones(self._device)
-                if zones:
-                    zone_map = {int(z): primary for z in zones}
-                    zone_map.update(_headset_per_zone_overrides(self._device) or {})
-                    headset_rgb.write_zone_map(self._device, zone_map)
+                _headset_reassert_zone_layer(self._device)
             else:
                 onboard = next((s for s in self._device.settings if s.name == "headset-onboard-effect"), None)
                 if onboard is not None and onboard._value is not None:
@@ -2909,6 +2924,17 @@ class HeadsetOnboardEffect(settings.Setting):
         ]
         setting.fields_map = {eid: (id_choices[eid], {field: 1 for field in cls._EFFECT_FIELDS[eid]}) for eid in supported}
         return setting
+
+    def write(self, value, save=True):
+        # Writing the 0x0621 cluster effect re-fills every LED uniformly; the
+        # firmware treats that as dropping the host per-zone buffer. After a
+        # Static write, re-overlay the per-zone paint so individually-colored
+        # zones survive a LEDs Primary change. _headset_reassert_zone_layer is
+        # a no-op for non-Static effects (the animation masks per-zone).
+        result = super().write(value, save)
+        if result is not None and self._device.online and _headset_led_control_on(self._device):
+            _headset_reassert_zone_layer(self._device)
+        return result
 
 
 # ----------------------------------------------------------------------------

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -2330,13 +2330,31 @@ def _headset_setting_by_name(device, name):
 
 
 def _headset_primary_color(device, default=0xFFFFFF):
-    """Resolve the currently-saved Primary color, or `default` if absent."""
-    s = _headset_setting_by_name(device, HeadsetLEDsPrimary.name)
+    """The headset's base color — the 0x0621 onboard Fixed-effect color.
+    Per-zone 'No change' cells resolve against this. Returns `default` when
+    the onboard-effect setting is absent or not currently on Fixed."""
+    s = _headset_setting_by_name(device, HeadsetOnboardEffect.name)
+    value = getattr(s, "_value", None) if s is not None else None
+    if value is not None and int(getattr(value, "ID", -1)) == 0:
+        return int(getattr(value, "color1", default))
+    return default
+
+
+def _headset_cluster_effect_is_fixed(device):
+    """True when the 0x0621 onboard effect is Fixed (the Static analog), or
+    when the device has no onboard-effect setting. A non-Fixed cluster
+    animation masks the per-zone buffer, so per-zone writes are suppressed
+    while one runs."""
+    s = _headset_setting_by_name(device, HeadsetOnboardEffect.name)
     if s is None:
-        return default
+        return True
     value = getattr(s, "_value", None)
-    color = getattr(value, "color", None) if value is not None else None
-    return int(color) if color is not None else default
+    if value is None:
+        persister = getattr(device, "persister", None)
+        value = persister.get(HeadsetOnboardEffect.name) if persister else None
+    if value is None:
+        return True
+    return int(getattr(value, "ID", 0)) == 0
 
 
 def _headset_per_zone_overrides(device):
@@ -2360,35 +2378,48 @@ def _headset_per_zone_overrides(device):
     return overrides
 
 
-class _HeadsetStaticEffectOption:
-    """Minimal stand-in for `hidpp20.LEDEffectInfo`.
-
-    `HeteroValidator` only inspects `.ID` and `.index` on its `options`
-    list; we don't need the full device-query machinery here because the
-    headset wire protocol is handled by `headset_rgb.write_zone_map`.
-    """
-
-    ID = 0x01  # matches hidpp20.LEDEffects[0x01] = Static
-    index = 0x01
+def _headset_led_control_on(device):
+    """True when the headset LED Control is on (Solaar drives the LEDs).
+    When off, the firmware owns the LEDs and host color writes are
+    suppressed — the value is still persisted so it re-applies on switch-on.
+    Reads setting._value first, then the persister; accepts a bool or a
+    legacy int 0/1 from the old ChoicesValidator era."""
+    s = _headset_setting_by_name(device, HeadsetLEDControl.name)
+    v = getattr(s, "_value", None) if s is not None else None
+    if v is None:
+        persister = getattr(device, "persister", None)
+        v = persister.get(HeadsetLEDControl.name) if persister else None
+    if v is None:
+        return True  # unknown — don't suppress
+    return bool(v)
 
 
 class HeadsetLEDControl(settings.Setting):
-    """Switch headset LED control between device and Solaar.
+    """Whether Solaar holds the headset's live-coloring claim.
 
-    Mirrors the `LEDControl` / `RGBControl` pattern used for keyboards and
-    mice. When set to Solaar, the `LEDs Primary` and `Per-zone Lighting`
-    settings drive the LEDs; when set to Device, firmware-driven onboard
-    and signature effects resume.
+    Mirrors the `RGBControl` pattern for keyboards and mice. On = Solaar
+    may drive the LEDs — the 0x0621 onboard effect and 0x0620 per-zone
+    painting are both live LED control; off = Solaar releases the LEDs so
+    another app (e.g. OpenRGB) can drive them. The 0x0622 signature
+    effects are stored settings (startup/shutdown colors), not live
+    coloring, and stay editable either way.
     """
 
     name = "headset_led_control"
     label = _("LED Control")
-    description = _("Switch control of LED zones between device and Solaar")
+    description = _("Allow Solaar to control the headset LED zones.")
     feature = _F.HEADSET_RGB_HOSTMODE
     rw_options = {"read_fnid": 0x70, "write_fnid": 0x80}
-    choices_universe = common.NamedInts(Device=0, Solaar=1)
-    validator_class = settings_validator.ChoicesValidator
-    validator_options = {"choices": choices_universe}
+    # Two-state — render as a Gtk.Switch. Wire byte: 1 = Solaar (host) control,
+    # 0 = Device (firmware) control.
+    validator_class = settings_validator.BooleanValidator
+    validator_options = {"true_value": 1, "false_value": 0}
+
+    def _pre_read(self, cached, key=None):
+        # Migrate legacy int values (0/1 from the old ChoicesValidator) to bool.
+        super()._pre_read(cached, key)
+        if isinstance(self._value, int) and not isinstance(self._value, bool):
+            self._value = self._value != 0
 
     @classmethod
     def build(cls, device):
@@ -2402,103 +2433,22 @@ class HeadsetLEDControl(settings.Setting):
         return super().build(device)
 
     def write(self, value, save=True):
-        # After switching to Solaar control, the firmware drops whatever
-        # colors we'd programmed — so reassert the saved Primary + per-zone
-        # overrides immediately. Otherwise the LEDs stay on whatever
-        # device-driven effect was last shown until the user edits a color.
+        # On re-claim the firmware drops our colors; reassert the dominant
+        # layer — per-zone when the onboard effect is Static, else the effect.
         result = super().write(value, save)
-        if result is not None and int(value) == 1 and self._device.online:
-            primary = _headset_primary_color(self._device)
-            zones = headset_rgb.discover_zones(self._device)
-            if zones:
-                zone_map = {int(z): primary for z in zones}
-                zone_map.update(_headset_per_zone_overrides(self._device) or {})
-                headset_rgb.write_zone_map(self._device, zone_map)
+        if result is not None and value and self._device.online:
+            if _headset_cluster_effect_is_fixed(self._device):
+                primary = _headset_primary_color(self._device)
+                zones = headset_rgb.discover_zones(self._device)
+                if zones:
+                    zone_map = {int(z): primary for z in zones}
+                    zone_map.update(_headset_per_zone_overrides(self._device) or {})
+                    headset_rgb.write_zone_map(self._device, zone_map)
+            else:
+                onboard = next((s for s in self._device.settings if s.name == "headset-onboard-effect"), None)
+                if onboard is not None and onboard._value is not None:
+                    onboard.write(onboard._value, save=False)
         return result
-
-
-class HeadsetLEDsPrimary(settings.Setting):
-    """Primary headset LED color, rendered as a GTK color picker.
-
-    Mirrors the `LEDZoneSetting` / `RGBEffectSetting` shape: a
-    `HeteroValidator` with a single "Static" effect whose only visible
-    field is the color. Write applies the chosen color across all zones
-    discovered at build time, then re-applies any per-zone overrides on
-    top so they aren't clobbered.
-
-    Read support is deliberately disabled — the feature exposes no "get
-    current color" function, so we rely on the persister.
-    """
-
-    name = "headset_leds_primary"
-    label = _("LEDs") + " " + _("Primary")
-    description = _(
-        "Set the primary color applied to every headset LED zone.\n" "LED Control needs to be set to Solaar to be effective."
-    )
-    feature = _F.HEADSET_RGB_HOSTMODE
-    persist = True
-    rw_options = {"read_fnid": None, "write_fnid": None}
-
-    # HeteroKeyControl renders exactly these fields; ID is hidden
-    # (`label=None`) but kept so setup_visibles can key off it.
-    color_field = {"name": hidpp20.LEDParam.color, "kind": settings.Kind.COLOR, "label": _("Color")}
-    possible_fields = [
-        {
-            "name": "ID",
-            "kind": settings.Kind.CHOICE,
-            "label": None,
-            "choices": [common.NamedInt(0x01, _("Static"))],
-        },
-        color_field,
-    ]
-    # HeteroKeyControl.setup_visibles looks up fields_map[effect_id][1] to
-    # decide which fields to show — we only expose the color.
-    fields_map = {0x01: [common.NamedInt(0x01, _("Static")), {hidpp20.LEDParam.color: 0}]}
-
-    @classmethod
-    def build(cls, device):
-        zones = headset_rgb.discover_zones(device)
-        if not zones:
-            return None
-        rw = settings.FeatureRW(cls.feature)
-        validator = settings_validator.HeteroValidator(
-            data_class=hidpp20.LEDEffectSetting,
-            options=[_HeadsetStaticEffectOption()],
-            readable=False,
-        )
-        return cls(device, rw, validator)
-
-    def read(self, cached=True):
-        # Feature 0x0620 doesn't expose a "current primary color" read —
-        # pull from the persister via _pre_read, fall back to white so
-        # the picker opens on a sane starting color.
-        self._pre_read(cached)
-        if self._value is not None:
-            return self._value
-        self._value = hidpp20.LEDEffectSetting(ID=common.NamedInt(0x01, _("Static")), color=0xFFFFFF)
-        return self._value
-
-    def write(self, value, save=True):
-        color = getattr(value, "color", None)
-        if color is None:
-            return None
-        device = self._device
-        if not device.online:
-            return None
-        zones = headset_rgb.discover_zones(device)
-        if not zones:
-            return None
-        primary = int(color)
-        zone_map = {int(z): primary for z in zones}
-        # Re-apply any non-"No change" per-zone overrides on top of the
-        # fresh Primary baseline so the user's explicit zone choices stick
-        # when they change the bulk color.
-        overrides = _headset_per_zone_overrides(device) or {}
-        zone_map.update(overrides)
-        if headset_rgb.write_zone_map(device, zone_map):
-            self.update(value, save)
-            return value
-        return None
 
 
 class HeadsetPerZoneLighting(settings.Settings):
@@ -2559,19 +2509,24 @@ class HeadsetPerZoneLighting(settings.Settings):
         if not device.online:
             return None
         self.update(map_, save)
+        # Gate the wire on both conditions, like keyboard per-key (needs
+        # rgb_control on + zone Static): LED Control on, cluster effect Fixed.
+        if not _headset_led_control_on(device) or not _headset_cluster_effect_is_fixed(device):
+            return map_  # value stored, skip the wire
         primary = _headset_primary_color(device)
         zone_map = self._resolve_zone_map(map_, primary)
         if not zone_map:
-            return None
-        if headset_rgb.write_zone_map(device, zone_map):
             return map_
-        return None
+        headset_rgb.write_zone_map(device, zone_map)
+        return map_
 
     def write_key_value(self, key, value, save=True):
         result = super().write_key_value(int(key), value, save)
         device = self._device
         if not device.online:
             return result
+        if not _headset_led_control_on(device) or not _headset_cluster_effect_is_fixed(device):
+            return result  # value stored, skip the wire
         try:
             v = int(value)
         except (TypeError, ValueError):
@@ -2808,11 +2763,12 @@ yaml.add_representer(_HeadsetOnboardEffect, _HeadsetOnboardEffect.to_yaml)
 
 
 class HeadsetOnboardEffect(settings.Setting):
-    """The firmware RGB effect a headset runs autonomously on its primary
-    lighting cluster (HEADSET_RGB_ONBOARD_EFFECTS, 0x0621). Build reads the
-    cluster's supported-effect set so the picker offers only those. Like the
-    signature/boot effects this is firmware-driven and not gated on host LED
-    control. Multi-cluster devices (none seen yet) drive only cluster 0."""
+    """The RGB effect the headset shows on its primary lighting cluster
+    (HEADSET_RGB_ONBOARD_EFFECTS, 0x0621). Build reads the cluster's
+    supported-effect set so the picker offers only those. This is live LED
+    control, like per-zone painting — gated on Solaar holding the LED-control
+    claim: writes are skipped and the row greys out when the claim is
+    released. Multi-cluster devices (none seen yet) drive only cluster 0."""
 
     name = "headset-onboard-effect"
     label = _("Onboard Effect")
@@ -2821,7 +2777,7 @@ class HeadsetOnboardEffect(settings.Setting):
 
     _CLUSTER = 0
     _ALL_EFFECTS = (
-        ("Fixed", 0),
+        ("Static", 0),
         ("Color Cycle", 1),
         ("Color Wave", 2),
         ("Breathing", 3),
@@ -2852,7 +2808,11 @@ class HeadsetOnboardEffect(settings.Setting):
             return reply[1:10]  # strip clusterIndex -> [effectId_u16, 7 param bytes]
 
         def write(self, device, data_bytes):
-            # data_bytes is [effectId_u16, 7 param bytes]; prepend clusterIndex
+            # data_bytes is [effectId_u16, 7 param bytes]; prepend clusterIndex.
+            # The onboard effect is live LED control — skip the wire when Solaar
+            # doesn't hold the claim; the value is still persisted.
+            if not _headset_led_control_on(device):
+                return data_bytes
             reply = device.feature_request(self.feature, 0x30, bytes([self._cluster]) + bytes(data_bytes))
             return data_bytes if reply is not None else None
 
@@ -4463,12 +4423,11 @@ SETTINGS: list[settings.Setting] = [
     HeadsetActiveEQPreset,
     HeadsetAdvancedEQ,
     HeadsetLEDControl,
-    HeadsetLEDsPrimary,
+    HeadsetOnboardEffect,
     HeadsetPerZoneLighting,
     HeadsetSignatureStartupEffect,
     HeadsetSignatureShutdownEffect,
     HeadsetSignaturePassiveEffect,
-    HeadsetOnboardEffect,
     *_LOGIVOICE_SETTINGS,
 ]
 

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -2142,6 +2142,79 @@ class HeadsetAdvancedEQ(settings.RangeFieldSetting):
                     return None
             return map
 
+    def _is_valid_persisted_value(self, value):
+        """True iff `value` is a well-formed band-gain dict for the current
+        validator: a dict with exactly `count` int keys covering [0, count),
+        each mapped to an int within [min_value, max_value]. Used to detect
+        stale persister entries from older Solaar builds whose V2 parser had
+        a different stride/header (commits prior to 7c73c888) and produced
+        partial dicts or out-of-range gain values."""
+        validator = getattr(self, "_validator", None)
+        if not isinstance(value, dict) or validator is None:
+            return False
+        count = getattr(validator, "count", 0)
+        if count == 0 or len(value) != count:
+            return False
+        mn = getattr(validator, "min_value", None)
+        mx = getattr(validator, "max_value", None)
+        if mn is None or mx is None:
+            return False
+        for i in range(count):
+            if i not in value:
+                return False
+            v = value[i]
+            if not isinstance(v, int) or v < mn or v > mx:
+                return False
+        return True
+
+    def apply(self):
+        """Validate the persisted EQ against the live device state before
+        pushing. Setting.apply uses cached=True so the persister is treated
+        as authoritative — that's wrong here because (a) the EQ can be
+        changed externally (LGHUB, onboard preset buttons) and (b) older
+        Solaar V2 parsers stored partial/out-of-range dicts that
+        prepare_write silently fills with 0 dB, overwriting user EQ with
+        zeros. Strategy: if the persisted value is well-formed, apply it
+        normally (matches existing Solaar semantics). If it's corrupt,
+        treat the device's live read as truth and reseed the persister
+        from it without writing back. If both are invalid, skip this
+        setting only — apply_all_settings keeps going."""
+        assert hasattr(self, "_value")
+        assert hasattr(self, "_device")
+        if not self._device.online:
+            return
+        persister = getattr(self._device, "persister", None)
+        persisted = persister.get(self.name) if persister else None
+        persisted_valid = self._is_valid_persisted_value(persisted)
+        try:
+            live = self.read(cached=False)
+        except Exception as e:
+            logger.warning("%s: live EQ read failed during apply (%s): %s", self.name, self._device, repr(e))
+            live = None
+        live_valid = self._is_valid_persisted_value(live)
+        if persisted_valid:
+            try:
+                self.write(persisted, save=False)
+            except Exception as e:
+                logger.warning("%s: error applying %s (%s): %s", self.name, persisted, self._device, repr(e))
+        elif live_valid:
+            logger.info(
+                "%s: rejecting stale persister value %r; reseeding from device live %r",
+                self.name,
+                persisted,
+                live,
+            )
+            self._value = live
+            if persister is not None:
+                persister[self.name] = live
+        else:
+            logger.warning(
+                "%s: both persisted (%r) and live (%r) values invalid; skipping apply",
+                self.name,
+                persisted,
+                live,
+            )
+
 
 class HeadsetActiveEQPreset(settings.Setting):
     """Choose which AdvancedParaEQ slot drives live audio.

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -2581,6 +2581,150 @@ class HeadsetPerZoneLighting(settings.Settings):
         return result
 
 
+class _HeadsetSignatureEffect:
+    """A 0x0622 signature-effect slot value: an enable byte, two colors and a
+    speed. Synthetic 8-byte form [ID, R1,G1,B1, R2,G2,B2, speed] — ID is 0x01
+    on / 0x02 off. The rw_class splits it across get/setSignatureEffectParams
+    (colors + speed) and get/setSignatureEffectState (the enable byte)."""
+
+    def __init__(self, ID=1, color1=0, color2=0, speed=0):
+        self.ID = int(ID)
+        self.speed = max(0, min(100, int(speed)))
+        for k, v in (("color1", color1), ("color2", color2)):
+            setattr(self, k, common.ColorInt(int(v) & 0xFFFFFF))
+
+    @classmethod
+    def from_bytes(cls, data, options=None):
+        if data is None or len(data) < 8:
+            return cls()
+        c1 = (data[1] << 16) | (data[2] << 8) | data[3]
+        c2 = (data[4] << 16) | (data[5] << 8) | data[6]
+        return cls(ID=data[0], color1=c1, color2=c2, speed=data[7])
+
+    def to_bytes(self, options=None):
+        return bytes(
+            [
+                self.ID & 0xFF,
+                (self.color1 >> 16) & 0xFF,
+                (self.color1 >> 8) & 0xFF,
+                self.color1 & 0xFF,
+                (self.color2 >> 16) & 0xFF,
+                (self.color2 >> 8) & 0xFF,
+                self.color2 & 0xFF,
+                self.speed & 0xFF,
+            ]
+        )
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.to_bytes() == other.to_bytes()
+
+    def __str__(self):
+        return yaml.dump(self, width=float("inf")).rstrip("\n")
+
+    @classmethod
+    def from_yaml(cls, loader, node):
+        return cls(**loader.construct_mapping(node))
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return dumper.represent_mapping("!HeadsetSignatureEffect", data.__dict__, flow_style=True)
+
+
+yaml.SafeLoader.add_constructor("!HeadsetSignatureEffect", _HeadsetSignatureEffect.from_yaml)
+yaml.add_representer(_HeadsetSignatureEffect, _HeadsetSignatureEffect.to_yaml)
+
+
+class _HeadsetSignatureEffectSetting(settings.Setting):
+    """One firmware signature-effect slot on HEADSET_RGB_SIGNATURE_EFFECTS
+    (0x0622). Subclasses set effect_id (0 startup, 1 shutdown, 2 passive).
+    Build probes the slot via getSignatureEffectState and suppresses the
+    setting if the device doesn't expose it. These run autonomously on the
+    device firmware, so — like the keyboard boot animations — they are not
+    gated on host LED control."""
+
+    feature = _F.HEADSET_RGB_SIGNATURE_EFFECTS
+    effect_id: int = 0
+
+    _ENABLED_CHOICES = common.NamedInts(**{"On": 1, "Off": 2})
+    _COLOR1_FIELD = {"name": "color1", "kind": settings.Kind.COLOR, "label": _("Primary")}
+    _COLOR2_FIELD = {"name": "color2", "kind": settings.Kind.COLOR, "label": _("Secondary")}
+    _SPEED_FIELD = {"name": "speed", "kind": settings.Kind.RANGE, "label": _("Speed"), "min": 0, "max": 100}
+
+    class rw_class:
+        kind = settings.FeatureRW.kind
+
+        def __init__(self, feature, effect_id):
+            self.feature = feature
+            self._eid = bytes([(effect_id >> 8) & 0xFF, effect_id & 0xFF])
+
+        def read(self, device):
+            params = device.feature_request(self.feature, 0x10, self._eid)  # getSignatureEffectParams
+            state = device.feature_request(self.feature, 0x30, self._eid)  # getSignatureEffectState
+            if params is None or len(params) < 9 or state is None or len(state) < 3:
+                return None
+            # params: [effectId, R1,G1,B1, R2,G2,B2, speed]; state: [effectId, enabled]
+            return bytes([state[2]]) + params[2:9]
+
+        def write(self, device, data_bytes):
+            # data_bytes: [enabled, R1,G1,B1, R2,G2,B2, speed]
+            params = device.feature_request(self.feature, 0x20, self._eid + data_bytes[1:8])
+            state = device.feature_request(self.feature, 0x40, self._eid + data_bytes[0:1])
+            return data_bytes if params is not None and state is not None else None
+
+    @classmethod
+    def build(cls, device):
+        eid = bytes([(cls.effect_id >> 8) & 0xFF, cls.effect_id & 0xFF])
+        try:
+            state = device.feature_request(cls.feature, 0x30, eid)  # probe: is this slot present?
+        except exceptions.FeatureCallError:
+            return None
+        if state is None or len(state) < 3:
+            return None
+        # Log getSignatureEffectsInfo (fn 0) once per device — its byte layout
+        # isn't pinned down, so slot discovery uses per-slot probing for now.
+        if not getattr(device, "_headset_sig_info_logged", False):
+            device._headset_sig_info_logged = True
+            try:
+                info = device.feature_request(cls.feature, 0x00)
+                logger.debug("%s: getSignatureEffectsInfo raw reply: %s", cls.name, info.hex() if info else info)
+            except Exception as e:
+                logger.debug("%s: getSignatureEffectsInfo probe raised %s", cls.name, e)
+        rw = cls.rw_class(cls.feature, cls.effect_id)
+        validator = settings_validator.HeteroValidator(data_class=_HeadsetSignatureEffect, options=None)
+        setting = cls(device, rw, validator)
+        # Enable byte as a right-aligned Gtk.Switch (on=1 / off=2); colors and
+        # speed stay visible in both states so toggling Off keeps them.
+        id_field = {"name": "ID", "kind": settings.Kind.TOGGLE, "label": None, "on_value": 1, "off_value": 2}
+        setting.possible_fields = [id_field, cls._COLOR1_FIELD, cls._COLOR2_FIELD, cls._SPEED_FIELD]
+        visible = {"color1": 1, "color2": 1, "speed": 1}
+        setting.fields_map = {
+            int(cls._ENABLED_CHOICES["On"]): (cls._ENABLED_CHOICES["On"], visible),
+            int(cls._ENABLED_CHOICES["Off"]): (cls._ENABLED_CHOICES["Off"], visible),
+        }
+        return setting
+
+
+class HeadsetSignatureStartupEffect(_HeadsetSignatureEffectSetting):
+    name = "headset-signature-startup"
+    label = _("Startup Effect")
+    description = _("Firmware lighting effect played when the headset powers on or wakes.")
+    effect_id = 0
+
+
+class HeadsetSignatureShutdownEffect(_HeadsetSignatureEffectSetting):
+    name = "headset-signature-shutdown"
+    label = _("Shutdown Effect")
+    description = _("Firmware lighting effect played when the headset powers off or sleeps.")
+    effect_id = 1
+
+
+class HeadsetSignaturePassiveEffect(_HeadsetSignatureEffectSetting):
+    name = "headset-signature-passive"
+    label = _("Passive Effect")
+    description = _("Firmware lighting effect played while the headset is idle.")
+    effect_id = 2
+
+
 # ----------------------------------------------------------------------------
 # LogiVoice (0x0900 + 0x0901..0x0907) — read-only presentation pass.
 #
@@ -4150,6 +4294,9 @@ SETTINGS: list[settings.Setting] = [
     HeadsetLEDControl,
     HeadsetLEDsPrimary,
     HeadsetPerZoneLighting,
+    HeadsetSignatureStartupEffect,
+    HeadsetSignatureShutdownEffect,
+    HeadsetSignaturePassiveEffect,
     *_LOGIVOICE_SETTINGS,
 ]
 

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1721,6 +1721,15 @@ class HeadsetSidetone(settings.Setting):
             skip, prefix = 3, b"\x01\xff"
         else:
             skip, prefix = 2, b"\x01"
+        # getSidetoneLevelSettings (fn 2) carries the gain-step count that scales
+        # wire level <-> UI percent; its byte layout is unmapped. Log the raw
+        # reply under -dd so a user log pins it down.
+        if logger.isEnabledFor(logging.DEBUG):
+            try:
+                reply = device.feature_request(cls.feature, 0x20)
+                logger.debug("%s: getSidetoneLevelSettings raw reply: %s", cls.name, reply.hex() if reply else reply)
+            except Exception as e:
+                logger.debug("%s: getSidetoneLevelSettings probe raised %s", cls.name, e)
         rw = settings.FeatureRW(cls.feature, **cls.rw_options)
         validator = cls.validator_class.build(cls, device, read_skip_byte_count=skip, write_prefix_bytes=prefix)
         if validator:

--- a/lib/solaar/listener.py
+++ b/lib/solaar/listener.py
@@ -152,6 +152,12 @@ class SolaarListener(listener.EventsListener):
             from logitech_receiver.device import CenturionReceiver
 
             if isinstance(self.receiver, CenturionReceiver):
+                if self.receiver._pending:
+                    ihandle = int(self.receiver.handle)
+                    state = base._centurion_handles.get(ihandle)
+                    if state and state.device_addr is not None:
+                        self.receiver._complete_deferred_init()
+                        self._status_changed(self.receiver)
                 self._handle_centurion_notification(n)
                 return
             # a receiver notification

--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -816,6 +816,13 @@ _icons_allowables = {v: k for k, v in _allowables_icons.items()}
 # the zone index (rgb_zone_1, rgb_zone_2, ...).
 _SW_CONTROL_DEPENDENT_NAMES = ("rgb_idle_timeout", "rgb_idle_effect", "rgb_sleep_timeout")
 _SW_CONTROL_DEPENDENT_PREFIXES = ("rgb_zone_",)
+# headset_led_control = whether Solaar holds the live-coloring claim (off lets
+# another app drive the LEDs). The 0x0620 per-zone painting and the 0x0621
+# onboard effect are both live LED control, so both need the claim; per-zone
+# additionally needs the onboard effect on Static (the per-key analog of
+# needs-rgb_control + zone-Static). The 0x0622 signature effects are stored
+# settings (startup/shutdown colors) and stay ungated.
+_HEADSET_LED_DEPENDENT_NAMES = ("headset_per_zone_lighting", "headset-onboard-effect")
 
 
 def _sw_control_blocked(device):
@@ -837,6 +844,43 @@ def _sw_control_blocked(device):
         return False
     # Solaar = bool True or legacy int 3; everything else (False, 0, …) blocks.
     return value not in (True, 3)
+
+
+def _headset_led_blocked(device):
+    """True when the headset's LED Control is off (Device/firmware mode).
+    Reads setting._value first, then the persister; accepts the current bool
+    or a legacy int 0/1 from the old ChoicesValidator persister entries."""
+    persister = getattr(device, "persister", None)
+    if persister is None:
+        return False
+    value = None
+    for s in getattr(device, "settings", []) or []:
+        if s.name == "headset_led_control":
+            value = s._value
+            break
+    if value is None:
+        value = persister.get("headset_led_control")
+    if value is None:
+        return False
+    return value not in (True, 1)
+
+
+def _cluster_effect_blocks_perzone(device):
+    """True when the headset's 0x0621 onboard effect is not Fixed — a
+    non-Fixed cluster animation masks the per-zone buffer. Mirrors
+    `_zone_effect_blocks_perkey`. False when the device has no
+    onboard-effect setting (nothing to mask against)."""
+    persister = getattr(device, "persister", None)
+    value = None
+    for s in getattr(device, "settings", []) or []:
+        if s.name == "headset-onboard-effect":
+            value = s._value if s._value is not None else (persister.get(s.name) if persister else None)
+            break
+    else:
+        return False
+    if value is None:
+        return False
+    return int(getattr(value, "ID", 0)) != 0
 
 
 def _zone_effect_blocks_perkey(device):
@@ -877,6 +921,11 @@ def _gate_blocks(device, name):
         return _sw_control_blocked(device)
     if name == "per-key-lighting":
         return _sw_control_blocked(device) or _zone_effect_blocks_perkey(device)
+    if name in _HEADSET_LED_DEPENDENT_NAMES:
+        if _headset_led_blocked(device):
+            return True
+        # Per-zone painting additionally needs the onboard effect on Static.
+        return name == "headset_per_zone_lighting" and _cluster_effect_blocks_perzone(device)
     return False
 
 
@@ -895,6 +944,7 @@ def _apply_rgb_gates(device):
             name in _SW_CONTROL_DEPENDENT_NAMES
             or any(name.startswith(p) for p in _SW_CONTROL_DEPENDENT_PREFIXES)
             or name == "per-key-lighting"
+            or name in _HEADSET_LED_DEPENDENT_NAMES
         ):
             _set_row_sensitive(device, name, not _gate_blocks(device, name))
 
@@ -940,10 +990,12 @@ def _change_click(button, sbox):
         perkey, has_paint = rgb_power.perkey_has_paint(device)
         if has_paint:
             _write_async(perkey, perkey._value, None)
-    # The lock icon on rgb_control, any zone, or per-key itself can change
-    # whether per-key is functional — re-evaluate the gate.
+    # The lock icon on rgb_control, any zone, per-key, or headset_led_control
+    # can change whether a dependent row is functional — re-evaluate the gate.
     name = sbox.setting.name
-    if name == "rgb_control" or name == "per-key-lighting" or name.startswith("rgb_zone_"):
+    if name in ("rgb_control", "per-key-lighting", "headset_led_control", "headset-onboard-effect") or name.startswith(
+        "rgb_zone_"
+    ):
         _apply_rgb_gates(sbox.setting._device)
     return True
 
@@ -1047,8 +1099,9 @@ def _update_setting_item(sbox, value, is_online=True, sensitive=True, null_okay=
         logger.warning("%s: error setting control value (%s): %s", sbox.setting.name, sbox.setting._device, repr(e))
     sbox._control.set_sensitive(sensitive is True and can_function)
     _change_icon(sensitive, sbox._change_icon)
-    # rgb_control and rgb_zone_* state gate per-key sensitivity.
-    if name == "rgb_control" or name.startswith("rgb_zone_"):
+    # rgb_control / rgb_zone_* gate per-key; headset_led_control and the
+    # headset-onboard-effect gate the per-zone row — re-evaluate on a change.
+    if name in ("rgb_control", "headset_led_control", "headset-onboard-effect") or name.startswith("rgb_zone_"):
         _apply_rgb_gates(sbox.setting._device)
 
 

--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -611,9 +611,10 @@ class GraphicEQControl(MultipleControl):
         for vbox in self._items:
             item = vbox._setting_item
             v = value.get(int(item))
-            if v is None:
+            if v is not None:
+                vbox.control.set_value(v)
+            else:
                 v = stored.get(int(item), 0)
-            vbox.control.set_value(v)
             b += f"{str(item)}: ({str(v)}) "
         lbl_text = ngettext("%d value", "%d values", n) % n
         self._button.set_label(lbl_text)

--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -595,22 +595,25 @@ class GraphicEQControl(MultipleControl):
         control._timer.cancel()
         delattr(control, "_timer")
         new_state = int(control.get_value())
-        if self.sbox.setting._value[int(item)] != new_state:
-            self.sbox.setting._value[int(item)] = new_state
-            _write_async(self.sbox.setting, self.sbox.setting._value[int(item)], self.sbox, key=int(item))
+        value = self.sbox.setting._value
+        if not isinstance(value, dict):
+            return
+        if value.get(int(item)) != new_state:
+            value[int(item)] = new_state
+            _write_async(self.sbox.setting, value[int(item)], self.sbox, key=int(item))
 
     def set_value(self, value):
         if value is None:
             return
         b = ""
         n = len(self._items)
+        stored = self.sbox.setting._value if isinstance(self.sbox.setting._value, dict) else {}
         for vbox in self._items:
             item = vbox._setting_item
-            v = value.get(int(item), None)
-            if v is not None:
-                vbox.control.set_value(v)
-            else:
-                v = self.sbox.setting._value[int(item)]
+            v = value.get(int(item))
+            if v is None:
+                v = stored.get(int(item), 0)
+            vbox.control.set_value(v)
             b += f"{str(item)}: ({str(v)}) "
         lbl_text = ngettext("%d value", "%d values", n) % n
         self._button.set_label(lbl_text)

--- a/lib/solaar/ui/perkey/layouts/__init__.py
+++ b/lib/solaar/ui/perkey/layouts/__init__.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from ..layout import Layout
+from . import headset_g522
 from . import keyboard_ansi
 from . import keyboard_iso_azerty
 from . import keyboard_iso_qwerty
@@ -140,3 +141,5 @@ for _family, (_full, _tkl) in _FAMILY_LAYOUTS.items():
     register_layout(0x8081, _keyboard_matcher(_family, full_size=False), _tkl)
 
 register_layout(0x8081, _name_contains("G502 X"), mouse_g502x.LAYOUT)
+# HEADSET_RGB_HOSTMODE = 0x0620
+register_layout(0x0620, _name_contains("G522"), headset_g522.LAYOUT)

--- a/lib/solaar/ui/perkey/layouts/headset_g522.py
+++ b/lib/solaar/ui/perkey/layouts/headset_g522.py
@@ -1,0 +1,53 @@
+## Copyright (C) 2026  Solaar Contributors https://pwr-solaar.github.io/Solaar/
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License along
+## with this program; if not, write to the Free Software Foundation, Inc.,
+## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""LED layout for the G522 LIGHTSPEED headset.
+
+Eight LEDs in two 2×2 grids — one per earcup, viewed from outside:
+
+    Left earcup          Right earcup
+    ┌─────┬─────┐        ┌─────┬─────┐
+    │  8  │  7  │        │  6  │  5  │
+    ├─────┼─────┤        ├─────┼─────┤
+    │  4  │  3  │        │  2  │  1  │
+    └─────┴─────┘        └─────┴─────┘
+"""
+
+from __future__ import annotations
+
+from ..layout import Cell
+from ..layout import Layout
+
+_CELLS: tuple[Cell, ...] = (
+    # Left earcup (cols 0-1, outer view): top-left=8, top-right=7, bottom-left=4, bottom-right=3
+    Cell(zone_id=8, row=0, col=0, group="main", label="8"),
+    Cell(zone_id=7, row=0, col=1, group="main", label="7"),
+    Cell(zone_id=4, row=1, col=0, group="main", label="4"),
+    Cell(zone_id=3, row=1, col=1, group="main", label="3"),
+    # Right earcup (cols 3-4, outer view): top-left=6, top-right=5, bottom-left=2, bottom-right=1
+    Cell(zone_id=6, row=0, col=3, group="main", label="6"),
+    Cell(zone_id=5, row=0, col=4, group="main", label="5"),
+    Cell(zone_id=2, row=1, col=3, group="main", label="2"),
+    Cell(zone_id=1, row=1, col=4, group="main", label="1"),
+)
+
+
+LAYOUT: Layout = Layout(
+    cells=_CELLS,
+    rows=2,
+    cols=5,
+    description="Logitech G522 LIGHTSPEED headset (8 LEDs, 4 per earcup)",
+)

--- a/tests/logitech_receiver/test_base.py
+++ b/tests/logitech_receiver/test_base.py
@@ -326,8 +326,8 @@ class TestProbeCenturionDeviceAddr:
     def teardown_method(self):
         base._centurion_handles.pop(self.HANDLE, None)
 
-    def test_learns_addr_on_first_hit(self):
-        """Probe finds addr=0x23 on candidate #36 (0-indexed 0x23=35) and stops."""
+    def test_learns_addr_and_sweeps_all(self):
+        """Full sweep finds addr=0x23 and continues to 0xFF, logging all responders."""
         state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
         reply = bytes([0x50, 0x23, 0x03, 0x00]) + b"\x00" * 60
 
@@ -344,8 +344,8 @@ class TestProbeCenturionDeviceAddr:
             result = base.probe_centurion_device_addr(self.HANDLE, state)
         assert result is True
         assert state.device_addr == 0x23
-        # Should have stopped at candidate 0x23 (36 writes), not all 256
-        assert mock_write.call_count == 0x24
+        # Full sweep — should have written all 256 candidates
+        assert mock_write.call_count == 256
 
     def test_skips_non_matching_read_until_match(self):
         """Non-0x50 frames in the read are ignored; next candidate's read succeeds."""

--- a/tests/logitech_receiver/test_base.py
+++ b/tests/logitech_receiver/test_base.py
@@ -8,7 +8,10 @@ import pytest
 
 from logitech_receiver import base
 from logitech_receiver import exceptions
+from logitech_receiver.base import CENTURION_ADDRESSED_REPORT_ID
+from logitech_receiver.base import CENTURION_REPORT_ID
 from logitech_receiver.base import HIDPP_SHORT_MESSAGE_ID
+from logitech_receiver.base import CenturionHandleState
 from logitech_receiver.common import LOGITECH_VENDOR_ID
 from logitech_receiver.common import BusID
 from logitech_receiver.hidpp10_constants import ErrorCode as Hidpp10Error
@@ -200,3 +203,113 @@ def test_ping_errors(simulated_error: Hidpp10Error, expected_result):
         else:
             result = base.ping(handle=handle, devnumber=device_number)
             assert result == expected_result
+
+
+# --- Centurion transport tests ---
+
+
+class TestCenturionFrameHeader:
+    """Test _centurion_frame_header builds correct headers for both variants."""
+
+    def test_0x51_header(self):
+        state = CenturionHandleState(report_id=CENTURION_REPORT_ID)
+        header = base._centurion_frame_header(state, cpl_length=5, flags=0x00)
+        assert header == bytes([0x51, 5, 0x00])
+
+    def test_0x51_header_with_flags(self):
+        state = CenturionHandleState(report_id=CENTURION_REPORT_ID)
+        header = base._centurion_frame_header(state, cpl_length=10, flags=0x03)
+        assert header == bytes([0x51, 10, 0x03])
+
+    def test_0x50_header_unknown_addr(self):
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID, device_addr=None)
+        header = base._centurion_frame_header(state, cpl_length=5, flags=0x00)
+        # device_addr defaults to 0x00 when unknown
+        assert header == bytes([0x50, 0x00, 5, 0x00])
+
+    def test_0x50_header_known_addr(self):
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID, device_addr=0x23)
+        header = base._centurion_frame_header(state, cpl_length=5, flags=0x00)
+        assert header == bytes([0x50, 0x23, 5, 0x00])
+
+    def test_0x50_header_with_flags(self):
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID, device_addr=0x23)
+        header = base._centurion_frame_header(state, cpl_length=10, flags=0x07)
+        assert header == bytes([0x50, 0x23, 10, 0x07])
+
+
+class TestUnwrapCenturionFrame:
+    """Test _unwrap_centurion_frame for both 0x51 and 0x50 variants."""
+
+    HANDLE = 99
+
+    def setup_method(self):
+        """Ensure no leftover centurion state between tests."""
+        base._centurion_handles.pop(self.HANDLE, None)
+
+    def teardown_method(self):
+        base._centurion_handles.pop(self.HANDLE, None)
+
+    def test_unwrap_0x51_frame(self):
+        """0x51 frame with feat_idx=0x02, func_sw=0x1A, 2 data bytes."""
+        # cpl_length = 1(flags) + 1(feat_idx) + 1(func_sw) + 2(data) = 5
+        raw = bytes([0x51, 5, 0x00, 0x02, 0x1A, 0xAA, 0xBB]) + b"\x00" * 57
+        result = base._unwrap_centurion_frame(raw, self.HANDLE, self.HANDLE)
+        # Should reconstruct as [0x11, 0xFF, feat_idx, func_sw, data..., pad to 20]
+        assert result[0] == 0x11
+        assert result[1] == 0xFF
+        assert result[2] == 0x02  # feat_idx
+        assert result[3] == 0x1A  # func_sw
+        assert result[4] == 0xAA
+        assert result[5] == 0xBB
+        assert len(result) == 20  # padded to standard long
+
+    def test_unwrap_0x50_frame(self):
+        """0x50 frame with device_addr=0x23, same payload as above."""
+        # Frame: [0x50, device_addr, cpl_length, flags, feat_idx, func_sw, data...]
+        raw = bytes([0x50, 0x23, 5, 0x00, 0x02, 0x1A, 0xAA, 0xBB]) + b"\x00" * 56
+        base._centurion_handles[self.HANDLE] = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
+        result = base._unwrap_centurion_frame(raw, self.HANDLE, self.HANDLE)
+        assert result[0] == 0x11
+        assert result[1] == 0xFF
+        assert result[2] == 0x02  # feat_idx
+        assert result[3] == 0x1A  # func_sw
+        assert result[4] == 0xAA
+        assert result[5] == 0xBB
+        assert len(result) == 20
+
+    def test_0x50_learns_device_addr(self):
+        """First RX on a 0x50 handle should learn the device address."""
+        base._centurion_handles[self.HANDLE] = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
+        assert base._centurion_handles[self.HANDLE].device_addr is None
+
+        raw = bytes([0x50, 0x23, 3, 0x00, 0x02, 0x1A]) + b"\x00" * 58
+        base._unwrap_centurion_frame(raw, self.HANDLE, self.HANDLE)
+
+        assert base._centurion_handles[self.HANDLE].device_addr == 0x23
+
+    def test_0x50_does_not_overwrite_addr(self):
+        """Once learned, device address should not be overwritten."""
+        base._centurion_handles[self.HANDLE] = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID, device_addr=0x23)
+        raw = bytes([0x50, 0xFF, 3, 0x00, 0x02, 0x1A]) + b"\x00" * 58
+        base._unwrap_centurion_frame(raw, self.HANDLE, self.HANDLE)
+
+        # Should keep the original address, not overwrite with 0xFF
+        assert base._centurion_handles[self.HANDLE].device_addr == 0x23
+
+    def test_non_centurion_frame_passthrough(self):
+        """Non-centurion report IDs should be returned unchanged."""
+        raw = bytes([0x11, 0x01, 0x02, 0x1A]) + b"\x00" * 16
+        result = base._unwrap_centurion_frame(raw, self.HANDLE, self.HANDLE)
+        assert result == raw
+
+    def test_unwrap_0x51_large_payload(self):
+        """0x51 frame with payload large enough to need 63-byte padding."""
+        # cpl_length covers all 61 payload bytes + flags = 62
+        payload = bytes(range(61))
+        raw = bytes([0x51, 62, 0x00]) + payload
+        result = base._unwrap_centurion_frame(raw, self.HANDLE, self.HANDLE)
+        assert len(result) == 63  # padded to centurion extended
+        assert result[0] == 0x11
+        assert result[1] == 0xFF
+        assert result[2:63] == payload

--- a/tests/logitech_receiver/test_base.py
+++ b/tests/logitech_receiver/test_base.py
@@ -326,28 +326,33 @@ class TestProbeCenturionDeviceAddr:
     def teardown_method(self):
         base._centurion_handles.pop(self.HANDLE, None)
 
-    def test_learns_addr_from_response(self):
+    def test_learns_addr_on_first_hit(self):
+        """Probe finds addr=0x23 on candidate #36 (0-indexed 0x23=35) and stops."""
         state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
         reply = bytes([0x50, 0x23, 0x03, 0x00]) + b"\x00" * 60
+
+        def read_side_effect(_handle, _size, _timeout):
+            # Return a response only after the write with addr=0x23
+            if mock_write.call_count == 0x24:  # 0x23 is the 36th write (1-indexed)
+                return reply
+            return None
+
         with (
             mock.patch.object(base.hidapi, "write") as mock_write,
-            mock.patch.object(base.hidapi, "read", return_value=reply),
+            mock.patch.object(base.hidapi, "read", side_effect=read_side_effect),
         ):
             result = base.probe_centurion_device_addr(self.HANDLE, state)
         assert result is True
         assert state.device_addr == 0x23
-        # Should have written 256 probe frames (one per candidate addr)
-        assert mock_write.call_count == 256
-        # Each frame should be 64 bytes with report_id 0x50
-        for call in mock_write.call_args_list:
-            _, wdata = call[0]
-            assert len(wdata) == base.CENTURION_FRAME_SIZE
-            assert wdata[0] == CENTURION_ADDRESSED_REPORT_ID
+        # Should have stopped at candidate 0x23 (36 writes), not all 256
+        assert mock_write.call_count == 0x24
 
-    def test_skips_non_matching_frames_until_match(self):
+    def test_skips_non_matching_read_until_match(self):
+        """Non-0x50 frames in the read are ignored; next candidate's read succeeds."""
         state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
         noise = b"\x11\xff" + b"\x00" * 62
         match = bytes([0x50, 0x42, 0x03, 0x00]) + b"\x00" * 60
+        # Reads cycle: noise, noise, match — so addr is found on 3rd candidate
         with (
             mock.patch.object(base.hidapi, "write"),
             mock.patch.object(base.hidapi, "read", side_effect=[noise, noise, match]),
@@ -356,7 +361,7 @@ class TestProbeCenturionDeviceAddr:
         assert result is True
         assert state.device_addr == 0x42
 
-    def test_returns_false_on_timeout(self):
+    def test_returns_false_when_no_response(self):
         state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
         with (
             mock.patch.object(base.hidapi, "write"),
@@ -406,7 +411,7 @@ class TestProbeCenturionDeviceAddr:
         state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
         with (
             mock.patch.object(base.hidapi, "write") as mock_write,
-            mock.patch.object(base.hidapi, "read", return_value=None),
+            mock.patch.object(base.hidapi, "read", return_value=None),  # no response → scans all 256
         ):
             base.probe_centurion_device_addr(self.HANDLE, state)
         assert mock_write.call_count == 256

--- a/tests/logitech_receiver/test_base.py
+++ b/tests/logitech_receiver/test_base.py
@@ -313,3 +313,91 @@ class TestUnwrapCenturionFrame:
         assert result[0] == 0x11
         assert result[1] == 0xFF
         assert result[2:63] == payload
+
+
+class TestProbeCenturionDeviceAddr:
+    """Test probe_centurion_device_addr: write-then-read dance to learn device_addr."""
+
+    HANDLE = 101
+
+    def setup_method(self):
+        base._centurion_handles.pop(self.HANDLE, None)
+
+    def teardown_method(self):
+        base._centurion_handles.pop(self.HANDLE, None)
+
+    def test_learns_addr_from_first_frame(self):
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
+        reply = bytes([0x50, 0x23, 0x03, 0x00]) + b"\x00" * 60
+        with (
+            mock.patch.object(base.hidapi, "write") as mock_write,
+            mock.patch.object(base.hidapi, "read", return_value=reply) as mock_read,
+        ):
+            result = base.probe_centurion_device_addr(self.HANDLE, state)
+        assert result is True
+        assert state.device_addr == 0x23
+        # probe write is a 64-byte all-zero frame with just the report ID
+        mock_write.assert_called_once()
+        _, wdata = mock_write.call_args[0]
+        assert len(wdata) == base.CENTURION_FRAME_SIZE
+        assert wdata[0] == CENTURION_ADDRESSED_REPORT_ID
+        assert wdata[1:] == b"\x00" * (base.CENTURION_FRAME_SIZE - 1)
+        mock_read.assert_called_once()
+
+    def test_skips_non_matching_frames_until_match(self):
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
+        # first two reads return unrelated frames, third returns our 0x50 frame
+        noise = b"\x11\xff" + b"\x00" * 62
+        match = bytes([0x50, 0x42, 0x03, 0x00]) + b"\x00" * 60
+        with (
+            mock.patch.object(base.hidapi, "write"),
+            mock.patch.object(base.hidapi, "read", side_effect=[noise, noise, match]),
+        ):
+            result = base.probe_centurion_device_addr(self.HANDLE, state)
+        assert result is True
+        assert state.device_addr == 0x42
+
+    def test_returns_false_on_timeout(self):
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
+        with (
+            mock.patch.object(base.hidapi, "write"),
+            mock.patch.object(base.hidapi, "read", return_value=None),
+        ):
+            result = base.probe_centurion_device_addr(self.HANDLE, state)
+        assert result is False
+        assert state.device_addr is None
+
+    def test_noop_for_0x51_variant(self):
+        state = CenturionHandleState(report_id=CENTURION_REPORT_ID)
+        with (
+            mock.patch.object(base.hidapi, "write") as mock_write,
+            mock.patch.object(base.hidapi, "read") as mock_read,
+        ):
+            result = base.probe_centurion_device_addr(self.HANDLE, state)
+        assert result is False
+        assert state.device_addr is None
+        mock_write.assert_not_called()
+        mock_read.assert_not_called()
+
+    def test_noop_when_addr_already_known(self):
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID, device_addr=0x23)
+        with (
+            mock.patch.object(base.hidapi, "write") as mock_write,
+            mock.patch.object(base.hidapi, "read") as mock_read,
+        ):
+            result = base.probe_centurion_device_addr(self.HANDLE, state)
+        assert result is False
+        assert state.device_addr == 0x23
+        mock_write.assert_not_called()
+        mock_read.assert_not_called()
+
+    def test_handles_write_failure(self):
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
+        with (
+            mock.patch.object(base.hidapi, "write", side_effect=OSError("no device")),
+            mock.patch.object(base.hidapi, "read") as mock_read,
+        ):
+            result = base.probe_centurion_device_addr(self.HANDLE, state)
+        assert result is False
+        assert state.device_addr is None
+        mock_read.assert_not_called()

--- a/tests/logitech_receiver/test_base.py
+++ b/tests/logitech_receiver/test_base.py
@@ -316,7 +316,7 @@ class TestUnwrapCenturionFrame:
 
 
 class TestProbeCenturionDeviceAddr:
-    """Test probe_centurion_device_addr: write-then-read dance to learn device_addr."""
+    """Test probe_centurion_device_addr: brute-force write for all 256 addrs, then read."""
 
     HANDLE = 101
 
@@ -326,27 +326,26 @@ class TestProbeCenturionDeviceAddr:
     def teardown_method(self):
         base._centurion_handles.pop(self.HANDLE, None)
 
-    def test_learns_addr_from_first_frame(self):
+    def test_learns_addr_from_response(self):
         state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
         reply = bytes([0x50, 0x23, 0x03, 0x00]) + b"\x00" * 60
         with (
             mock.patch.object(base.hidapi, "write") as mock_write,
-            mock.patch.object(base.hidapi, "read", return_value=reply) as mock_read,
+            mock.patch.object(base.hidapi, "read", return_value=reply),
         ):
             result = base.probe_centurion_device_addr(self.HANDLE, state)
         assert result is True
         assert state.device_addr == 0x23
-        # probe write is a 64-byte all-zero frame with just the report ID
-        mock_write.assert_called_once()
-        _, wdata = mock_write.call_args[0]
-        assert len(wdata) == base.CENTURION_FRAME_SIZE
-        assert wdata[0] == CENTURION_ADDRESSED_REPORT_ID
-        assert wdata[1:] == b"\x00" * (base.CENTURION_FRAME_SIZE - 1)
-        mock_read.assert_called_once()
+        # Should have written 256 probe frames (one per candidate addr)
+        assert mock_write.call_count == 256
+        # Each frame should be 64 bytes with report_id 0x50
+        for call in mock_write.call_args_list:
+            _, wdata = call[0]
+            assert len(wdata) == base.CENTURION_FRAME_SIZE
+            assert wdata[0] == CENTURION_ADDRESSED_REPORT_ID
 
     def test_skips_non_matching_frames_until_match(self):
         state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
-        # first two reads return unrelated frames, third returns our 0x50 frame
         noise = b"\x11\xff" + b"\x00" * 62
         match = bytes([0x50, 0x42, 0x03, 0x00]) + b"\x00" * 60
         with (
@@ -391,7 +390,7 @@ class TestProbeCenturionDeviceAddr:
         mock_write.assert_not_called()
         mock_read.assert_not_called()
 
-    def test_handles_write_failure(self):
+    def test_aborts_on_repeated_write_failure(self):
         state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
         with (
             mock.patch.object(base.hidapi, "write", side_effect=OSError("no device")),
@@ -401,3 +400,15 @@ class TestProbeCenturionDeviceAddr:
         assert result is False
         assert state.device_addr is None
         mock_read.assert_not_called()
+
+    def test_write_frames_have_sequential_addrs(self):
+        """Verify each write uses a different device_addr from 0x00 to 0xFF."""
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
+        with (
+            mock.patch.object(base.hidapi, "write") as mock_write,
+            mock.patch.object(base.hidapi, "read", return_value=None),
+        ):
+            base.probe_centurion_device_addr(self.HANDLE, state)
+        assert mock_write.call_count == 256
+        addrs_sent = [mock_write.call_args_list[i][0][1][1] for i in range(256)]
+        assert addrs_sent == list(range(256))

--- a/tests/logitech_receiver/test_base.py
+++ b/tests/logitech_receiver/test_base.py
@@ -326,8 +326,8 @@ class TestProbeCenturionDeviceAddr:
     def teardown_method(self):
         base._centurion_handles.pop(self.HANDLE, None)
 
-    def test_learns_addr_and_sweeps_all(self):
-        """Full sweep finds addr=0x23 and continues to 0xFF, logging all responders."""
+    def test_learns_addr_on_first_hit(self):
+        """Probe finds addr=0x23 on candidate #36 (0-indexed 0x23=35) and stops."""
         state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
         reply = bytes([0x50, 0x23, 0x03, 0x00]) + b"\x00" * 60
 
@@ -344,8 +344,8 @@ class TestProbeCenturionDeviceAddr:
             result = base.probe_centurion_device_addr(self.HANDLE, state)
         assert result is True
         assert state.device_addr == 0x23
-        # Full sweep — should have written all 256 candidates
-        assert mock_write.call_count == 256
+        # Short-circuit: stopped at candidate 0x23 (36 writes), not all 256
+        assert mock_write.call_count == 0x24
 
     def test_skips_non_matching_read_until_match(self):
         """Non-0x50 frames in the read are ignored; next candidate's read succeeds."""

--- a/tests/logitech_receiver/test_base.py
+++ b/tests/logitech_receiver/test_base.py
@@ -8,7 +8,10 @@ import pytest
 
 from logitech_receiver import base
 from logitech_receiver import exceptions
+from logitech_receiver.base import CENTURION_ADDRESSED_REPORT_ID
+from logitech_receiver.base import CENTURION_REPORT_ID
 from logitech_receiver.base import HIDPP_SHORT_MESSAGE_ID
+from logitech_receiver.base import CenturionHandleState
 from logitech_receiver.common import LOGITECH_VENDOR_ID
 from logitech_receiver.common import BusID
 from logitech_receiver.hidpp10_constants import ErrorCode as Hidpp10Error
@@ -197,3 +200,217 @@ def test_ping_errors(simulated_error: Hidpp10Error, expected_result):
         else:
             result = base.ping(handle=handle, devnumber=device_number)
             assert result == expected_result
+
+
+# --- Centurion transport tests ---
+
+
+class TestCenturionFrameHeader:
+    """Test _centurion_frame_header builds correct headers for both variants."""
+
+    def test_0x51_header(self):
+        state = CenturionHandleState(report_id=CENTURION_REPORT_ID)
+        header = base._centurion_frame_header(state, cpl_length=5, flags=0x00)
+        assert header == bytes([0x51, 5, 0x00])
+
+    def test_0x51_header_with_flags(self):
+        state = CenturionHandleState(report_id=CENTURION_REPORT_ID)
+        header = base._centurion_frame_header(state, cpl_length=10, flags=0x03)
+        assert header == bytes([0x51, 10, 0x03])
+
+    def test_0x50_header_unknown_addr(self):
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID, device_addr=None)
+        header = base._centurion_frame_header(state, cpl_length=5, flags=0x00)
+        # device_addr defaults to 0x00 when unknown
+        assert header == bytes([0x50, 0x00, 5, 0x00])
+
+    def test_0x50_header_known_addr(self):
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID, device_addr=0x23)
+        header = base._centurion_frame_header(state, cpl_length=5, flags=0x00)
+        assert header == bytes([0x50, 0x23, 5, 0x00])
+
+    def test_0x50_header_with_flags(self):
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID, device_addr=0x23)
+        header = base._centurion_frame_header(state, cpl_length=10, flags=0x07)
+        assert header == bytes([0x50, 0x23, 10, 0x07])
+
+
+class TestUnwrapCenturionFrame:
+    """Test _unwrap_centurion_frame for both 0x51 and 0x50 variants."""
+
+    HANDLE = 99
+
+    def setup_method(self):
+        """Ensure no leftover centurion state between tests."""
+        base._centurion_handles.pop(self.HANDLE, None)
+
+    def teardown_method(self):
+        base._centurion_handles.pop(self.HANDLE, None)
+
+    def test_unwrap_0x51_frame(self):
+        """0x51 frame with feat_idx=0x02, func_sw=0x1A, 2 data bytes."""
+        # cpl_length = 1(flags) + 1(feat_idx) + 1(func_sw) + 2(data) = 5
+        raw = bytes([0x51, 5, 0x00, 0x02, 0x1A, 0xAA, 0xBB]) + b"\x00" * 57
+        result = base._unwrap_centurion_frame(raw, self.HANDLE, self.HANDLE)
+        # Should reconstruct as [0x11, 0xFF, feat_idx, func_sw, data..., pad to 20]
+        assert result[0] == 0x11
+        assert result[1] == 0xFF
+        assert result[2] == 0x02  # feat_idx
+        assert result[3] == 0x1A  # func_sw
+        assert result[4] == 0xAA
+        assert result[5] == 0xBB
+        assert len(result) == 20  # padded to standard long
+
+    def test_unwrap_0x50_frame(self):
+        """0x50 frame with device_addr=0x23, same payload as above."""
+        # Frame: [0x50, device_addr, cpl_length, flags, feat_idx, func_sw, data...]
+        raw = bytes([0x50, 0x23, 5, 0x00, 0x02, 0x1A, 0xAA, 0xBB]) + b"\x00" * 56
+        base._centurion_handles[self.HANDLE] = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
+        result = base._unwrap_centurion_frame(raw, self.HANDLE, self.HANDLE)
+        assert result[0] == 0x11
+        assert result[1] == 0xFF
+        assert result[2] == 0x02  # feat_idx
+        assert result[3] == 0x1A  # func_sw
+        assert result[4] == 0xAA
+        assert result[5] == 0xBB
+        assert len(result) == 20
+
+    def test_0x50_learns_device_addr(self):
+        """First RX on a 0x50 handle should learn the device address."""
+        base._centurion_handles[self.HANDLE] = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
+        assert base._centurion_handles[self.HANDLE].device_addr is None
+
+        raw = bytes([0x50, 0x23, 3, 0x00, 0x02, 0x1A]) + b"\x00" * 58
+        base._unwrap_centurion_frame(raw, self.HANDLE, self.HANDLE)
+
+        assert base._centurion_handles[self.HANDLE].device_addr == 0x23
+
+    def test_0x50_does_not_overwrite_addr(self):
+        """Once learned, device address should not be overwritten."""
+        base._centurion_handles[self.HANDLE] = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID, device_addr=0x23)
+        raw = bytes([0x50, 0xFF, 3, 0x00, 0x02, 0x1A]) + b"\x00" * 58
+        base._unwrap_centurion_frame(raw, self.HANDLE, self.HANDLE)
+
+        # Should keep the original address, not overwrite with 0xFF
+        assert base._centurion_handles[self.HANDLE].device_addr == 0x23
+
+    def test_non_centurion_frame_passthrough(self):
+        """Non-centurion report IDs should be returned unchanged."""
+        raw = bytes([0x11, 0x01, 0x02, 0x1A]) + b"\x00" * 16
+        result = base._unwrap_centurion_frame(raw, self.HANDLE, self.HANDLE)
+        assert result == raw
+
+    def test_unwrap_0x51_large_payload(self):
+        """0x51 frame with payload large enough to need 63-byte padding."""
+        # cpl_length covers all 61 payload bytes + flags = 62
+        payload = bytes(range(61))
+        raw = bytes([0x51, 62, 0x00]) + payload
+        result = base._unwrap_centurion_frame(raw, self.HANDLE, self.HANDLE)
+        assert len(result) == 63  # padded to centurion extended
+        assert result[0] == 0x11
+        assert result[1] == 0xFF
+        assert result[2:63] == payload
+
+
+class TestProbeCenturionDeviceAddr:
+    """Test probe_centurion_device_addr: brute-force write for all 256 addrs, then read."""
+
+    HANDLE = 101
+
+    def setup_method(self):
+        base._centurion_handles.pop(self.HANDLE, None)
+
+    def teardown_method(self):
+        base._centurion_handles.pop(self.HANDLE, None)
+
+    def test_learns_addr_on_first_hit(self):
+        """Probe finds addr=0x23 on candidate #36 (0-indexed 0x23=35) and stops."""
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
+        reply = bytes([0x50, 0x23, 0x03, 0x00]) + b"\x00" * 60
+
+        def read_side_effect(_handle, _size, _timeout):
+            # Return a response only after the write with addr=0x23
+            if mock_write.call_count == 0x24:  # 0x23 is the 36th write (1-indexed)
+                return reply
+            return None
+
+        with (
+            mock.patch.object(base.hidapi, "write") as mock_write,
+            mock.patch.object(base.hidapi, "read", side_effect=read_side_effect),
+        ):
+            result = base.probe_centurion_device_addr(self.HANDLE, state)
+        assert result is True
+        assert state.device_addr == 0x23
+        # Short-circuit: stopped at candidate 0x23 (36 writes), not all 256
+        assert mock_write.call_count == 0x24
+
+    def test_skips_non_matching_read_until_match(self):
+        """Non-0x50 frames in the read are ignored; next candidate's read succeeds."""
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
+        noise = b"\x11\xff" + b"\x00" * 62
+        match = bytes([0x50, 0x42, 0x03, 0x00]) + b"\x00" * 60
+        # Reads cycle: noise, noise, match — so addr is found on 3rd candidate
+        with (
+            mock.patch.object(base.hidapi, "write"),
+            mock.patch.object(base.hidapi, "read", side_effect=[noise, noise, match]),
+        ):
+            result = base.probe_centurion_device_addr(self.HANDLE, state)
+        assert result is True
+        assert state.device_addr == 0x42
+
+    def test_returns_false_when_no_response(self):
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
+        with (
+            mock.patch.object(base.hidapi, "write"),
+            mock.patch.object(base.hidapi, "read", return_value=None),
+        ):
+            result = base.probe_centurion_device_addr(self.HANDLE, state)
+        assert result is False
+        assert state.device_addr is None
+
+    def test_noop_for_0x51_variant(self):
+        state = CenturionHandleState(report_id=CENTURION_REPORT_ID)
+        with (
+            mock.patch.object(base.hidapi, "write") as mock_write,
+            mock.patch.object(base.hidapi, "read") as mock_read,
+        ):
+            result = base.probe_centurion_device_addr(self.HANDLE, state)
+        assert result is False
+        assert state.device_addr is None
+        mock_write.assert_not_called()
+        mock_read.assert_not_called()
+
+    def test_noop_when_addr_already_known(self):
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID, device_addr=0x23)
+        with (
+            mock.patch.object(base.hidapi, "write") as mock_write,
+            mock.patch.object(base.hidapi, "read") as mock_read,
+        ):
+            result = base.probe_centurion_device_addr(self.HANDLE, state)
+        assert result is False
+        assert state.device_addr == 0x23
+        mock_write.assert_not_called()
+        mock_read.assert_not_called()
+
+    def test_aborts_on_repeated_write_failure(self):
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
+        with (
+            mock.patch.object(base.hidapi, "write", side_effect=OSError("no device")),
+            mock.patch.object(base.hidapi, "read") as mock_read,
+        ):
+            result = base.probe_centurion_device_addr(self.HANDLE, state)
+        assert result is False
+        assert state.device_addr is None
+        mock_read.assert_not_called()
+
+    def test_write_frames_have_sequential_addrs(self):
+        """Verify each write uses a different device_addr from 0x00 to 0xFF."""
+        state = CenturionHandleState(report_id=CENTURION_ADDRESSED_REPORT_ID)
+        with (
+            mock.patch.object(base.hidapi, "write") as mock_write,
+            mock.patch.object(base.hidapi, "read", return_value=None),  # no response → scans all 256
+        ):
+            base.probe_centurion_device_addr(self.HANDLE, state)
+        assert mock_write.call_count == 256
+        addrs_sent = [mock_write.call_args_list[i][0][1][1] for i in range(256)]
+        assert addrs_sent == list(range(256))

--- a/tests/logitech_receiver/test_device.py
+++ b/tests/logitech_receiver/test_device.py
@@ -17,6 +17,7 @@
 from dataclasses import dataclass
 from functools import partial
 from typing import Optional
+from unittest import mock
 
 import pytest
 
@@ -61,6 +62,7 @@ class DeviceInfoStub:
     bus_id: int = 0x0003  # USB
     serial: str = "aa:aa:aa;aa"
     centurion: bool = False
+    centurion_report_id: int | None = None
 
 
 di_bad_handle = DeviceInfoStub(None, product_id="CCCC")
@@ -100,16 +102,42 @@ def test_create_centurion_device():
     """Test that a centurion device gets hidpp_long forced to True and centurion flag set."""
     from logitech_receiver import base
 
-    low_level_mock = LowLevelInterfaceFake(fake_hidpp.r_empty)
-    test_device = device.create_device(low_level_mock, di_0AF7)
+    with mock.patch.object(base, "probe_centurion_device_addr", return_value=False):
+        low_level_mock = LowLevelInterfaceFake(fake_hidpp.r_empty)
+        test_device = device.create_device(low_level_mock, di_0AF7)
 
     assert test_device is not None
     assert test_device.centurion is True
     assert test_device.hidpp_long is True
     assert int(test_device.handle) in base._centurion_handles
+    state = base._centurion_handles[int(test_device.handle)]
+    assert state.report_id == base.CENTURION_REPORT_ID  # 0x51 default
 
     # Clean up
-    base._centurion_handles.discard(int(test_device.handle))
+    base._centurion_handles.pop(int(test_device.handle), None)
+
+
+di_0B18 = DeviceInfoStub("11", product_id="0B18", centurion=True, centurion_report_id=0x50)
+
+
+def test_create_centurion_0x50_device():
+    """Test that a 0x50 centurion device gets the correct report ID registered."""
+    from logitech_receiver import base
+
+    with mock.patch.object(base, "probe_centurion_device_addr", return_value=False):
+        low_level_mock = LowLevelInterfaceFake(fake_hidpp.r_empty)
+        test_device = device.create_device(low_level_mock, di_0B18)
+
+    assert test_device is not None
+    assert test_device.centurion is True
+    assert test_device.hidpp_long is True
+    assert int(test_device.handle) in base._centurion_handles
+    state = base._centurion_handles[int(test_device.handle)]
+    assert state.report_id == base.CENTURION_ADDRESSED_REPORT_ID  # 0x50
+    assert state.device_addr is None  # not yet learned
+
+    # Clean up
+    base._centurion_handles.pop(int(test_device.handle), None)
 
 
 @pytest.mark.parametrize(

--- a/tests/logitech_receiver/test_device.py
+++ b/tests/logitech_receiver/test_device.py
@@ -17,6 +17,7 @@
 from dataclasses import dataclass
 from functools import partial
 from typing import Optional
+from unittest import mock
 
 import pytest
 
@@ -101,8 +102,9 @@ def test_create_centurion_device():
     """Test that a centurion device gets hidpp_long forced to True and centurion flag set."""
     from logitech_receiver import base
 
-    low_level_mock = LowLevelInterfaceFake(fake_hidpp.r_empty)
-    test_device = device.create_device(low_level_mock, di_0AF7)
+    with mock.patch.object(base, "probe_centurion_device_addr", return_value=False):
+        low_level_mock = LowLevelInterfaceFake(fake_hidpp.r_empty)
+        test_device = device.create_device(low_level_mock, di_0AF7)
 
     assert test_device is not None
     assert test_device.centurion is True
@@ -122,8 +124,9 @@ def test_create_centurion_0x50_device():
     """Test that a 0x50 centurion device gets the correct report ID registered."""
     from logitech_receiver import base
 
-    low_level_mock = LowLevelInterfaceFake(fake_hidpp.r_empty)
-    test_device = device.create_device(low_level_mock, di_0B18)
+    with mock.patch.object(base, "probe_centurion_device_addr", return_value=False):
+        low_level_mock = LowLevelInterfaceFake(fake_hidpp.r_empty)
+        test_device = device.create_device(low_level_mock, di_0B18)
 
     assert test_device is not None
     assert test_device.centurion is True

--- a/tests/logitech_receiver/test_device.py
+++ b/tests/logitech_receiver/test_device.py
@@ -61,6 +61,7 @@ class DeviceInfoStub:
     bus_id: int = 0x0003  # USB
     serial: str = "aa:aa:aa;aa"
     centurion: bool = False
+    centurion_report_id: int | None = None
 
 
 di_bad_handle = DeviceInfoStub(None, product_id="CCCC")
@@ -107,9 +108,33 @@ def test_create_centurion_device():
     assert test_device.centurion is True
     assert test_device.hidpp_long is True
     assert int(test_device.handle) in base._centurion_handles
+    state = base._centurion_handles[int(test_device.handle)]
+    assert state.report_id == base.CENTURION_REPORT_ID  # 0x51 default
 
     # Clean up
-    base._centurion_handles.discard(int(test_device.handle))
+    base._centurion_handles.pop(int(test_device.handle), None)
+
+
+di_0B18 = DeviceInfoStub("11", product_id="0B18", centurion=True, centurion_report_id=0x50)
+
+
+def test_create_centurion_0x50_device():
+    """Test that a 0x50 centurion device gets the correct report ID registered."""
+    from logitech_receiver import base
+
+    low_level_mock = LowLevelInterfaceFake(fake_hidpp.r_empty)
+    test_device = device.create_device(low_level_mock, di_0B18)
+
+    assert test_device is not None
+    assert test_device.centurion is True
+    assert test_device.hidpp_long is True
+    assert int(test_device.handle) in base._centurion_handles
+    state = base._centurion_handles[int(test_device.handle)]
+    assert state.report_id == base.CENTURION_ADDRESSED_REPORT_ID  # 0x50
+    assert state.device_addr is None  # not yet learned
+
+    # Clean up
+    base._centurion_handles.pop(int(test_device.handle), None)
 
 
 @pytest.mark.parametrize(

--- a/tests/logitech_receiver/test_hidpp20_complex.py
+++ b/tests/logitech_receiver/test_hidpp20_complex.py
@@ -956,29 +956,18 @@ def test_centurion_sub_device_feature_discovery():
     dev = fake_hidpp.Device("CENT_SUB", True, 2.6, fake_hidpp.r_centurion_headset, centurion=True)
     # Set up bridge responses for sub-device discovery:
     # 1. CenturionRoot.GetFeature(0x0001) -> FeatureSet at sub-index 1
-    # 2. CenturionFeatureSet.GetFeatureId(index=0) -> bulk feature list
+    # 2. CenturionFeatureSet.GetCount (func 0) -> total feature count
+    # 3. CenturionFeatureSet.GetFeatureId (func 0x10) per-index -> one feature each
     dev._bridge_responses = {
         # CenturionRoot(idx=0).GetFeature(func=0) with feature_id=0x0001 -> sub_fs_index=1
         (0x00, 0x00, "0001"): bytes([0x01, 0x00, 0x00]),
-        # CenturionFeatureSet(idx=1).GetFeatureId(func=0x10, start=0) -> 3 features
-        # Response: [count, (feat_hi, feat_lo, type, flags) × count]
-        (0x01, 0x10, "00"): bytes(
-            [
-                0x03,  # 3 features
-                0x06,
-                0x04,
-                0x00,
-                0x00,  # HEADSET_AUDIO_SIDETONE (0x0604) at sub-idx 0
-                0x06,
-                0x01,
-                0x00,
-                0x00,  # HEADSET_MIC_MUTE (0x0601) at sub-idx 1
-                0x06,
-                0x11,
-                0x00,
-                0x00,  # HEADSET_MIC_GAIN (0x0611) at sub-idx 2
-            ]
-        ),
+        # CenturionFeatureSet(idx=1).GetCount (func=0) -> 3 features
+        (0x01, 0x00, ""): bytes([0x03, 0x00, 0x00]),
+        # CenturionFeatureSet(idx=1).GetFeatureId (func=0x10, index=N) -> one feature per response.
+        # Response format: [remaining, feat_hi, feat_lo, type, flags]
+        (0x01, 0x10, "00"): bytes([0x02, 0x06, 0x04, 0x00, 0x00]),  # HEADSET_AUDIO_SIDETONE at sub-idx 0
+        (0x01, 0x10, "01"): bytes([0x01, 0x06, 0x01, 0x00, 0x00]),  # HEADSET_MIC_MUTE at sub-idx 1
+        (0x01, 0x10, "02"): bytes([0x00, 0x06, 0x11, 0x00, 0x00]),  # HEADSET_MIC_GAIN at sub-idx 2
     }
     featuresarray = hidpp20.FeaturesArray(dev)
     dev.features = featuresarray

--- a/tests/logitech_receiver/test_setting_templates.py
+++ b/tests/logitech_receiver/test_setting_templates.py
@@ -1018,3 +1018,38 @@ def test_RGBIdleEffect_unrecognized_int_passes_through():
 
     assert setting._value == 999
     assert device.persister[setting.name] == 999
+
+
+def test_HeadsetOnboardEffect_explicit_black_is_honored():
+    """An explicit Static color1 of 0 (black) must survive: 0 is a real
+    choice — it turns the LEDs off — not an absent field to seed white."""
+    effect = settings_templates._HeadsetOnboardEffect(ID=0, color1=0)
+
+    assert int(effect.color1) == 0
+    assert effect.to_bytes()[2:5] == b"\x00\x00\x00"
+
+
+def test_HeadsetOnboardEffect_absent_color_seeds_default():
+    """A genuinely absent field (None) still falls back to the per-effect
+    default — Static with no color1 given is white."""
+    effect = settings_templates._HeadsetOnboardEffect(ID=0)
+
+    assert int(effect.color1) == 0xFFFFFF
+
+
+def test_HeadsetOnboardEffect_from_bytes_black_round_trips():
+    """A black Static frame read off the device round-trips to black
+    rather than being rewritten to the white default."""
+    effect = settings_templates._HeadsetOnboardEffect.from_bytes(bytes(9))
+
+    assert effect.ID == 0
+    assert int(effect.color1) == 0
+
+
+def test_HeadsetOnboardEffect_absent_animated_fields_seed_defaults():
+    """Animated effects with no params given still get sane defaults so
+    the picker never emits a zero-intensity (LEDs-off) frame."""
+    effect = settings_templates._HeadsetOnboardEffect(ID=1)  # Color Cycle
+
+    assert effect.intensity == 100
+    assert effect.period == 5000


### PR DESCRIPTION
This expands on my existing PRO X 2 LIGHTSPEED support, to also include the alternate variation of the new transport which uses a device ID.

This will allow the G522 headphones to utilize the existing features I already reversed (battery status, sidetone mic SNR, EQ). Additional features like RGB support will still need to be sorted out before that can be offered, though it should be very similar to the existing hid++ support.

This support in Solaar is still pretty theoretical, though packet level data has been fully confirmed through working with the developer of [LGSTrayEx](https://github.com/strain08/LGSTrayEx) who had access to a user with a physical pair of G522 headphones.

This support requires the PRO X 2 branch to be merged first, and should probably be tested against someone on linux with a set of the G522 headphones, but it also doesn't impact functionality of the existing PRO X 2 models as-is, and simulated packet data logged elsewhere replays all as expected for behavioral testing.