### PR TITLE
config_panel: don't show failed-write alert for unreadable settings

### DIFF
--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -57,7 +57,8 @@ def _read_async(setting, force_read, sbox, device_is_online, sensitive):
         except Exception as e:
             v = None
             logger.warning("%s: error reading so use None (%s): %s", s.name, s._device, repr(e))
-        GLib.idle_add(_update_setting_item, sb, v, online, sensitive, True, priority=99)
+        null_okay = not getattr(getattr(s, "_validator", None), "readable", True)
+        GLib.idle_add(_update_setting_item, sb, v, online, sensitive, null_okay, priority=99)
 
     ui_async(_do_read, setting, force_read, sbox, device_is_online, sensitive)
 
@@ -722,8 +723,6 @@ class HeteroKeyControl(Gtk.HBox, Control):
                         box.set_rgba(rgba)
                     else:
                         box.set_value(v)
-        else:
-            self.sbox._failed.set_visible(True)
         self.setup_visibles(id_)
 
     def setup_visibles(self, id_):


### PR DESCRIPTION
Saw this bug show up in [@yurinogueira's screenshot](https://private-user-images.githubusercontent.com/55946612/592205259-06866426-8ce7-42e0-8748-5516614303c7.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Nzg3MjkwNDQsIm5iZiI6MTc3ODcyODc0NCwicGF0aCI6Ii81NTk0NjYxMi81OTIyMDUyNTktMDY4NjY0MjYtOGNlNy00MmUwLTg3NDgtNTUxNjYxNDMwM2M3LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA1MTQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNTE0VDAzMTkwNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTdjY2M5YmU5MzRlYjJmNzNmMGJjNTU3MTk5MTY3OGViYjVhNTcwYmJhNjY0MjNkMTQ3MmY1ZjNmMmVlMjQ4YTYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT1pbWFnZSUyRnBuZyJ9.SYjq-nGLGc8_QSqRdh7o_FHHayh5RE49K2-76BydLug) and figured I'd go chase it down.

Write-only HeteroKey settings (e.g. 0x8071 zone effects) legitimately return None on first read. Gate null_okay on validator.readable so genuine read failures on readable settings still surface; drop the unconditional alert in HeteroKeyControl.set_value(None).