### PR TITLE
Handle composite IntFlag.name on Python < 3.11

### DIFF
--- a/lib/logitech_receiver/hidpp10_constants.py
+++ b/lib/logitech_receiver/hidpp10_constants.py
@@ -91,9 +91,12 @@ class NotificationFlag(IntFlag):
     @classmethod
     def flag_names(cls, flags) -> List[str]:
         """Extract the names of the flags from the integer."""
-        if flags is None or flags.name is None:
+        if flags is None:
             return []
-        return flags.name.replace("_", " ").lower().split("|")
+        if flags.name is not None:
+            return flags.name.replace("_", " ").lower().split("|")
+        # Python < 3.11: .name is None for composite flags, decompose manually
+        return [m.name.replace("_", " ").lower() for m in cls if m.value and m in flags]
 
     NUMPAD_NUMERICAL_KEYS = 0x800000
     F_LOCK_STATUS = 0x400000

--- a/tests/logitech_receiver/test_hidpp10.py
+++ b/tests/logitech_receiver/test_hidpp10.py
@@ -296,6 +296,31 @@ def test_notification_flag_str(flag_bits, expected_names):
     assert flag_names == expected_names
 
 
+@pytest.mark.parametrize(
+    "flags, expected",
+    [
+        (None, []),
+        (hidpp10_constants.NotificationFlag(0x000900), ["software present", "wireless"]),  # composite flag, .name is None on Python < 3.11
+        (hidpp10_constants.NotificationFlag(0x100000), ["battery status"]),
+        (hidpp10_constants.NotificationFlag(0x080000), ["mouse extra buttons"]),
+    ],
+)
+def test_notification_flag_names(flags, expected):
+    result = hidpp10_constants.NotificationFlag.flag_names(flags)
+    assert result == expected
+
+
+def test_notification_flag_names_none_does_not_crash():
+    """Regression test for #3184: flag_names crashes with AttributeError when
+    flags.name is None, which happens with certain receiver firmware versions
+    (e.g. Nano C52F reporting 0x000900)."""
+    flags_with_none_name = hidpp10_constants.NotificationFlag(0x000900)
+    result = hidpp10_constants.NotificationFlag.flag_names(flags_with_none_name)
+    assert "software present" in result
+    assert "wireless" in result
+    assert isinstance(result, list)
+
+
 def test_get_device_features():
     result = _hidpp10.get_device_features(device_standard)
 

--- a/tests/logitech_receiver/test_hidpp10.py
+++ b/tests/logitech_receiver/test_hidpp10.py
@@ -300,7 +300,8 @@ def test_notification_flag_str(flag_bits, expected_names):
     "flags, expected",
     [
         (None, []),
-        (hidpp10_constants.NotificationFlag(0x000900), ["software present", "wireless"]),  # composite flag, .name is None on Python < 3.11
+        # composite flag, .name is None on Python < 3.11
+        (hidpp10_constants.NotificationFlag(0x000900), ["software present", "wireless"]),
         (hidpp10_constants.NotificationFlag(0x100000), ["battery status"]),
         (hidpp10_constants.NotificationFlag(0x080000), ["mouse extra buttons"]),
     ],


### PR DESCRIPTION
Fixes #3083

## Summary

Follow-up to #3185. The previous fix returns `[]` for composite flags on Python < 3.11 because `IntFlag.name` is `None` for composite values on those versions. This PR decomposes composite flags manually, producing correct results on all supported Python versions (`>= 3.8` as declared in `setup.py`).

## Changes

- **`hidpp10_constants.py`**: When `flags.name is None`, iterate over enum members to decompose the composite flag instead of returning an empty list
- **`test_hidpp10.py`**: Add regression tests for composite flags (`0x000900`) and `None` input

## Test Results

|  | Without fix | With fix |
|--|------------|---------|
| **Python 3.9.2** (Debian 11) | 4 FAILED | 56 passed |
| **Python 3.11.15** (pyenv) | 1 FAILED | 56 passed |

Fixes #3186