### PR TITLE
centurion: show the receiver as "Lightspeed Headset Receiver" in the UI

### DIFF
--- a/lib/logitech_receiver/centurion.py
+++ b/lib/logitech_receiver/centurion.py
@@ -272,7 +272,9 @@ class CenturionReceiver:
         self._usb_name = getattr(device_info, "product", None)
         if not self._usb_name and self.path:
             self._usb_name = _read_usb_product_string(self.path)
-        self.name = "Centurion Receiver"
+        # User-facing name: "Centurion" is Logitech's internal codename for this
+        # headset-dongle transport, kept in code/logs but not shown to users.
+        self.name = "Lightspeed Headset Receiver"
 
         # Dummy pairing object — lock_open stays False
         from .receiver import Pairing

--- a/tests/logitech_receiver/test_hidpp20_complex.py
+++ b/tests/logitech_receiver/test_hidpp20_complex.py
@@ -1185,7 +1185,7 @@ def test_centurion_receiver_attributes():
     assert recv.handle == 0x99
     assert recv.path == "/dev/hidraw99"
     assert recv.product_id == "0AF0"
-    assert recv.name == "Centurion Receiver"
+    assert recv.name == "Lightspeed Headset Receiver"
     assert recv.serial is None
     assert recv.pairing is not None
     assert recv.pairing.lock_open is False


### PR DESCRIPTION
"Centurion" is Logitech's internal codename for the headset-dongle transport — useful as a developer/log identifier but meaningless to a user. We're probably better off just keeping the official name on the interface so we don't add confusion.

Rename only the user-facing receiver name. The protocol label, module, class, function names, and log messages keep "Centurion" — the codename stays everywhere it helps developers, and is hidden only where it faced the user.