### PR TITLE
Perkey UI improvements

### DIFF
--- a/lib/logitech_receiver/common.py
+++ b/lib/logitech_receiver/common.py
@@ -361,6 +361,53 @@ yaml.SafeLoader.add_constructor("!NamedInt", NamedInt.from_yaml)
 yaml.add_representer(NamedInt, NamedInt.to_yaml)
 
 
+class ColorInt(int):
+    """A 24-bit RGB color (``0x000000``-``0xFFFFFF``) as an int subclass.
+
+    Renders as ``0xrrggbb`` in ``str()`` / ``repr()`` and as a YAML hex int
+    literal in dumped configs (e.g. ``color: 0xfc3300``), which loads back
+    natively as a plain int via YAML 1.1's hex int parsing — so the value
+    round-trips cleanly with no special loader registration. The constructor
+    accepts both ints and hex strings (``0xfc3300`` or ``#fc3300``) so configs
+    saved before this type existed continue to load unchanged.
+
+    Negative or out-of-range values fall back to plain decimal formatting so
+    sentinels like ``COLORSPLUS["No change"] = -1`` keep their natural display.
+    """
+
+    def __new__(cls, value):
+        if isinstance(value, str):
+            s = value.strip().lower()
+            if s.startswith("#"):
+                value = int(s[1:], 16)
+            elif s.startswith(("0x", "0X")):
+                value = int(s, 16)
+            else:
+                value = int(s)
+        else:
+            value = int(value)
+        return super().__new__(cls, value)
+
+    def __str__(self):
+        v = int(self)
+        if 0 <= v <= 0xFFFFFF:
+            return "0x%06x" % v
+        return str(v)
+
+    def __repr__(self):
+        return self.__str__()
+
+
+def color_int_representer(dumper, data):
+    v = int(data)
+    if 0 <= v <= 0xFFFFFF:
+        return dumper.represent_scalar("tag:yaml.org,2002:int", "0x%06x" % v)
+    return dumper.represent_scalar("tag:yaml.org,2002:int", str(v))
+
+
+yaml.add_representer(ColorInt, color_int_representer)
+
+
 class NamedInts:
     """An ordered set of NamedInt values.
 

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -1177,9 +1177,17 @@ LEDEffects = {
 
 
 class LEDEffectSetting:  # an effect plus its parameters
+    # Params whose value space is an RGB color; wrapped in ColorInt so the
+    # value self-formats as ``0xrrggbb`` in solaar show and the YAML config.
+    _COLOR_PARAMS = (str(LEDParam.color),)
+
     def __init__(self, **kwargs):
         self.ID = None
         for key, val in kwargs.items():
+            # type(val) is int — exact match excludes NamedInt/ColorInt and
+            # any other int subclass; only "raw" ints get wrapped here.
+            if key in self._COLOR_PARAMS and type(val) is int and 0 <= val <= 0xFFFFFF:  # noqa: E721
+                val = common.ColorInt(val)
             setattr(self, key, val)
 
     @classmethod

--- a/lib/logitech_receiver/settings.py
+++ b/lib/logitech_receiver/settings.py
@@ -61,6 +61,11 @@ class Setting:
     validator_class = None
     validator_options = {}
     display = True  # display setting in UI
+    # Set False for settings whose value cannot be read back from the device
+    # (e.g. PerKeyLighting — the 0x8081 protocol has no GetIndividualRgbZones).
+    # `solaar show` uses this to suppress the "(live)" output line that would
+    # otherwise print a fabricated value misleadingly.
+    live_readable = True
     # Optional UI editor override as "module.path:ClassName". Resolved by the
     # config panel before the Kind dispatch. Kept as a string so this module
     # stays free of GTK imports — the FE/BE seam is preserved.

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1894,6 +1894,11 @@ class PerKeyLighting(settings.Settings):
     feature = _F.PER_KEY_LIGHTING_V2
     keys_universe = special_keys.KEYCODES
     editor_class = "solaar.ui.perkey.control:PerKeyControl"
+    # 0x8081 has no GetIndividualRgbZones — there's no way to ask the device
+    # what colors are currently on the per-key buffer. read() returns the
+    # canonical in-memory map for callers that need a value, but `solaar show`
+    # honors this flag and skips its live-read line to avoid misleading output.
+    live_readable = False
 
     @staticmethod
     def _wrap_color(value):
@@ -1916,12 +1921,20 @@ class PerKeyLighting(settings.Settings):
         super().update_key_value(key, self._wrap_color(value), save)
 
     def read(self, cached=True):
+        # The 0x8081 protocol has no GetIndividualRgbZones — the device cannot
+        # report its current per-key buffer back. So a "live" read is fictional:
+        # we either return what we last wrote (the persisted/in-memory map,
+        # which is the canonical truth for this setting) or, on a fresh device
+        # with no persisted state, fabricate an all-"No change" sentinel map
+        # as the starting point. Returning the cached value unconditionally
+        # also fixes `solaar show` showing every key as "No change" on the
+        # live line — it now matches what's actually on the keyboard.
         self._pre_read(cached)
-        if cached and self._value is not None:
+        if self._value is not None:
             return self._value
         reply_map = {}
         for key in self._validator.choices:
-            reply_map[int(key)] = special_keys.COLORSPLUS["No change"]  # this signals no change
+            reply_map[int(key)] = special_keys.COLORSPLUS["No change"]  # starting state, no per-key write yet
         self._value = reply_map
         return reply_map
 

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1895,6 +1895,26 @@ class PerKeyLighting(settings.Settings):
     keys_universe = special_keys.KEYCODES
     editor_class = "solaar.ui.perkey.control:PerKeyControl"
 
+    @staticmethod
+    def _wrap_color(value):
+        # Wrap raw 24-bit-range ints in ColorInt so saved configs render as
+        # ``0xrrggbb`` hex literals and `solaar show` prints hex. Sentinels
+        # (NamedInt "No change" = -1) and existing ColorInt values pass
+        # through untouched.
+        # type(value) is int — exact match excludes NamedInt sentinels like
+        # COLORSPLUS["No change"] = -1 and avoids re-wrapping ColorInts.
+        if type(value) is int and 0 <= value <= 0xFFFFFF:  # noqa: E721
+            return common.ColorInt(value)
+        return value
+
+    def update(self, value, save=True):
+        if isinstance(value, dict):
+            value = {k: self._wrap_color(v) for k, v in value.items()}
+        super().update(value, save)
+
+    def update_key_value(self, key, value, save=True):
+        super().update_key_value(key, self._wrap_color(value), save)
+
     def read(self, cached=True):
         self._pre_read(cached)
         if cached and self._value is not None:
@@ -1951,7 +1971,7 @@ class PerKeyLighting(settings.Settings):
         pass
 
     class validator_class(settings_validator.MapRangeValidator):
-        _COLOR_RANGE = settings_validator.Range(min=0, max=0xFFFFFF, byte_count=3)
+        _COLOR_RANGE = settings_validator.Range(min=0, max=0xFFFFFF, byte_count=3, value_type=common.ColorInt)
 
         @classmethod
         def build(cls, setting_class, device):

--- a/lib/logitech_receiver/settings_validator.py
+++ b/lib/logitech_receiver/settings_validator.py
@@ -754,6 +754,11 @@ class Range:
     """Inclusive integer range used as the value side of a MapRangeValidator.
 
     `byte_count` is the wire encoding width. `signed` selects two's-complement.
