### PR TITLE
Fix crash in NotificationFlag.flag_names when flags is None

### DIFF
--- a/lib/logitech_receiver/hidpp10_constants.py
+++ b/lib/logitech_receiver/hidpp10_constants.py
@@ -91,6 +91,8 @@ class NotificationFlag(IntFlag):
     @classmethod
     def flag_names(cls, flags) -> List[str]:
         """Extract the names of the flags from the integer."""
+        if flags is None or flags.name is None:
+            return []
         return flags.name.replace("_", " ").lower().split("|")
 
     NUMPAD_NUMERICAL_KEYS = 0x800000


### PR DESCRIPTION
## Summary

- Fix `AttributeError: 'NoneType' object has no attribute 'replace'` in `NotificationFlag.flag_names()` when `flags` or `flags.name` is `None`
- Return an empty list instead of crashing, consistent with the `List[str]` return type
- Affects Nano (C52F), Unifying (C52B), and Bolt (C548) receivers

## Details

The crash blocks both CLI (`solaar show`) and GUI startup (`listener.py` → `enable_connection_notifications`), making Solaar unusable with affected receivers.

The fix is a two-line `None` guard before the existing `.name.replace(...)` call.

## Environment

- **Solaar version:** 1.1.19 (commit `99a403c5`)
- **OS:** Debian 11.11 (Bullseye)
- **Python:** 3.9.2
- **Kernel:** 5.10.0-39-amd64

Fixes #3184