### PR TITLE
listener: share bluez-watch wiring across Centurion-direct and standard device paths

### DIFF
--- a/lib/logitech_receiver/centurion.py
+++ b/lib/logitech_receiver/centurion.py
@@ -483,8 +483,9 @@ def create_centurion_receiver(low_level, device_info, setting_callback=None):
 
     Creates a CenturionReceiver, discovers its features, then checks if
     CentPPBridge (0x0003) is among them. If not, this is a direct-connected
-    device (wired headset) — close and return None so the caller can fall
-    back to create_device().
+    device — wired headset, or a Bluetooth-paired Centurion headset where
+    there is no separate dongle. Close and return None so the caller can
+    fall back to create_device().
 
     :returns: A CenturionReceiver, or None.
     """

--- a/lib/solaar/listener.py
+++ b/lib/solaar/listener.py
@@ -356,6 +356,21 @@ def _cleanup_bluez_dbus(device: Device):
 _all_listeners = {}  # all known receiver listeners, listeners that stop on their own may remain here
 
 
+def _post_attach_device(device):
+    """Shared post-create_device wiring: hook configuration up to the new
+    Device, and if it's BT-paired, install the bluez-dbus connect watcher
+    so disconnect/reconnect events propagate to the UI without a restart.
+
+    Both the Centurion-direct fallback (no-dongle device, e.g. BT-paired
+    G522 / PRO X 2) and the regular non-Centurion device path call this —
+    previously only the latter wired the bluez watcher, so a BT-paired
+    Centurion device wouldn't see reconnect events."""
+    configuration.attach_to(device)
+    if device.bluetooth and device.hid_serial:
+        dbus.watch_bluez_connect(device.hid_serial, partial(_process_bluez_dbus, device))
+        device.cleanups.append(_cleanup_bluez_dbus)
+
+
 def _start(device_info: DeviceInfo):
     assert _status_callback and _setting_callback
 
@@ -364,17 +379,15 @@ def _start(device_info: DeviceInfo):
     elif getattr(device_info, "centurion", False):
         receiver_ = logitech_receiver.device.create_centurion_receiver(base, device_info, _setting_callback)
         if receiver_ is None:
-            # No bridge found — treat as a direct-connected centurion device (e.g., wired headset)
+            # No bridge found — treat as a direct-connected centurion device
+            # (wired headset, or BT-paired headset with no LIGHTSPEED dongle).
             receiver_ = logitech_receiver.device.create_device(base, device_info, _setting_callback)
             if receiver_:
-                configuration.attach_to(receiver_)
+                _post_attach_device(receiver_)
     else:
         receiver_ = logitech_receiver.device.create_device(base, device_info, _setting_callback)
         if receiver_:
-            configuration.attach_to(receiver_)
-            if receiver_.bluetooth and receiver_.hid_serial:
-                dbus.watch_bluez_connect(receiver_.hid_serial, partial(_process_bluez_dbus, receiver_))
-                receiver_.cleanups.append(_cleanup_bluez_dbus)
+            _post_attach_device(receiver_)
 
     if receiver_:
         rl = SolaarListener(receiver_, _status_callback)


### PR DESCRIPTION
I don't know how to test this, since my headset doesn't seem to support HID++ over BT for control, but I suspect this will work for others which do implement such things.

The bluez-dbus connect watcher (used to surface BT disconnect / reconnect events to the UI without restarting Solaar) was only installed in the non-Centurion device path of _start(). The Centurion-direct fallback — used for wired headsets and, prospectively, for BT-paired Centurion headsets where there's no LIGHTSPEED dongle — skipped it.

Factor the post-create_device wiring (configuration.attach_to + bluez watch installation) into a shared _post_attach_device() helper that both paths call. No behaviour change for wired headsets (they aren't Bluetooth, so the watch installation is a no-op for them). For BT-paired headsets that come through the centurion-direct fallback, this makes reconnect events propagate the same way as for any other BT-paired Logitech HID++ device.

Also broadens the docstring on create_centurion_receiver to mention BT-paired Centurion headsets as a valid "direct device" case alongside wired headsets.

First commit on the centurion-bluetooth branch. Hardware verification still required to confirm Path A (existing hidraw pipeline works for BT Centurion) before any further changes. We want to hold off on merging until we can find a tester, but this isn't going to go anywhere just sitting in my branch where nobody with the right hardware can be pointed to it.