+    `value_type` is the int factory used to wrap values returned from
+    `validate_read` — defaults to `int`, but settings that store RGB colors
+    pass `common.ColorInt` so the values self-format as ``0xrrggbb`` in
+    `solaar show` output and the YAML config file.
+
     Settings whose value space is a continuous integer range (e.g. per-key RGB
     colors as 24-bit ints) use this in place of a NamedInts choice list.
     """
@@ -762,6 +767,7 @@ class Range:
     max: int
     byte_count: int = 1
     signed: bool = False
+    value_type: type = int
 
     def contains(self, value: int) -> bool:
         return isinstance(value, int) and self.min <= value <= self.max
@@ -795,14 +801,31 @@ class MapRangeValidator(Validator):
     def to_string(self, value) -> str:
         if not isinstance(value, dict):
             return str(value)
-        return "{" + ", ".join(f"{k}:{value[k]}" for k in sorted(value)) + "}"
+        # Persisted dicts loaded from YAML come back as plain ints regardless
+        # of the choice's `value_type`. Re-wrap raw ints through the configured
+        # value_type (e.g. ColorInt) so they self-format consistently here and
+        # in `solaar show`. Skip wrapping for NamedInt sentinels / subclasses
+        # (`type(v) is int` is the exact-match guard).
+        rng_by_int_key = {int(k): rng for k, rng in self.choices.items()}
+
+        def _fmt(k):
+            v = value[k]
+            rng = rng_by_int_key.get(int(k))
+            if rng is not None and type(v) is int and rng.value_type is not int:  # noqa: E721
+                try:
+                    v = rng.value_type(v)
+                except Exception:
+                    pass
+            return f"{k}:{v}"
+
+        return "{" + ", ".join(_fmt(k) for k in sorted(value)) + "}"
 
     def validate_read(self, reply_bytes, key):
         rng = self.choices.get(key)
         if rng is None:
             return None
         end = self._key_byte_count + rng.byte_count
-        return common.bytes2int(reply_bytes[self._key_byte_count : end], signed=rng.signed)
+        return rng.value_type(common.bytes2int(reply_bytes[self._key_byte_count : end], signed=rng.signed))
 
     def prepare_key(self, key):
         return int(key).to_bytes(self._key_byte_count, "big")

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -375,14 +375,19 @@ def _print_device(dev, num=None):
                     ):
                         v = setting.val_to_string(setting._device.persister.get(setting.name))
                         print(f"            {setting.label} (saved): {v}")
-                    try:
-                        v = setting.read(False)
-                        v = setting.val_to_string(v)
-                    except exceptions.FeatureCallError as e:
-                        v = "HID++ error " + str(e)
-                    except AssertionError as e:
-                        v = "AssertionError " + str(e)
-                    print(f"            {setting.label}        : {v}")
+                    # Settings whose value cannot be read back from the device
+                    # (e.g. PerKeyLighting — 0x8081 has no GetIndividualRgbZones)
+                    # suppress the live-read line; the saved line above is the
+                    # authoritative record. See Setting.live_readable.
+                    if getattr(setting, "live_readable", True):
+                        try:
+                            v = setting.read(False)
+                            v = setting.val_to_string(v)
+                        except exceptions.FeatureCallError as e:
+                            v = "HID++ error " + str(e)
+                        except AssertionError as e:
+                            v = "AssertionError " + str(e)
+                        print(f"            {setting.label}        : {v}")
 
     if dev.online and dev.keys:
         print(f"     Has {len(dev.keys)} reprogrammable keys:")

--- a/lib/solaar/ui/perkey/_icons.py
+++ b/lib/solaar/ui/perkey/_icons.py
@@ -86,3 +86,48 @@ def themed_icon_image(icon_name: str, style_widget: Gtk.Widget) -> Gtk.Image | N
     except Exception as e:
         logger.debug("recolor failed for %s: %s", icon_name, e)
         return None
+
+
+def _fg_color_key(widget: Gtk.Widget) -> tuple[float, float, float]:
+    fg = widget.get_style_context().get_color(Gtk.StateFlags.NORMAL)
+    return (round(fg.red, 3), round(fg.green, 3), round(fg.blue, 3))
+
+
+def attach_themed_icon(button: Gtk.Container, icon_name: str) -> int | None:
+    """Add a themed icon to `button` and re-render it whenever the active
+    GTK theme changes the button's foreground color. Returns the
+    style-updated signal handler ID, or None if the icon couldn't be
+    loaded (in which case the button is left unchanged so the caller can
+    fall back to a text label).
+
+    Listening to the button's own ``style-updated`` signal — instead of
+    ``Gtk.Settings notify::gtk-theme-name`` — means we read the
+    foreground color *after* GTK has re-resolved CSS for the new theme.
+    Subscribing to the Settings notify fires too early; it returns the
+    stale (pre-switch) color and produces icons that all settle on the
+    previous theme's tone. We guard the rebuild with a per-button color
+    key so unrelated style updates (hover, focus, active) don't trigger
+    needless re-renders.
+    """
+    image = themed_icon_image(icon_name, button)
+    if image is None:
+        return None
+    button.add(image)
+    image.show()
+    state = {"color_key": _fg_color_key(button)}
+
+    def _refresh(_widget) -> None:
+        new_key = _fg_color_key(button)
+        if new_key == state["color_key"]:
+            return
+        state["color_key"] = new_key
+        new_image = themed_icon_image(icon_name, button)
+        if new_image is None:
+            return
+        old = button.get_child()
+        if old is not None:
+            button.remove(old)
+        button.add(new_image)
+        new_image.show()
+
+    return button.connect("style-updated", _refresh)

--- a/lib/solaar/ui/perkey/_icons.py
+++ b/lib/solaar/ui/perkey/_icons.py
@@ -1,0 +1,88 @@
+## Copyright (C) 2026  Solaar Contributors https://pwr-solaar.github.io/Solaar/
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License along
+## with this program; if not, write to the Free Software Foundation, Inc.,
+## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Theme-aware loader for Solaar's per-key UI icons.
+
+Loads SVG icons from ``share/solaar/icons/`` and recolors them at load
+time to match the active GTK theme's text foreground, by substituting
+``currentColor`` in the SVG before passing it to GdkPixbuf. GTK's stock
+symbolic loader is bypassed because it only recolors specific palette
+fill stand-ins and ignores ``stroke="currentColor"``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from pathlib import Path
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import GdkPixbuf  # NOQA: E402
+from gi.repository import Gio  # NOQA: E402
+from gi.repository import Gtk  # NOQA: E402
+
+logger = logging.getLogger(__name__)
+
+ICON_PIXEL_SIZE = 22
+
+_search_path_added = False
+
+
+def ensure_icon_path() -> None:
+    """Register share/solaar/icons with the default GtkIconTheme so our
+    custom symbolic tool icons resolve by name. Idempotent."""
+    global _search_path_added
+    if _search_path_added:
+        return
+    theme = Gtk.IconTheme.get_default()
+    existing = set(theme.get_search_path() or [])
+    # _icons.py: lib/solaar/ui/perkey/_icons.py -> parents[4] = repo root
+    candidates = [
+        Path(__file__).resolve().parents[4] / "share" / "solaar" / "icons",
+    ]
+    for c in candidates:
+        if c.is_dir() and str(c) not in existing:
+            theme.append_search_path(str(c))
+    _search_path_added = True
+
+
+def themed_icon_image(icon_name: str, style_widget: Gtk.Widget) -> Gtk.Image | None:
+    """Load a Solaar tool icon and recolor it to match the given widget's
+    text foreground color, so the icons follow the active GTK theme
+    (light / dark / custom). Returns None if the icon can't be loaded.
+    """
+    ensure_icon_path()
+    theme = Gtk.IconTheme.get_default()
+    icon_info = theme.lookup_icon(icon_name, ICON_PIXEL_SIZE, Gtk.IconLookupFlags.FORCE_SIZE)
+    if icon_info is None:
+        return None
+    path = icon_info.get_filename()
+    if not path:
+        return None
+    fg = style_widget.get_style_context().get_color(Gtk.StateFlags.NORMAL)
+    color = f"#{int(fg.red * 255):02x}{int(fg.green * 255):02x}{int(fg.blue * 255):02x}"
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            svg = f.read()
+        svg = svg.replace("currentColor", color)
+        stream = Gio.MemoryInputStream.new_from_data(svg.encode("utf-8"))
+        pixbuf = GdkPixbuf.Pixbuf.new_from_stream_at_scale(stream, ICON_PIXEL_SIZE, ICON_PIXEL_SIZE, True)
+        return Gtk.Image.new_from_pixbuf(pixbuf)
+    except Exception as e:
+        logger.debug("recolor failed for %s: %s", icon_name, e)
+        return None

--- a/lib/solaar/ui/perkey/canvas.py
+++ b/lib/solaar/ui/perkey/canvas.py
@@ -229,9 +229,12 @@ class KeyboardCanvas(Gtk.DrawingArea):
             logger.debug("text rendering failed for %r: %s", label, e)
 
     def _fill_checker(self, cr, x, y, w, h) -> None:
-        # Diagonal hash for "no change" cells. Background uses the zone base
-        # color (what these cells actually display on the keyboard); stripes
-        # pick a black or white contrast based on luminance.
+        # Diagonal hash for "no change" cells. The background is the zone
+        # base color (what these cells actually display on the keyboard).
+        # Stripes alternate darker / lighter than base in equal measure so
+        # the cell's perceived average stays at the base color, instead of
+        # being uniformly biased toward black or white as a single-overlay
+        # stripe would.
         cr.save()
         self._round_rect(cr, x, y, w, h, 4)
         cr.clip()
@@ -240,26 +243,61 @@ class KeyboardCanvas(Gtk.DrawingArea):
             r = ((base >> 16) & 0xFF) / 255.0
             g = ((base >> 8) & 0xFF) / 255.0
             b = (base & 0xFF) / 255.0
+            cr.set_source_rgba(r, g, b, 1.0)
+            cr.rectangle(x, y, w, h)
+            cr.fill()
+            # Per-channel ±offset. When a channel is too close to 0 or 1 to
+            # fit the full offset, halve the offset on the constrained side
+            # (per spec: average drifts at the limits, but stays centered on
+            # base elsewhere).
+            offset = 0.22
+
+            def _shift(v: float) -> tuple[float, float]:
+                down_off = offset if (v - offset) >= 0.0 else offset / 2.0
+                up_off = offset if (v + offset) <= 1.0 else offset / 2.0
+                return max(0.0, v - down_off), min(1.0, v + up_off)
+
+            rd, ru = _shift(r)
+            gd, gu = _shift(g)
+            bd, bu = _shift(b)
+            # Interleave darker and lighter stripes (period = step per set,
+            # other-color set offset by step/2). Equal coverage of the two
+            # colors keeps the perceived average at base.
+            cr.set_line_width(1.5)
+            step = 6
+            half = step // 2
+            d_max = int(w + h)
+            cr.set_source_rgba(rd, gd, bd, 1.0)
+            d = -int(h)
+            while d <= d_max:
+                cr.move_to(x + d, y + h)
+                cr.line_to(x + d + h, y)
+                cr.stroke()
+                d += step
+            cr.set_source_rgba(ru, gu, bu, 1.0)
+            d = -int(h) + half
+            while d <= d_max:
+                cr.move_to(x + d, y + h)
+                cr.line_to(x + d + h, y)
+                cr.stroke()
+                d += step
         else:
-            r = g = 0.30
-            b = 0.32
-        cr.set_source_rgba(r, g, b, 1.0)
-        cr.rectangle(x, y, w, h)
-        cr.fill()
-        if base is not None and base >= 0:
-            lum = 0.299 * r + 0.587 * g + 0.114 * b
-            cr.set_source_rgba(0, 0, 0, 0.45) if lum > 0.55 else cr.set_source_rgba(1, 1, 1, 0.35)
-        else:
+            # No zone base color known — fall back to a neutral dark bg with
+            # medium-gray stripes; "average = base" doesn't apply since there
+            # is no expected color to preserve.
+            cr.set_source_rgba(0.30, 0.30, 0.32, 1.0)
+            cr.rectangle(x, y, w, h)
+            cr.fill()
             cr.set_source_rgba(0.55, 0.55, 0.60, 1.0)
-        cr.set_line_width(1.5)
-        step = 5
-        d_max = int(w + h)
-        d = -int(h)
-        while d <= d_max:
-            cr.move_to(x + d, y + h)
-            cr.line_to(x + d + h, y)
-            cr.stroke()
-            d += step
+            cr.set_line_width(1.5)
+            step = 5
+            d_max = int(w + h)
+            d = -int(h)
+            while d <= d_max:
+                cr.move_to(x + d, y + h)
+                cr.line_to(x + d + h, y)
+                cr.stroke()
+                d += step
         cr.restore()
 
     def _round_rect(self, cr, x, y, w, h, r) -> None:

--- a/lib/solaar/ui/perkey/control.py
+++ b/lib/solaar/ui/perkey/control.py
@@ -248,5 +248,17 @@ class PerKeyControl(Gtk.Box):
             "zone_count": len(self._sink.zones),
         }
         layout = layout_for(feature_int, hint)
-        dlg = dialog_mod.get_dialog()
+        # Stable per-device key so the same physical device on USB and on
+        # the receiver shares a single dialog. unitId is read from the
+        # device firmware (via DeviceInformation) and is the same across
+        # transports; serial is per-pairing-slot. id(self._sink) is a
+        # last-resort fallback that should never be hit in practice.
+        key = (
+            getattr(device, "unitId", None)
+            or getattr(device, "serial", None)
+            or getattr(device, "hid_serial", None)
+            or getattr(device, "codename", None)
+            or id(self._sink)
+        )
+        dlg = dialog_mod.get_dialog(key)
         dlg.present(self._sink, layout)

--- a/lib/solaar/ui/perkey/dialog.py
+++ b/lib/solaar/ui/perkey/dialog.py
@@ -14,11 +14,18 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""Singleton dialog hosting a PerKeyEditor for one sink at a time."""
+"""Per-device dialogs hosting a PerKeyEditor.
+
+One dialog instance is kept per device key (firmware unit-id, falling
+back to other stable identifiers — see ``get_dialog``). The same
+physical device on different transports (receiver vs direct USB) shares
+a key so it doesn't open two windows.
+"""
 
 from __future__ import annotations
 
 from enum import Enum
