### PR TITLE
fix sw_id at 0x0B instead of rotating 0x2..0xF

### DIFF
--- a/lib/logitech_receiver/base.py
+++ b/lib/logitech_receiver/base.py
@@ -793,17 +793,22 @@ def _read_input_buffer(handle, ihandle, notifications_hook):
             return
 
 
+# HID++ Software ID claimed by Solaar. Fixed (not rotated) so cooperative
+# userspace HID++ clients sharing the same device can pick a different value
+# and reliably filter Solaar's traffic out of their reply stream.
+#
+# Known values in use by other tools at the time of writing:
+#
+#   0x07  OpenRGB
+#   0x0A  LGSTrayEx
+#   0x0D  Logitech G HUB (host-side)
+#   0x0F  Logitech firmware (sub-device self-enumeration on wired transports)
+#
+# 0x0B avoids those and keeps the high bit set so notifications (sw_id=0)
+# remain trivially distinguishable from replies.
+SOLAAR_SOFTWARE_ID = 0x0B
+
+
 def _get_next_sw_id() -> int:
-    """Returns 'random' software ID to separate replies from different devices.
-
-    Cycle the HID++ 2.0 software ID from 0x2 to 0xF to separate
-    results and notifications.
-    """
-    if not hasattr(_get_next_sw_id, "software_id"):
-        _get_next_sw_id.software_id = 0xF
-
-    if _get_next_sw_id.software_id < 0xF:
-        _get_next_sw_id.software_id += 1
-    else:
-        _get_next_sw_id.software_id = 2
-    return _get_next_sw_id.software_id
+    """Return Solaar's HID++ Software ID (fixed, see SOLAAR_SOFTWARE_ID)."""
+    return SOLAAR_SOFTWARE_ID

--- a/tests/logitech_receiver/test_base.py
+++ b/tests/logitech_receiver/test_base.py
@@ -125,11 +125,8 @@ def test_make_notification(report_id, sub_id, address, valid_notification):
 
 
 def test_get_next_sw_id():
-    res1 = base._get_next_sw_id()
-    res2 = base._get_next_sw_id()
-
-    assert res1 == 2
-    assert res2 == 3
+    assert base._get_next_sw_id() == base.SOLAAR_SOFTWARE_ID
+    assert base._get_next_sw_id() == base.SOLAAR_SOFTWARE_ID
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Solaar's old rotating sw_id (cycling 0x2..0xF on every request) eats HID++ replies addressed to other userspace clients sharing the same device, because reply matching is feature + function + sw_id only and Solaar eventually claims every value in the range. Cooperative use with OpenRGB, LGSTrayEx, etc. is impossible by construction.

Pick one value and hold it. Other tools can pick a different one and filter Solaar's traffic out of their reply stream cleanly.

  0x07  OpenRGB
  0x0A  LGSTrayEx
  0x0D  Logitech G HUB (host-side)
  0x0F  Logitech firmware (sub-device self-enumeration on wired)

0x0B is unallocated among the above and keeps the high bit set so replies stay trivially distinguishable from notifications (sw_id=0).

Audit of why nothing breaks:

- Reply matcher in request() still works — Solaar's request loop is synchronous per device, so (feat, func, fixed_sw_id) is enough to identify the in-flight request's reply. The rotation never bought uniqueness across processes; it only avoided self-collision across successive synchronous requests, which doesn't exist as a problem.

- Ping reply identification uses a separate random mark byte (getrandbits(8) appended to the request data, checked at byte 4 of the reply). That randomization is unchanged.

- Stale-reply protection comes from _read_input_buffer draining the device handle before every new write. A delayed reply from a prior timed-out request gets routed to the notification hook, not mistaken for the current request's reply — independent of whether sw_id rotates.

- The "separate results and notifications" claim in the old docstring was misleading: true notifications carry sw_id=0 per the HID++ spec. What actually keeps replies distinguishable is the high bit being set, which 0x0B preserves.

- Centurion bridge in device.py uses the same sw_id-as-correlation- token pattern with the same synchronous-per-device flow; fixed sw_id works identically.