### PR TITLE
Fix test config isolation and test notification noise

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolate_solaar_configuration(tmp_path, monkeypatch):
+    """Redirect solaar.configuration at a throwaway path for every test.
+
+    Tests build FakeDevices named 'TestDevice'; any that touch device.settings
+    or device.persister without mocking call the real configuration.persister(),
+    which loads and rewrites ~/.config/solaar/config.yaml — appending a fresh
+    un-matchable TestDevice entry on every run. Pointing the paths at tmp_path
+    and clearing the cached _config keeps each test off the real config and
+    isolated from every other test."""
+    from solaar import configuration
+
+    monkeypatch.setattr(configuration, "_yaml_file_path", str(tmp_path / "config.yaml"))
+    monkeypatch.setattr(configuration, "_json_file_path", str(tmp_path / "config.json"))
+    monkeypatch.setattr(configuration, "_config", [])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+import importlib
+
+from unittest import mock
+
 import pytest
 
 
@@ -16,3 +20,24 @@ def isolate_solaar_configuration(tmp_path, monkeypatch):
     monkeypatch.setattr(configuration, "_yaml_file_path", str(tmp_path / "config.yaml"))
     monkeypatch.setattr(configuration, "_json_file_path", str(tmp_path / "config.json"))
     monkeypatch.setattr(configuration, "_config", [])
+
+
+@pytest.fixture(autouse=True)
+def mock_desktop_notifications(monkeypatch):
+    """Swap the libnotify backend for a mock in both desktop_notifications
+    modules. Tests still exercise the real init/alert/show code paths, but
+    Notification.show() never reaches the daemon — without this the suite
+    raises real 'MockDevice' / 'unknown' notifications on every run.
+
+    Returns the Notify mock so notification tests can assert against it."""
+    notify = mock.MagicMock(name="Notify")
+    notify.is_initted.return_value = True
+    notify.init.return_value = True
+    for modname in ("solaar.ui.desktop_notifications", "logitech_receiver.desktop_notifications"):
+        try:
+            module = importlib.import_module(modname)
+        except Exception:
+            continue
+        monkeypatch.setattr(module, "Notify", notify, raising=False)
+        monkeypatch.setattr(module, "_notifications", {}, raising=False)
+    return notify

--- a/tests/logitech_receiver/test_desktop_notifications.py
+++ b/tests/logitech_receiver/test_desktop_notifications.py
@@ -2,7 +2,9 @@ from unittest import mock
 
 from logitech_receiver import desktop_notifications
 
-# depends on external environment, so make some tests dependent on availability
+# The mock_desktop_notifications autouse fixture (tests/conftest.py) swaps the
+# libnotify backend for a mock, so these exercise the real code paths without
+# raising real desktop notifications.
 
 
 def test_init():
@@ -22,8 +24,11 @@ class MockDevice(mock.Mock):
         return True
 
 
-def test_show():
-    dev = MockDevice()
-    reason = "unknown"
-    result = desktop_notifications.show(dev, reason)
-    assert result is not None if desktop_notifications.available else result is None
+def test_show(mock_desktop_notifications):
+    result = desktop_notifications.show(MockDevice(), "unknown")
+
+    if desktop_notifications.available:
+        assert result is not None
+        mock_desktop_notifications.Notification.return_value.show.assert_called()
+    else:
+        assert result is None

--- a/tests/solaar/ui/test_desktop_notifications.py
+++ b/tests/solaar/ui/test_desktop_notifications.py
@@ -2,7 +2,9 @@ from unittest import mock
 
 from solaar.ui import desktop_notifications
 
-# depends on external environment, so make some tests dependent on availability
+# The mock_desktop_notifications autouse fixture (tests/conftest.py) swaps the
+# libnotify backend for a mock, so these exercise the real code paths without
+# raising real desktop notifications.
 
 
 def test_init():
@@ -15,9 +17,11 @@ def test_uninit():
     assert desktop_notifications.uninit() is None
 
 
-def test_alert():
-    reason = "unknown"
-    assert desktop_notifications.alert(reason) is None
+def test_alert(mock_desktop_notifications):
+    assert desktop_notifications.alert("unknown") is None
+
+    if desktop_notifications.available:
+        mock_desktop_notifications.Notification.return_value.show.assert_called()
 
 
 class MockDevice(mock.Mock):
@@ -27,13 +31,11 @@ class MockDevice(mock.Mock):
         return True
 
 
-def test_show():
-    dev = MockDevice()
-    reason = "unknown"
-    available = desktop_notifications.init()
+def test_show(mock_desktop_notifications):
+    result = desktop_notifications.show(MockDevice(), "unknown")
 
-    result = desktop_notifications.show(dev, reason)
-    if available:
+    if desktop_notifications.available:
         assert result is not None
+        mock_desktop_notifications.Notification.return_value.show.assert_called()
     else:
         assert result is None


### PR DESCRIPTION
Right now tests use the real config, which tends to make a bit of a mess.
We're also making notification noise that isn't really adding anything to the
testing process, we can just mock that part too.

Add an autouse conftest fixture that points configuration's yaml/json
paths at a per-test tmp_path and clears the cached _config. No test
can reach the real config now, and each test starts from an empty
config instead of inheriting entries from earlier tests.

Add an autouse conftest fixture that swaps Notify for a mock in both
desktop_notifications modules (solaar.ui and logitech_receiver). The
tests still exercise the real init/alert/show code paths, but
Notification.show() never reaches the daemon. The fixture returns the
mock; the notification tests now assert show() was actually dispatched
against it, so they verify the path instead of just "didn't crash".