+from typing import Hashable
 
 import gi
 
@@ -36,51 +43,77 @@ class GtkSignal(Enum):
     DELETE_EVENT = "delete-event"
 
 
-class PerKeyEditorDialog:
-    _instance: "PerKeyEditorDialog | None" = None
+_dialogs: dict[Hashable, "PerKeyEditorDialog"] = {}
 
-    def __init__(self) -> None:
-        self._window = Gtk.Window()
-        self._window.set_title(_("Per-key Lighting"))
-        # No default size or geometry hints — the editor's content size
-        # (driven by KeyboardCanvas's size_request) determines the window size
-        # via the ScrolledWindow's propagate_natural_size. Wide keyboards open
-        # large; small mice open small.
-        self._window.connect(GtkSignal.DELETE_EVENT.value, self._on_delete)
+
+class PerKeyEditorDialog:
+    def __init__(self, key: Hashable) -> None:
+        self._key = key
+        self._window: Gtk.Window | None = None
+        self._wrapper: Gtk.Box | None = None
         self._editor: PerKeyEditor | None = None
+        self._sink: PerKeyColorSink | None = None
+
+    def _on_delete(self, _w, _e) -> bool:
+        self._destroy()
+        _dialogs.pop(self._key, None)
+        return True
+
+    def _destroy(self) -> None:
+        if self._editor is not None:
+            self._editor.shutdown()
+            self._editor = None
+        if self._window is not None:
+            self._window.destroy()
+            self._window = None
+            self._wrapper = None
+        self._sink = None
+
+    def present(self, sink: PerKeyColorSink, layout: Layout | None) -> None:
+        # Re-opening for the same sink while the window is already open:
+        # just raise it (no rebuild flicker, preserves any in-progress
+        # interaction state).
+        if self._window is not None and self._sink is sink:
+            self._window.present()
+            return
+        # Otherwise build a fresh window. We always recreate rather than
+        # swap content in place because Gtk.Window.resize() after first
+        # show is unreliable across X11/Wayland WMs — the WM often keeps
+        # the original geometry — and a new window picks up the layout's
+        # natural size cleanly on first show.
+        self._destroy()
+        self._sink = sink
+        self._window = Gtk.Window()
+        self._window.set_title(_("Per-key Lighting") + " — " + sink.title)
+        self._window.connect(GtkSignal.DELETE_EVENT.value, self._on_delete)
         self._wrapper = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
         self._wrapper.set_border_width(8)
         self._window.add(self._wrapper)
-
-    def _on_delete(self, _w, _e) -> bool:
-        self._window.hide()
-        if self._editor is not None:
-            self._editor.shutdown()
-            self._wrapper.remove(self._editor)
-            self._editor = None
-        return True
-
-    def present(self, sink: PerKeyColorSink, layout: Layout | None) -> None:
-        if self._editor is not None:
-            self._editor.shutdown()
-            self._wrapper.remove(self._editor)
-            self._editor = None
         self._editor = PerKeyEditor(sink, layout)
         self._wrapper.pack_start(self._editor, True, True, 0)
         self._wrapper.show_all()
-        self._window.set_title(_("Per-key Lighting") + " — " + sink.title)
         # Ask GTK what the wrapper actually wants to be — the canvas's
         # size_request propagates up through ScrolledWindow + editor VBox
         # (toolbar + scrolled canvas) + the wrapper's border, so the
-        # natural size already accounts for every layout contribution
-        # rather than hardcoding "toolbar ~50, border 8 each side".
+        # natural size already accounts for every layout contribution.
         _min, nat = self._wrapper.get_preferred_size()
         if nat.width > 0 and nat.height > 0:
             self._window.resize(nat.width, nat.height)
         self._window.present()
 
 
-def get_dialog() -> PerKeyEditorDialog:
-    if PerKeyEditorDialog._instance is None:
-        PerKeyEditorDialog._instance = PerKeyEditorDialog()
-    return PerKeyEditorDialog._instance
+def get_dialog(key: Hashable) -> PerKeyEditorDialog:
+    """Return the dialog for `key`, creating one if none is open.
+
+    `key` should be a stable per-device identifier. The caller (control.py)
+    builds it from `device.unitId` first — that's read from the device
+    firmware via the DeviceInformation feature and is the same regardless
+    of whether the device is on a receiver or plugged directly via USB,
+    so the same physical device doesn't open two windows when its
+    transport changes.
+    """
+    d = _dialogs.get(key)
+    if d is None:
+        d = PerKeyEditorDialog(key)
+        _dialogs[key] = d
+    return d

--- a/lib/solaar/ui/perkey/dialog.py
+++ b/lib/solaar/ui/perkey/dialog.py
@@ -69,15 +69,14 @@ class PerKeyEditorDialog:
         self._wrapper.pack_start(self._editor, True, True, 0)
         self._wrapper.show_all()
         self._window.set_title(_("Per-key Lighting") + " — " + sink.title)
-        # Resize to fit canvas + toolbar. ScrolledWindow's *minimum* is tiny
-        # (one row's worth) regardless of propagate_natural_size, so we have
-        # to compute the target ourselves from the canvas's size_request.
-        canvas_w, canvas_h = self._editor.canvas_size()
-        if canvas_w > 0 and canvas_h > 0:
-            # Toolbar ~50px, wrapper border 8px each side, scrollbar slack ~4.
-            target_w = canvas_w + 32
-            target_h = canvas_h + 80
-            self._window.resize(target_w, target_h)
+        # Ask GTK what the wrapper actually wants to be — the canvas's
+        # size_request propagates up through ScrolledWindow + editor VBox
+        # (toolbar + scrolled canvas) + the wrapper's border, so the
+        # natural size already accounts for every layout contribution
+        # rather than hardcoding "toolbar ~50, border 8 each side".
+        _min, nat = self._wrapper.get_preferred_size()
+        if nat.width > 0 and nat.height > 0:
+            self._window.resize(nat.width, nat.height)
         self._window.present()
 
 

--- a/lib/solaar/ui/perkey/editor.py
+++ b/lib/solaar/ui/perkey/editor.py
@@ -126,6 +126,9 @@ class PerKeyEditor(Gtk.Box):
         scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         scroll.set_propagate_natural_width(True)
         scroll.set_propagate_natural_height(True)
+        # Inset frame around the keyboard so it reads as a distinct panel
+        # rather than floating flat against the dialog background.
+        scroll.set_shadow_type(Gtk.ShadowType.IN)
         self._canvas = KeyboardCanvas()
         self._canvas.connect(GtkSignal.PAINT.value, self._on_canvas_paint)
         scroll.add(self._canvas)

--- a/lib/solaar/ui/perkey/editor.py
+++ b/lib/solaar/ui/perkey/editor.py
@@ -25,18 +25,16 @@ from __future__ import annotations
 import logging
 
 from enum import Enum
-from pathlib import Path
 
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import GdkPixbuf  # NOQA: E402
-from gi.repository import Gio  # NOQA: E402
 from gi.repository import Gtk  # NOQA: E402
 
 from solaar.i18n import _  # NOQA: E402
 
 from . import binding  # NOQA: E402
+from ._icons import themed_icon_image  # NOQA: E402
 from .canvas import KeyboardCanvas  # NOQA: E402
 from .layout import Layout  # NOQA: E402
 from .palette import GradientSwatch  # NOQA: E402
@@ -65,59 +63,6 @@ _TOOL_ICON_NAMES = {
     "rect": "solaar-tool-rect-symbolic",
     "bucket": "solaar-tool-bucket-symbolic",
 }
