### PR TITLE
Use battery-level-N icons with semantic and generic fallback

### DIFF
--- a/lib/solaar/ui/icons.py
+++ b/lib/solaar/ui/icons.py
@@ -30,10 +30,11 @@ TRAY_ATTENTION = "solaar-attention"
 
 _default_theme = None
 _has_level_icons = False
+_has_padded_level_icons = False
 
 
 def _init_icon_paths():
-    global _default_theme, _has_level_icons
+    global _default_theme, _has_level_icons, _has_padded_level_icons
     if _default_theme:
         return
     _default_theme = Gtk.IconTheme.get_default()
@@ -50,7 +51,8 @@ def _init_icon_paths():
             gtk.battery_icons_style = "solaar"
     suffix = "-symbolic" if gtk.battery_icons_style == "symbolic" else ""
     _has_level_icons = _default_theme.has_icon(f"battery-level-50{suffix}")
-    logger.debug("battery level icons available: %s", _has_level_icons)
+    _has_padded_level_icons = not _has_level_icons and _default_theme.has_icon(f"battery-050{suffix}")
+    logger.debug("battery level icons available: %s (padded scheme: %s)", _has_level_icons, _has_padded_level_icons)
 
 
 def battery(level=None, charging=False):
@@ -77,20 +79,23 @@ def _battery_icon_name(level, charging):
 
     rounded = min(100, max(0, round(level / 10) * 10))
 
-    # Try precise level icons first (battery-level-N[-charging|-charged][-symbolic])
-    if _has_level_icons:
+    # Try precise level icons (battery-level-N or battery-0N0 naming scheme)
+    if _has_level_icons or _has_padded_level_icons:
         if charging and rounded == 100:
             charging_str = "-charged"
         elif charging:
             charging_str = "-charging"
         else:
             charging_str = ""
-        icon_name = f"battery-level-{rounded}{charging_str}{suffix}"
+        if _has_level_icons:
+            icon_name = f"battery-level-{rounded}{charging_str}{suffix}"
+        else:
+            icon_name = f"battery-{rounded:03}{charging_str}{suffix}"
         if _default_theme.has_icon(icon_name):
             logger.debug("battery level icon for %s:%s = %s", level, charging, icon_name)
             return icon_name
 
-    # Fall back to semantic names with corrected thresholds
+    # Fall back to semantic names
     level_name = _first_res(level, ((90, "full"), (60, "good"), (20, "low"), (5, "caution"), (0, "empty")))
     if level_name:
         if charging:

--- a/lib/solaar/ui/icons.py
+++ b/lib/solaar/ui/icons.py
@@ -29,16 +29,15 @@ TRAY_OKAY = "solaar"
 TRAY_ATTENTION = "solaar-attention"
 
 _default_theme = None
+_has_level_icons = False
 
 
 def _init_icon_paths():
-    global _default_theme
+    global _default_theme, _has_level_icons
     if _default_theme:
         return
-
     _default_theme = Gtk.IconTheme.get_default()
     logger.debug("icon theme paths: %s", _default_theme.get_search_path())
-
     if gtk.battery_icons_style == "symbolic":
         global TRAY_OKAY
         TRAY_OKAY = TRAY_INIT  # use monochrome tray icon
@@ -49,6 +48,9 @@ def _init_icon_paths():
         if not _default_theme.has_icon("battery-good"):
             logger.warning("failed to detect icons")
             gtk.battery_icons_style = "solaar"
+    suffix = "-symbolic" if gtk.battery_icons_style == "symbolic" else ""
+    _has_level_icons = _default_theme.has_icon(f"battery-level-50{suffix}")
+    logger.debug("battery level icons available: %s", _has_level_icons)
 
 
 def battery(level=None, charging=False):
@@ -68,16 +70,42 @@ def _first_res(val, pairs):
 
 def _battery_icon_name(level, charging):
     _init_icon_paths()
+    suffix = "-symbolic" if gtk.battery_icons_style == "symbolic" else ""
 
     if level is None or level < 0:
-        return "battery-missing" + ("-symbolic" if gtk.battery_icons_style == "symbolic" else "")
+        return f"battery-missing{suffix}"
 
-    level_name = _first_res(level, ((90, "full"), (30, "good"), (20, "low"), (5, "caution"), (0, "empty")))
-    return "battery-%s%s%s" % (
-        level_name,
-        "-charging" if charging else "",
-        "-symbolic" if gtk.battery_icons_style == "symbolic" else "",
-    )
+    rounded = min(100, max(0, round(level / 10) * 10))
+
+    # Try precise level icons first (battery-level-N[-charging|-charged][-symbolic])
+    if _has_level_icons:
+        if charging and rounded == 100:
+            charging_str = "-charged"
+        elif charging:
+            charging_str = "-charging"
+        else:
+            charging_str = ""
+        icon_name = f"battery-level-{rounded}{charging_str}{suffix}"
+        if _default_theme.has_icon(icon_name):
+            logger.debug("battery level icon for %s:%s = %s", level, charging, icon_name)
+            return icon_name
+
+    # Fall back to semantic names with corrected thresholds
+    level_name = _first_res(level, ((90, "full"), (60, "good"), (20, "low"), (5, "caution"), (0, "empty")))
+    if level_name:
+        if charging:
+            charging_str = "-charging"
+        else:
+            charging_str = ""
+        icon_name = f"battery-{level_name}{charging_str}{suffix}"
+        if _default_theme.has_icon(icon_name):
+            logger.debug("battery semantic icon for %s:%s = %s", level, charging, icon_name)
+            return icon_name
+
+    # Last resort: plain battery icon
+    icon_name = f"battery{suffix}"
+    logger.debug("battery generic icon for %s:%s = %s", level, charging, icon_name)
+    return icon_name
 
 
 def lux(level=None):


### PR DESCRIPTION
Closes #3192

As discussed in the issue, `_battery_icon_name` is rewritten to use a three-level
fallback strategy:

1. **Precise level icons** — `battery-level-N[-charging|-charged][-symbolic]` in 10%
   steps, used when the active theme supports them. Availability is probed once in
   `_init_icon_paths` and cached in `_has_level_icons` to avoid repeated `has_icon`
   calls at runtime.
2. **Semantic names** — `battery-{full|good|low|caution|empty}[-charging][-symbolic]`
   with corrected thresholds (`60` instead of `30` for `good`) to better reflect
   actual charge levels on themes that lack level icons.
3. **Generic fallback** — plain `battery[-symbolic]`, before the existing last-resort
   fallback to the Solaar tray icon in `battery()`.

The charging logic uses `if`/`elif`/`else` statements consistently throughout.