-_TOOL_ICON_PIXEL_SIZE = 22
-
-_icon_search_path_added = False
-
-
-def _ensure_tool_icon_path() -> None:
-    """Register share/solaar/icons with the default GtkIconTheme so our
-    custom symbolic tool icons resolve by name. Idempotent."""
-    global _icon_search_path_added
-    if _icon_search_path_added:
-        return
-    theme = Gtk.IconTheme.get_default()
-    existing = set(theme.get_search_path() or [])
-    # Source-tree path: lib/solaar/ui/perkey/editor.py -> parents[4] = repo root
-    candidates = [
-        Path(__file__).resolve().parents[4] / "share" / "solaar" / "icons",
-    ]
-    for c in candidates:
-        if c.is_dir() and str(c) not in existing:
-            theme.append_search_path(str(c))
-    _icon_search_path_added = True
-
-
-def _tool_icon_image(icon_name: str, style_widget: Gtk.Widget) -> Gtk.Image | None:
-    """Load a Solaar tool icon and recolor it to match the given widget's
-    text foreground color, so the icons follow the active GTK theme
-    (light / dark / custom). Returns None if the icon can't be loaded.
-
-    GTK's stock symbolic loader (`load_symbolic_for_context`) only recolors
-    specific palette stand-ins (e.g. fill="#bebebe"); it ignores
-    `stroke="currentColor"`. We bypass it and substitute currentColor
-    ourselves so any SVG using the currentColor convention works.
-    """
-    _ensure_tool_icon_path()
-    theme = Gtk.IconTheme.get_default()
-    icon_info = theme.lookup_icon(icon_name, _TOOL_ICON_PIXEL_SIZE, Gtk.IconLookupFlags.FORCE_SIZE)
-    if icon_info is None:
-        return None
-    path = icon_info.get_filename()
-    if not path:
-        return None
-    fg = style_widget.get_style_context().get_color(Gtk.StateFlags.NORMAL)
-    color = f"#{int(fg.red * 255):02x}{int(fg.green * 255):02x}{int(fg.blue * 255):02x}"
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            svg = f.read()
-        svg = svg.replace("currentColor", color)
-        stream = Gio.MemoryInputStream.new_from_data(svg.encode("utf-8"))
-        pixbuf = GdkPixbuf.Pixbuf.new_from_stream_at_scale(stream, _TOOL_ICON_PIXEL_SIZE, _TOOL_ICON_PIXEL_SIZE, True)
-        return Gtk.Image.new_from_pixbuf(pixbuf)
-    except Exception as e:
-        logger.debug("recolor failed for %s: %s", icon_name, e)
-        return None
 
 
 class PerKeyEditor(Gtk.Box):
@@ -148,7 +93,7 @@ class PerKeyEditor(Gtk.Box):
                 icon_name = _TOOL_ICON_NAMES.get(name)
                 btn = Gtk.RadioButton.new_from_widget(first)
                 btn.set_mode(False)  # render as toggle button rather than radio
-                image = _tool_icon_image(icon_name, btn) if icon_name else None
+                image = themed_icon_image(icon_name, btn) if icon_name else None
                 if image is not None:
                     btn.add(image)
                     btn.set_tooltip_text(tip or label)
@@ -209,7 +154,6 @@ class PerKeyEditor(Gtk.Box):
             logger.debug("zone_base_color read failed: %s", e)
             base = None
         self._canvas.set_zone_base_color(base)
-        self._palette.set_zone_base_color(base)
         self._refresh_layout()
         self._sync_from_sink()
         self._unsubscribe = sink.subscribe(self._on_sink_update)
@@ -227,12 +171,16 @@ class PerKeyEditor(Gtk.Box):
             except Exception as e:
                 logger.debug("theme signal disconnect failed: %s", e)
         self._theme_signal_handlers = []
+        try:
+            self._palette.shutdown()
+        except Exception as e:
+            logger.debug("palette shutdown failed: %s", e)
 
     def _on_gtk_theme_changed(self, _settings, _pspec) -> None:
         """Rebuild themed tool icons so they match the new theme's foreground."""
         for btn, icon_name in self._themed_icon_buttons.items():
             old = btn.get_child()
-            new_image = _tool_icon_image(icon_name, btn)
+            new_image = themed_icon_image(icon_name, btn)
             if new_image is None:
                 continue
             if old is not None:

--- a/lib/solaar/ui/perkey/editor.py
+++ b/lib/solaar/ui/perkey/editor.py
@@ -25,10 +25,13 @@ from __future__ import annotations
 import logging
 
 from enum import Enum
+from pathlib import Path
 
 import gi
 
 gi.require_version("Gtk", "3.0")
+from gi.repository import GdkPixbuf  # NOQA: E402
+from gi.repository import Gio  # NOQA: E402
 from gi.repository import Gtk  # NOQA: E402
 
 from solaar.i18n import _  # NOQA: E402
@@ -57,6 +60,64 @@ _TOOL_LABELS = {
 _TOOL_TOOLTIPS = {
     "gradient": _("Drag to fade from previous color to active color"),
 }
+_TOOL_ICON_NAMES = {
+    "single": "solaar-tool-brush-symbolic",
+    "rect": "solaar-tool-rect-symbolic",
+    "bucket": "solaar-tool-bucket-symbolic",
+}
+_TOOL_ICON_PIXEL_SIZE = 22
+
+_icon_search_path_added = False
+
+
+def _ensure_tool_icon_path() -> None:
+    """Register share/solaar/icons with the default GtkIconTheme so our
+    custom symbolic tool icons resolve by name. Idempotent."""
+    global _icon_search_path_added
+    if _icon_search_path_added:
+        return
+    theme = Gtk.IconTheme.get_default()
+    existing = set(theme.get_search_path() or [])
+    # Source-tree path: lib/solaar/ui/perkey/editor.py -> parents[4] = repo root
+    candidates = [
+        Path(__file__).resolve().parents[4] / "share" / "solaar" / "icons",
+    ]
+    for c in candidates:
+        if c.is_dir() and str(c) not in existing:
+            theme.append_search_path(str(c))
+    _icon_search_path_added = True
+
+
+def _tool_icon_image(icon_name: str, style_widget: Gtk.Widget) -> Gtk.Image | None:
+    """Load a Solaar tool icon and recolor it to match the given widget's
+    text foreground color, so the icons follow the active GTK theme
+    (light / dark / custom). Returns None if the icon can't be loaded.
+
+    GTK's stock symbolic loader (`load_symbolic_for_context`) only recolors
+    specific palette stand-ins (e.g. fill="#bebebe"); it ignores
+    `stroke="currentColor"`. We bypass it and substitute currentColor
+    ourselves so any SVG using the currentColor convention works.
+    """
+    _ensure_tool_icon_path()
+    theme = Gtk.IconTheme.get_default()
+    icon_info = theme.lookup_icon(icon_name, _TOOL_ICON_PIXEL_SIZE, Gtk.IconLookupFlags.FORCE_SIZE)
+    if icon_info is None:
+        return None
+    path = icon_info.get_filename()
+    if not path:
+        return None
+    fg = style_widget.get_style_context().get_color(Gtk.StateFlags.NORMAL)
+    color = f"#{int(fg.red * 255):02x}{int(fg.green * 255):02x}{int(fg.blue * 255):02x}"
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            svg = f.read()
+        svg = svg.replace("currentColor", color)
+        stream = Gio.MemoryInputStream.new_from_data(svg.encode("utf-8"))
+        pixbuf = GdkPixbuf.Pixbuf.new_from_stream_at_scale(stream, _TOOL_ICON_PIXEL_SIZE, _TOOL_ICON_PIXEL_SIZE, True)
+        return Gtk.Image.new_from_pixbuf(pixbuf)
+    except Exception as e:
+        logger.debug("recolor failed for %s: %s", icon_name, e)
+        return None
 
 
 class PerKeyEditor(Gtk.Box):
@@ -81,9 +142,17 @@ class PerKeyEditor(Gtk.Box):
                 btn.set_tooltip_text(_TOOL_TOOLTIPS["gradient"])
             else:
                 label, tip = _TOOL_LABELS.get(name, (name, ""))
-                btn = Gtk.RadioButton.new_with_label_from_widget(first, label)
+                icon_name = _TOOL_ICON_NAMES.get(name)
+                btn = Gtk.RadioButton.new_from_widget(first)
                 btn.set_mode(False)  # render as toggle button rather than radio
-                btn.set_tooltip_text(tip)
+                image = _tool_icon_image(icon_name, btn) if icon_name else None
+                if image is not None:
+                    btn.add(image)
+                    btn.set_tooltip_text(tip or label)
+                    btn.get_accessible().set_name(label)
+                else:
+                    btn.set_label(label)
+                    btn.set_tooltip_text(tip)
             btn.connect(GtkSignal.TOGGLED.value, self._on_tool_toggled, name)
             if first is None:
                 first = btn

--- a/lib/solaar/ui/perkey/editor.py
+++ b/lib/solaar/ui/perkey/editor.py
@@ -34,7 +34,7 @@ from gi.repository import Gtk  # NOQA: E402
 from solaar.i18n import _  # NOQA: E402
 
 from . import binding  # NOQA: E402
-from ._icons import themed_icon_image  # NOQA: E402
+from ._icons import attach_themed_icon  # NOQA: E402
 from .canvas import KeyboardCanvas  # NOQA: E402
 from .layout import Layout  # NOQA: E402
 from .palette import GradientSwatch  # NOQA: E402
@@ -75,9 +75,6 @@ class PerKeyEditor(Gtk.Box):
         # toolbar row
         toolbar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         self._tool_buttons: dict[str, Gtk.RadioButton] = {}
-        # Track which buttons display a themed icon, so we can re-render them
-        # when the active GTK theme switches (light <-> dark, theme name).
-        self._themed_icon_buttons: dict[Gtk.RadioButton, str] = {}
         self._gradient_swatch: GradientSwatch | None = None
         first: Gtk.RadioButton | None = None
         supported = layout.supported_tools if layout else ("single", "rect", "bucket", "gradient")
@@ -93,12 +90,9 @@ class PerKeyEditor(Gtk.Box):
                 icon_name = _TOOL_ICON_NAMES.get(name)
                 btn = Gtk.RadioButton.new_from_widget(first)
                 btn.set_mode(False)  # render as toggle button rather than radio
-                image = themed_icon_image(icon_name, btn) if icon_name else None
-                if image is not None:
-                    btn.add(image)
+                if icon_name and attach_themed_icon(btn, icon_name) is not None:
                     btn.set_tooltip_text(tip or label)
                     btn.get_accessible().set_name(label)
-                    self._themed_icon_buttons[btn] = icon_name
                 else:
                     btn.set_label(label)
                     btn.set_tooltip_text(tip)
@@ -107,14 +101,6 @@ class PerKeyEditor(Gtk.Box):
                 first = btn
             toolbar.pack_start(btn, False, False, 0)
             self._tool_buttons[name] = btn
-
-        # Re-render themed icons when the GTK theme changes at runtime.
-        self._theme_signal_handlers: list[tuple[object, int]] = []
-        if self._themed_icon_buttons:
-            settings = Gtk.Settings.get_default()
-            for prop in ("notify::gtk-theme-name", "notify::gtk-application-prefer-dark-theme"):
-                hid = settings.connect(prop, self._on_gtk_theme_changed)
-                self._theme_signal_handlers.append((settings, hid))
 
         initial_active, initial_previous = 0xFF0000, 0xFF0000
         try:
@@ -165,28 +151,10 @@ class PerKeyEditor(Gtk.Box):
             except Exception as e:
                 logger.debug("perkey sink unsubscribe failed: %s", e)
             self._unsubscribe = None
-        for obj, hid in self._theme_signal_handlers:
-            try:
-                obj.disconnect(hid)
-            except Exception as e:
-                logger.debug("theme signal disconnect failed: %s", e)
-        self._theme_signal_handlers = []
         try:
             self._palette.shutdown()
         except Exception as e:
             logger.debug("palette shutdown failed: %s", e)
-
-    def _on_gtk_theme_changed(self, _settings, _pspec) -> None:
-        """Rebuild themed tool icons so they match the new theme's foreground."""
-        for btn, icon_name in self._themed_icon_buttons.items():
-            old = btn.get_child()
-            new_image = themed_icon_image(icon_name, btn)
-            if new_image is None:
-                continue
-            if old is not None:
-                btn.remove(old)
-            btn.add(new_image)
-            new_image.show()
 
     def canvas_size(self) -> tuple[int, int]:
         """Return the canvas's pixel size_request — what the dialog should

--- a/lib/solaar/ui/perkey/editor.py
+++ b/lib/solaar/ui/perkey/editor.py
@@ -130,6 +130,9 @@ class PerKeyEditor(Gtk.Box):
         # toolbar row
         toolbar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         self._tool_buttons: dict[str, Gtk.RadioButton] = {}
+        # Track which buttons display a themed icon, so we can re-render them
+        # when the active GTK theme switches (light <-> dark, theme name).
+        self._themed_icon_buttons: dict[Gtk.RadioButton, str] = {}
         self._gradient_swatch: GradientSwatch | None = None
         first: Gtk.RadioButton | None = None
         supported = layout.supported_tools if layout else ("single", "rect", "bucket", "gradient")
@@ -150,6 +153,7 @@ class PerKeyEditor(Gtk.Box):
                     btn.add(image)
                     btn.set_tooltip_text(tip or label)
                     btn.get_accessible().set_name(label)
+                    self._themed_icon_buttons[btn] = icon_name
                 else:
                     btn.set_label(label)
                     btn.set_tooltip_text(tip)
@@ -158,6 +162,14 @@ class PerKeyEditor(Gtk.Box):
                 first = btn
             toolbar.pack_start(btn, False, False, 0)
             self._tool_buttons[name] = btn
+
+        # Re-render themed icons when the GTK theme changes at runtime.
+        self._theme_signal_handlers: list[tuple[object, int]] = []
+        if self._themed_icon_buttons:
+            settings = Gtk.Settings.get_default()
+            for prop in ("notify::gtk-theme-name", "notify::gtk-application-prefer-dark-theme"):
+                hid = settings.connect(prop, self._on_gtk_theme_changed)
+                self._theme_signal_handlers.append((settings, hid))
 
         initial_active, initial_previous = 0xFF0000, 0xFF0000
         try:
@@ -209,6 +221,24 @@ class PerKeyEditor(Gtk.Box):
             except Exception as e:
                 logger.debug("perkey sink unsubscribe failed: %s", e)
             self._unsubscribe = None
+        for obj, hid in self._theme_signal_handlers:
+            try:
+                obj.disconnect(hid)
+            except Exception as e:
+                logger.debug("theme signal disconnect failed: %s", e)
+        self._theme_signal_handlers = []
+
+    def _on_gtk_theme_changed(self, _settings, _pspec) -> None:
+        """Rebuild themed tool icons so they match the new theme's foreground."""
+        for btn, icon_name in self._themed_icon_buttons.items():
+            old = btn.get_child()
+            new_image = _tool_icon_image(icon_name, btn)
+            if new_image is None:
+                continue
+            if old is not None:
+                btn.remove(old)
+            btn.add(new_image)
+            new_image.show()
 
     def canvas_size(self) -> tuple[int, int]:
         """Return the canvas's pixel size_request — what the dialog should

--- a/lib/solaar/ui/perkey/editor.py
+++ b/lib/solaar/ui/perkey/editor.py
@@ -156,12 +156,6 @@ class PerKeyEditor(Gtk.Box):
         except Exception as e:
             logger.debug("palette shutdown failed: %s", e)
 
-    def canvas_size(self) -> tuple[int, int]:
-        """Return the canvas's pixel size_request — what the dialog should
-        size its content area to so the layout fits without scrollbars.
-        """
-        return self._canvas.get_size_request()
-
     def _refresh_layout(self) -> None:
         if self._layout is None:
             # No registered layout: lay out all reported zones as a flat strip.

--- a/lib/solaar/ui/perkey/layouts/mouse_g502x.py
+++ b/lib/solaar/ui/perkey/layouts/mouse_g502x.py
@@ -16,12 +16,12 @@
 
 """LED layout for the G502 X family (G502 X, G502 X PLUS, G502 X LIGHTSPEED).
 
-Eight LEDs (A..H) reported as zones 1..8 by the firmware. Positions may
-need revision per actual hardware.
+Eight LEDs reported as zones 1..8 by the firmware. Positions may need
+revision per actual hardware.
 
-    Row 0:  C  .  .  .  .  .  B
-    Row 1:  .  D  H  G  F  E  .
-    Row 2:  .  .  .  .  .  .  A
+    Row 0:  3  .  .  .  .  .  2
+    Row 1:  .  4  8  7  6  5  .
+    Row 2:  .  .  .  .  .  .  1
 """
 
 from __future__ import annotations
@@ -30,14 +30,14 @@ from ..layout import Cell
 from ..layout import Layout
 
 _CELLS: tuple[Cell, ...] = (
-    Cell(zone_id=1, row=2, col=6, group="main", label="A"),
-    Cell(zone_id=2, row=0, col=6, group="main", label="B"),
-    Cell(zone_id=3, row=0, col=0, group="main", label="C"),
-    Cell(zone_id=4, row=1, col=1, group="main", label="D"),
-    Cell(zone_id=5, row=1, col=5, group="main", label="E"),
-    Cell(zone_id=6, row=1, col=4, group="main", label="F"),
-    Cell(zone_id=7, row=1, col=3, group="main", label="G"),
-    Cell(zone_id=8, row=1, col=2, group="main", label="H"),
+    Cell(zone_id=1, row=2, col=6, group="main", label="1"),
+    Cell(zone_id=2, row=0, col=6, group="main", label="2"),
+    Cell(zone_id=3, row=0, col=0, group="main", label="3"),
+    Cell(zone_id=4, row=1, col=1, group="main", label="4"),
+    Cell(zone_id=5, row=1, col=5, group="main", label="5"),
+    Cell(zone_id=6, row=1, col=4, group="main", label="6"),
+    Cell(zone_id=7, row=1, col=3, group="main", label="7"),
+    Cell(zone_id=8, row=1, col=2, group="main", label="8"),
 )
 
 

--- a/lib/solaar/ui/perkey/palette.py
+++ b/lib/solaar/ui/perkey/palette.py
@@ -211,7 +211,13 @@ class GradientSwatch(Gtk.DrawingArea):
         cr.clip()
         # Top-left (previous, gradient start) → bottom-right (active, end).
         # Matches the directional behavior of dragging the line tool TL → BR.
-        pat = cairo.LinearGradient(3, 3, 21, 21)
+        # Endpoints are shifted inward by the arc inset (corner radius * (1
+        # - 1/sqrt(2)), ~0.586 for r=2) so t=0 lands on the actual visible
+        # TL corner pixel of the rounded rect — without this, the rendered
+        # corners sample at t≈0.033/0.967 and the displayed colors are
+        # ~8 RGB units short of the true endpoint colors.
+        inset = 2 * (1 - 1 / (2**0.5))
+        pat = cairo.LinearGradient(3 + inset, 3 + inset, 21 - inset, 21 - inset)
         pat.add_color_stop_rgb(0.0, *rgb(self._previous))
         pat.add_color_stop_rgb(1.0, *rgb(self._active))
         cr.set_source(pat)

--- a/lib/solaar/ui/perkey/palette.py
+++ b/lib/solaar/ui/perkey/palette.py
@@ -159,6 +159,10 @@ class GradientSwatch(Gtk.DrawingArea):
         self._active: int = 0xFF0000
         self._previous: int = 0xFF0000
         self.connect(GtkSignal.DRAW.value, self._on_draw)
+        # Re-render when the GTK theme changes, so the rounded-square
+        # outline (drawn in the theme foreground color) stays in sync
+        # with the tool icons next to it.
+        self.connect("style-updated", lambda w: w.queue_draw())
 
     def update(self, active: int, previous: int) -> None:
         self._active = int(active)
@@ -175,27 +179,51 @@ class GradientSwatch(Gtk.DrawingArea):
         """Return (active, previous) — the colors the gradient tool will paint with."""
         return (self._active, self._previous)
 
+    @staticmethod
+    def _rounded_rect_path(cr, x: float, y: float, w: float, h: float, r: float) -> None:
+        cr.new_sub_path()
+        cr.arc(x + w - r, y + r, r, -1.5708, 0)
+        cr.arc(x + w - r, y + h - r, r, 0, 1.5708)
+        cr.arc(x + r, y + h - r, r, 1.5708, 3.1416)
+        cr.arc(x + r, y + r, r, 3.1416, 4.7124)
+        cr.close_path()
+
     def _on_draw(self, _w, cr) -> None:
         import cairo  # local: keeps the module light when GradientSwatch isn't built
-
-        s = self.SIZE
 
         def rgb(c: int) -> tuple[float, float, float]:
             if c is None or c < 0:
                 return (0.5, 0.5, 0.5)
             return (((c >> 16) & 0xFF) / 255.0, ((c >> 8) & 0xFF) / 255.0, (c & 0xFF) / 255.0)
 
+        # Render in Tabler "square" coordinates (24x24 viewBox, rounded
+        # rect from (3,3) to (21,21), corner radius 2, stroke 2) and let
+        # cairo scale to the swatch's pixel size. Matches the outline
+        # style of the tool icons exactly.
+        cr.save()
+        cr.scale(self.SIZE / 24.0, self.SIZE / 24.0)
+
+        # Build the rounded-square path once, clip+fill the gradient
+        # inside it, then re-build and stroke the outline in the theme
+        # foreground color.
+        self._rounded_rect_path(cr, 3, 3, 18, 18, 2)
+        cr.save()
+        cr.clip()
         # Top-left (previous, gradient start) → bottom-right (active, end).
         # Matches the directional behavior of dragging the line tool TL → BR.
-        pat = cairo.LinearGradient(0, 0, s, s)
+        pat = cairo.LinearGradient(3, 3, 21, 21)
         pat.add_color_stop_rgb(0.0, *rgb(self._previous))
         pat.add_color_stop_rgb(1.0, *rgb(self._active))
         cr.set_source(pat)
-        cr.rectangle(0, 0, s, s)
+        cr.rectangle(3, 3, 18, 18)
         cr.fill()
+        cr.restore()  # drop clip
 
-        # Subtle border so the swatch reads as a control even on similar bg.
-        cr.set_source_rgba(0, 0, 0, 0.45)
-        cr.set_line_width(1.0)
-        cr.rectangle(0.5, 0.5, s - 1, s - 1)
+        self._rounded_rect_path(cr, 3, 3, 18, 18, 2)
+        fg = self.get_style_context().get_color(Gtk.StateFlags.NORMAL)
+        cr.set_source_rgba(fg.red, fg.green, fg.blue, fg.alpha)
+        cr.set_line_width(2)
+        cr.set_line_join(cairo.LINE_JOIN_ROUND)
+        cr.set_line_cap(cairo.LINE_CAP_ROUND)
         cr.stroke()
+        cr.restore()

--- a/lib/solaar/ui/perkey/palette.py
+++ b/lib/solaar/ui/perkey/palette.py
@@ -24,8 +24,6 @@ itself — see `GradientSwatch` below, used by `editor.py`.
 
 from __future__ import annotations
 
-import logging
-
 from enum import Enum
 
 import gi
@@ -37,9 +35,7 @@ from gi.repository import Gtk  # NOQA: E402
 
 from solaar.i18n import _  # NOQA: E402
 
-from ._icons import themed_icon_image  # NOQA: E402
-
-logger = logging.getLogger(__name__)
+from ._icons import attach_themed_icon  # NOQA: E402
 
 _UNSET_ICON_NAME = "solaar-tool-palette-off-symbolic"
 
@@ -97,42 +93,19 @@ class Palette(Gtk.Box):
 
         self._unset_btn = Gtk.ToggleButton()
         self._unset_btn.set_tooltip_text(_("Paint as 'no change' — clears the cell to the zone base color"))
-        self._unset_label = _("Unset")
-        self._unset_image = themed_icon_image(_UNSET_ICON_NAME, self._unset_btn)
-        if self._unset_image is not None:
-            self._unset_btn.add(self._unset_image)
-            self._unset_btn.get_accessible().set_name(self._unset_label)
+        unset_label = _("Unset")
+        if attach_themed_icon(self._unset_btn, _UNSET_ICON_NAME) is not None:
+            self._unset_btn.get_accessible().set_name(unset_label)
         else:
-            self._unset_btn.set_label(self._unset_label)
+            self._unset_btn.set_label(unset_label)
         self._unset_btn.connect(GtkSignal.TOGGLED.value, self._on_unset_toggled)
         self.pack_start(self._unset_btn, False, False, 0)
 
-        # Track theme changes so the unset icon re-renders to match.
-        self._theme_signal_handlers: list[tuple[object, int]] = []
-        if self._unset_image is not None:
-            settings = Gtk.Settings.get_default()
-            for prop in ("notify::gtk-theme-name", "notify::gtk-application-prefer-dark-theme"):
-                hid = settings.connect(prop, self._on_gtk_theme_changed)
-                self._theme_signal_handlers.append((settings, hid))
-
     def shutdown(self) -> None:
-        for obj, hid in self._theme_signal_handlers:
-            try:
-                obj.disconnect(hid)
-            except Exception as e:
-                logger.debug("palette theme signal disconnect failed: %s", e)
-        self._theme_signal_handlers = []
-
-    def _on_gtk_theme_changed(self, _settings, _pspec) -> None:
-        new_image = themed_icon_image(_UNSET_ICON_NAME, self._unset_btn)
-        if new_image is None:
-            return
-        old = self._unset_btn.get_child()
-        if old is not None:
-            self._unset_btn.remove(old)
-        self._unset_btn.add(new_image)
-        new_image.show()
-        self._unset_image = new_image
+        # attach_themed_icon connects to the button's own style-updated
+        # signal; GTK disconnects it automatically when the button is
+        # destroyed, so there is nothing to clean up here.
+        pass
 
     def _on_color_set(self, btn: Gtk.ColorButton) -> None:
         c = _rgb_to_int(btn.get_rgba())

--- a/lib/solaar/ui/perkey/palette.py
+++ b/lib/solaar/ui/perkey/palette.py
@@ -24,6 +24,8 @@ itself — see `GradientSwatch` below, used by `editor.py`.
 
 from __future__ import annotations
 
+import logging
+
 from enum import Enum
 
 import gi
@@ -34,6 +36,12 @@ from gi.repository import GObject  # NOQA: E402
 from gi.repository import Gtk  # NOQA: E402
 
 from solaar.i18n import _  # NOQA: E402
+
+from ._icons import themed_icon_image  # NOQA: E402
+
+logger = logging.getLogger(__name__)
+
+_UNSET_ICON_NAME = "solaar-tool-palette-off-symbolic"
 
 
 class GtkSignal(Enum):
@@ -62,70 +70,6 @@ def _int_to_rgba(c: int) -> Gdk.RGBA:
     return rgba
 
 
-def _draw_hash(cr, x: float, y: float, size: float, base_color: int | None = None) -> None:
-    """Diagonal hash pattern used as the visual for "no change" / unset.
-
-    Background is the zone base color (the color these cells actually display
-    on the keyboard) when known; stripes pick a black or white contrast based
-    on luminance so the texture stays readable on any base.
-    """
-    cr.save()
-    cr.rectangle(x, y, size, size)
-    cr.clip()
-    if base_color is not None and base_color >= 0:
-        r = ((base_color >> 16) & 0xFF) / 255.0
-        g = ((base_color >> 8) & 0xFF) / 255.0
-        b = (base_color & 0xFF) / 255.0
-        cr.set_source_rgba(r, g, b, 1.0)
-    else:
-        r = g = 0.30
-        b = 0.32
-        cr.set_source_rgba(r, g, b, 1.0)
-    cr.rectangle(x, y, size, size)
-    cr.fill()
-    if base_color is not None and base_color >= 0:
-        lum = 0.299 * r + 0.587 * g + 0.114 * b
-        cr.set_source_rgba(0, 0, 0, 0.45) if lum > 0.55 else cr.set_source_rgba(1, 1, 1, 0.35)
-    else:
-        cr.set_source_rgba(0.55, 0.55, 0.60, 1.0)
-    cr.set_line_width(1.2)
-    step = 4
-    d = -int(size)
-    while d <= int(size):
-        cr.move_to(x + d, y + size)
-        cr.line_to(x + d + size, y)
-        cr.stroke()
-        d += step
-    cr.restore()
-
-
-class HashSwatch(Gtk.DrawingArea):
-    """Square showing the diagonal hash pattern; used as the visual on the
-    "unset" toggle button and matches how unset cells render on the canvas.
-    Set the zone base color via `set_base_color` so the swatch reflects what
-    "no change" cells actually display on the keyboard.
-    """
-
-    SIZE = 22
-
-    def __init__(self) -> None:
-        super().__init__()
-        self._base_color: int | None = None
-        self.set_size_request(self.SIZE, self.SIZE)
-        self.connect(GtkSignal.DRAW.value, self._on_draw)
-
-    def set_base_color(self, color: int | None) -> None:
-        self._base_color = None if color is None else int(color)
-        self.queue_draw()
-
-    def _on_draw(self, _w, cr) -> None:
-        _draw_hash(cr, 0, 0, float(self.SIZE), self._base_color)
-        cr.set_source_rgba(0, 0, 0, 0.45)
-        cr.set_line_width(1.0)
-        cr.rectangle(0.5, 0.5, self.SIZE - 1, self.SIZE - 1)
-        cr.stroke()
-
-
 # Sentinel for "no change" / unset paint. Matches special_keys.COLORSPLUS["No change"].
 UNSET_COLOR = -1
 
@@ -151,15 +95,44 @@ class Palette(Gtk.Box):
         self._color_btn.connect(GtkSignal.COLOR_SET.value, self._on_color_set)
         self.pack_start(self._color_btn, False, False, 0)
 
-        self._unset_swatch = HashSwatch()
         self._unset_btn = Gtk.ToggleButton()
         self._unset_btn.set_tooltip_text(_("Paint as 'no change' — clears the cell to the zone base color"))
-        self._unset_btn.add(self._unset_swatch)
+        self._unset_label = _("Unset")
+        self._unset_image = themed_icon_image(_UNSET_ICON_NAME, self._unset_btn)
+        if self._unset_image is not None:
+            self._unset_btn.add(self._unset_image)
+            self._unset_btn.get_accessible().set_name(self._unset_label)
+        else:
+            self._unset_btn.set_label(self._unset_label)
         self._unset_btn.connect(GtkSignal.TOGGLED.value, self._on_unset_toggled)
         self.pack_start(self._unset_btn, False, False, 0)
 
-    def set_zone_base_color(self, color: int | None) -> None:
-        self._unset_swatch.set_base_color(color)
+        # Track theme changes so the unset icon re-renders to match.
+        self._theme_signal_handlers: list[tuple[object, int]] = []
+        if self._unset_image is not None:
+            settings = Gtk.Settings.get_default()
+            for prop in ("notify::gtk-theme-name", "notify::gtk-application-prefer-dark-theme"):
+                hid = settings.connect(prop, self._on_gtk_theme_changed)
+                self._theme_signal_handlers.append((settings, hid))
+
+    def shutdown(self) -> None:
+        for obj, hid in self._theme_signal_handlers:
+            try:
+                obj.disconnect(hid)
+            except Exception as e:
+                logger.debug("palette theme signal disconnect failed: %s", e)
+        self._theme_signal_handlers = []
+
+    def _on_gtk_theme_changed(self, _settings, _pspec) -> None:
+        new_image = themed_icon_image(_UNSET_ICON_NAME, self._unset_btn)
+        if new_image is None:
+            return
+        old = self._unset_btn.get_child()
+        if old is not None:
+            self._unset_btn.remove(old)
+        self._unset_btn.add(new_image)
+        new_image.show()
+        self._unset_image = new_image
 
     def _on_color_set(self, btn: Gtk.ColorButton) -> None:
         c = _rgb_to_int(btn.get_rgba())

--- a/share/solaar/icons/THIRD_PARTY.md
+++ b/share/solaar/icons/THIRD_PARTY.md
@@ -13,6 +13,7 @@ copyright (c) 2020-2024 Paweł Kuna, distributed under the MIT License:
 - `solaar-tool-brush-symbolic.svg` — from `brush`
 - `solaar-tool-rect-symbolic.svg` — from `paint`
 - `solaar-tool-bucket-symbolic.svg` — from `bucket-droplet`
+- `solaar-tool-palette-off-symbolic.svg` — from `palette-off`
 
 ### MIT License (Tabler Icons)
 

--- a/share/solaar/icons/THIRD_PARTY.md
+++ b/share/solaar/icons/THIRD_PARTY.md
@@ -1,0 +1,41 @@
+# Third-party assets in this directory
+
+Solaar itself is licensed under GPL-2.0 (see `LICENSE.txt` at the repository
+root). Some icons in this directory are sourced from third-party projects
+under permissive licenses compatible with GPL-2.0. Their original license
+notices are preserved as comments inside each SVG file.
+
+## Tabler Icons
+
+The following SVGs are derived from [Tabler Icons](https://tabler.io/icons),
+copyright (c) 2020-2024 Paweł Kuna, distributed under the MIT License:
+
+- `solaar-tool-brush-symbolic.svg` — from `brush`
+- `solaar-tool-rect-symbolic.svg` — from `paint`
+- `solaar-tool-bucket-symbolic.svg` — from `bucket-droplet`
+
+### MIT License (Tabler Icons)
+
+```
+MIT License
+
+Copyright (c) 2020-2024 Paweł Kuna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/share/solaar/icons/solaar-tool-brush-symbolic.svg
+++ b/share/solaar/icons/solaar-tool-brush-symbolic.svg
@@ -1,0 +1,22 @@
+<!--
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: 2020-2024 Paweł Kuna
+Source: Tabler Icons (https://tabler.io/icons) - "brush"
+License: MIT (https://github.com/tabler/tabler-icons/blob/main/LICENSE)
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 21v-4a4 4 0 1 1 4 4h-4" />
+  <path d="M21 3a16 16 0 0 0 -12.8 10.2" />
+  <path d="M21 3a16 16 0 0 1 -10.2 12.8" />
+  <path d="M10.6 9a9 9 0 0 1 4.4 4.4" />
+</svg>

--- a/share/solaar/icons/solaar-tool-bucket-symbolic.svg
+++ b/share/solaar/icons/solaar-tool-bucket-symbolic.svg
@@ -1,0 +1,21 @@
+<!--
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: 2020-2024 Paweł Kuna
+Source: Tabler Icons (https://tabler.io/icons) - "bucket-droplet"
+License: MIT (https://github.com/tabler/tabler-icons/blob/main/LICENSE)
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 16l1.465 1.638a2 2 0 1 1 -3.015 .099l1.55 -1.737" />
+  <path d="M13.737 9.737c2.299 -2.3 3.23 -5.095 2.081 -6.245c-1.15 -1.15 -3.945 -.217 -6.244 2.082c-2.3 2.299 -3.231 5.095 -2.082 6.244c1.15 1.15 3.946 .218 6.245 -2.081" />
+  <path d="M7.492 11.818c.362 .362 .768 .676 1.208 .934l6.895 4.047c1.078 .557 2.255 -.075 3.692 -1.512c1.437 -1.437 2.07 -2.614 1.512 -3.692c-.372 -.718 -1.72 -3.017 -4.047 -6.895a6.015 6.015 0 0 0 -.934 -1.208" />
+</svg>

--- a/share/solaar/icons/solaar-tool-palette-off-symbolic.svg
+++ b/share/solaar/icons/solaar-tool-palette-off-symbolic.svg
@@ -1,0 +1,24 @@
+<!--
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: 2020-2024 Paweł Kuna
+Source: Tabler Icons (https://tabler.io/icons) - "palette-off"
+License: MIT (https://github.com/tabler/tabler-icons/blob/main/LICENSE)
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M15 15h-1a2 2 0 0 0 -1 3.75a1.3 1.3 0 0 1 -1 2.25a9 9 0 0 1 -6.372 -15.356" />
+  <path d="M8 4c1.236 -.623 2.569 -1 4 -1c4.97 0 9 3.582 9 8c0 1.06 -.474 2.078 -1.318 2.828a4.516 4.516 0 0 1 -1.127 .73" />
+  <path d="M7.5 10.5a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />
+  <path d="M11.5 7.5a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />
+  <path d="M15.5 10.5a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />
+  <path d="M3 3l18 18" />
+</svg>

--- a/share/solaar/icons/solaar-tool-rect-symbolic.svg
+++ b/share/solaar/icons/solaar-tool-rect-symbolic.svg
@@ -1,0 +1,21 @@
+<!--
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: 2020-2024 Paweł Kuna
+Source: Tabler Icons (https://tabler.io/icons) - "paint"
+License: MIT (https://github.com/tabler/tabler-icons/blob/main/LICENSE)
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 5a2 2 0 0 1 2 -2h10a2 2 0 0 1 2 2v2a2 2 0 0 1 -2 2h-10a2 2 0 0 1 -2 -2l0 -2" />
+  <path d="M19 6h1a2 2 0 0 1 2 2a5 5 0 0 1 -5 5l-5 0v2" />
+  <path d="M10 16a1 1 0 0 1 1 -1h2a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-2a1 1 0 0 1 -1 -1l0 -4" />
+</svg>

--- a/tests/logitech_receiver/test_common.py
+++ b/tests/logitech_receiver/test_common.py
@@ -65,6 +65,58 @@ def test_named_int_yaml():
     assert yaml_load == named_int
 
 
+def test_color_int_str_and_repr():
+    c = common.ColorInt(0xFC3300)
+    assert str(c) == "0xfc3300"
+    assert repr(c) == "0xfc3300"
+    assert int(c) == 0xFC3300
+
+
+def test_color_int_equality_with_plain_int():
+    assert common.ColorInt(0xFC3300) == 0xFC3300
+    assert isinstance(common.ColorInt(0), int)
+
+
+def test_color_int_from_hex_string_prefixes():
+    assert common.ColorInt("0xfc3300") == 0xFC3300
+    assert common.ColorInt("0XFC3300") == 0xFC3300
+    assert common.ColorInt("#fc3300") == 0xFC3300
+
+
+def test_color_int_from_int_passes_through():
+    assert common.ColorInt(0) == 0
+    assert common.ColorInt(0xFFFFFF) == 0xFFFFFF
+
+
+def test_color_int_out_of_range_falls_back_to_decimal():
+    # Sentinel values like COLORSPLUS["No change"] = -1 should still render
+    # in their natural form when wrapped (though they normally aren't).
+    assert str(common.ColorInt(-1)) == "-1"
+
+
+def test_color_int_yaml_dumps_as_hex_int_literal():
+    c = common.ColorInt(0xFC3300)
+    dumped = yaml.dump(c).strip()
+    assert dumped == "0xfc3300\n..." or dumped.startswith("0xfc3300")
+
+
+def test_color_int_yaml_roundtrips_to_plain_int():
+    # yaml.safe_load returns a plain int (yaml 1.1 hex literal parsing).
+    # The value matches; type promotion to ColorInt happens lazily at
+    # validator/setting boundaries.
+    c = common.ColorInt(0xFC3300)
+    loaded = yaml.safe_load(yaml.dump(c))
+    assert loaded == 0xFC3300
+
+
+def test_color_int_in_dict_yaml_dumps_each_value_as_hex():
+    data = {1: common.ColorInt(0xFC3300), 2: common.ColorInt(0x00FF00), 3: -1}
+    dumped = yaml.dump(data, default_flow_style=None, width=150).strip()
+    assert "0xfc3300" in dumped
+    assert "0x00ff00" in dumped
+    assert "-1" in dumped  # sentinel preserved
+
+
 def test_named_ints():
     named_ints = common.NamedInts(empty=0, critical=5, low=20, good=50, full=90)
 

--- a/tests/logitech_receiver/test_setting_templates.py
+++ b/tests/logitech_receiver/test_setting_templates.py
@@ -33,7 +33,7 @@ from logitech_receiver import special_keys
 from . import fake_hidpp
 
 # Per-key colors: any 24-bit RGB; matches PerKeyLighting.validator_class._COLOR_RANGE.
-_PERKEY_COLOR_RANGE = settings_validator.Range(min=0, max=0xFFFFFF, byte_count=3)
+_PERKEY_COLOR_RANGE = settings_validator.Range(min=0, max=0xFFFFFF, byte_count=3, value_type=common.ColorInt)
 
 # TODO action part of DpiSlidingXY, MouseGesturesXY
 

--- a/tests/logitech_receiver/test_settings_validator.py
+++ b/tests/logitech_receiver/test_settings_validator.py
@@ -1,5 +1,6 @@
 import pytest
 
+from logitech_receiver import common
 from logitech_receiver import settings_validator
 
 
@@ -23,3 +24,54 @@ def test_bool_or_toggle(current, new, expected):
     result = settings_validator.bool_or_toggle(current=current, new=new)
 
     assert result == expected
+
+
+def _color_validator():
+    rng = settings_validator.Range(min=0, max=0xFFFFFF, byte_count=3, value_type=common.ColorInt)
+    choices = {
+        common.NamedInt(1, "A"): rng,
+        common.NamedInt(2, "B"): rng,
+        common.NamedInt(3, "C"): rng,
+    }
+    return settings_validator.MapRangeValidator(choices)
+
+
+def test_map_range_to_string_formats_plain_int_through_value_type():
+    """Configs loaded from YAML come back as plain ints; to_string should
+    re-wrap them via the choice's value_type so `solaar show` renders hex
+    regardless of whether the dict came from a fresh read or a stale load."""
+    v = _color_validator()
+    plain = {1: 12590120, 2: 12922150, 3: 16106001}  # what YAML load produces
+    rendered = v.to_string(plain)
+    assert "0xc01c28" in rendered
+    assert "0xc52d26" in rendered
+    assert "0xf5c211" in rendered
+
+
+def test_map_range_to_string_passes_color_int_through():
+    v = _color_validator()
+    wrapped = {1: common.ColorInt(0xFC3300), 2: common.ColorInt(0x00FF00)}
+    rendered = v.to_string(wrapped)
+    assert "0xfc3300" in rendered
+    assert "0x00ff00" in rendered
+
+
+def test_map_range_to_string_preserves_sentinel_subclass():
+    """NamedInt 'No change' = -1 must not be re-wrapped (its name would be
+    lost). The exact-type guard `type(v) is int` excludes it."""
+    v = _color_validator()
+    mixed = {1: common.ColorInt(0xFC3300), 2: -1}
+    rendered = v.to_string(mixed)
+    assert "0xfc3300" in rendered
+    assert "2:-1" in rendered
+
+
+def test_map_range_to_string_int_value_type_unchanged():
+    """When value_type is the default int, to_string emits decimal as before
+    (no behavior change for non-color settings)."""
+    rng = settings_validator.Range(min=0, max=255, byte_count=1)
+    choices = {common.NamedInt(1, "A"): rng, common.NamedInt(2, "B"): rng}
+    v = settings_validator.MapRangeValidator(choices)
+    rendered = v.to_string({1: 42, 2: 200})
+    assert "1:42" in rendered
+    assert "2:200" in rendered


### PR DESCRIPTION
# Per-Key UI cleanup pass

A pass over the per-key color editor UI that landed in #3209, plus a couple of small adjacent fixes that surfaced while using it. Mostly visual + ergonomics.

<img width="762" height="401" alt="Screenshot From 2026-05-11 01-15-24" src="https://github.com/user-attachments/assets/a436ad9f-8af8-47eb-909e-b5fd35b6a27b" />

## Summary of changes

### Editor toolbar — icons instead of labels

The tool buttons (`Brush`, `Rect`, `Fill`) were text labels next to the gradient swatch. Replaced with [Tabler Icons](https://tabler.io/icons) (MIT-licensed, see [`share/solaar/icons/THIRD_PARTY.md`](share/solaar/icons/THIRD_PARTY.md)) and the original labels are kept as tooltips + `Atk` accessible names. The "Unset" toggle next to the color picker — previously a duplicate of the canvas's diagonal-hash pattern at button size — uses the Tabler `palette-off` icon.

Icon recoloring is theme-aware: at load time we read the button's style-context foreground color and substitute it for `currentColor` in the SVG before handing it to `GdkPixbuf`. GTK's stock symbolic loader (`load_symbolic_for_context`) is bypassed because it only recolors specific palette stand-ins (`#bebebe` etc.) and ignores `stroke="currentColor"`, which is what Tabler outline icons use.

A per-button `style-updated` listener with an idempotency guard (color-key hash) handles runtime theme changes — switching between light and dark via gsettings re-renders the icons in the new foreground color, and unrelated style emissions (hover, focus, active) don't trigger needless rebuilds.

### Gradient swatch — matched outline

The gradient swatch on the gradient-tool button was a sharp-cornered rectangle with a 1px translucent border, visually inconsistent with the rounded-corner Tabler outline icons next to it. Re-rendered using the Tabler `square` icon's path (rounded rect from (3,3) to (21,21), corner radius 2, stroke 2 in a 24×24 viewBox) with the gradient filling the inside. Outline color follows the GTK theme alongside the icon buttons.

Endpoint alignment fix as a follow-up: cairo's gradient endpoints were placed at the rounded rect's geometric corners, but the *visible* corner pixel is inset along the diagonal by `r * (1 - 1/√2) ≈ 0.586` units. As a result the rendered corners sampled at `t ≈ 0.033` / `0.967` instead of `0` / `1`, dropping ~8 RGB units off the true endpoint color (visible on saturated pairs — the "pure red" corner rendered as `rgb(194, 10, 0)`). Endpoints are now shifted inward so `t=0` maps to the visible TL corner and `t=1` to the visible BR.

### Canvas — symmetric hash stripes for unset cells

The "no change" hash overlay used a single black-or-white stripe color picked by base luminance. The perceived average of an unset cell was uniformly biased toward black or white instead of sitting on the actual base color, making dark base cells look darker than the keyboard actually shows them and light ones lighter.

Now draws two interleaved stripe sets at `base ± offset` per channel, spaced by half-period so the dark and light stripes alternate evenly. Equal coverage of the two stripe colors keeps the perceived average at base. When a channel is too close to 0 or 1 to fit the full offset (±0.22), the offset is halved on the constrained side — average drifts at the limits but stays centered on base everywhere else.

### Canvas — inset frame

Set `Gtk.ShadowType.IN` on the keyboard's `ScrolledWindow` so the canvas reads as a distinct panel rather than floating flat against the dialog background.

### Dialog — measured natural size, per-device windows

Two changes to how the per-key editor dialog sizes itself and how it's keyed.

**Sizing**: the dialog used hardcoded magic offsets (`canvas_w + 32`, `canvas_h + 80`) to compute its target size from `KeyboardCanvas.size_request`. The width offset only covered the canvas + borders, not the toolbar — small layouts (e.g. an 8-LED mouse: canvas ~172px, toolbar wants ~261px) opened windows narrow enough to clip the toolbar. Replaced with `wrapper.get_preferred_size()`, which already aggregates every layout contribution including the toolbar's natural width.

**Per-device windows**: the dialog was a process-wide singleton — opening the editor on a different device replaced the content in the existing window, which both lost any in-progress edits and (because `Gtk.Window.resize()` after first show is unreliable across X11/Wayland WMs) left the window stuck at the previous device's size. Now keyed by a stable per-device identifier built from `device.unitId` first (read from device firmware via `DeviceInformation`, the same regardless of transport), falling back to `serial` / `hid_serial` / `codename`. The same physical device on USB and on a wireless receiver shares one dialog rather than opening two windows. Re-opening the dialog for the same already-open device just raises the existing window — no flicker.

### G502 X — label cells by zone id, not letter

Inherited from OpenRGB which labels each LED with a letter (A..H). For LEDs without physical keycaps, the letter→zone-id translation is mental overhead with no visual benefit. Switched to bare zone numbers so cell labels match what shows up in logs, the persister, and rule arguments.

### `solaar show` — drop fabricated PerKeyLighting "current" output

The 0x8081 PerKeyLighting v2 protocol has no `GetIndividualRgbZones` function — the device doesn't expose its current per-key buffer over HID++. `PerKeyLighting.read()` was papering over this by fabricating an all-`No change` sentinel map, which `solaar show` then rendered as if it were the real device state. Removed the fabricated read so `solaar show` no longer prints misleading per-zone color output for the feature.

### `common`: render RGB as `0xrrggbb`

In `solaar show` and config dumps, RGB color values for non-perkey settings (single-zone effects, etc.) were rendered as plain decimal ints. Switched to `0xrrggbb` hex form everywhere a color int crosses a user-facing boundary — much easier to eyeball and to copy-paste back into a config file.

## Licensing

The four new icon SVGs in `share/solaar/icons/` (`solaar-tool-{brush,rect,bucket,palette-off}-symbolic.svg`) are MIT-licensed Tabler Icons. Each file carries an `SPDX-License-Identifier: MIT` header plus the original copyright; the full notice and the Tabler MIT license text live in [`share/solaar/icons/THIRD_PARTY.md`](share/solaar/icons/THIRD_PARTY.md).

MIT is GPL-2.0-compatible; the combined work is still distributable under GPL-2.0, with the MIT components retaining their MIT license. The only packaging touchpoint is updating the multi-license expression in `debian/copyright` / Fedora `License:` field — heads-up for downstream maintainers.
