### PR TITLE
cli/config: wrap argv in list for Gio.Application.run (PyGObject 3.56)

### DIFF
--- a/lib/solaar/cli/config.py
+++ b/lib/solaar/cli/config.py
@@ -231,7 +231,7 @@ def run(receivers, args, _find_receiver, find_device):
         argl = ["config", dev.serial or dev.unitId, setting.name]
         argl.extend([a for a in [args.value_key, args.extra_subkey, args.extra2] if a is not None])
         args = yaml.dump(argl)
-        application.run(args)
+        application.run([args])
     else:
         if dev.persister and setting.persist:
             dev.persister[setting.name] = setting._value


### PR DESCRIPTION
## Problem

With the Solaar GUI running, any `solaar config <device> <setting> <value>` invocation raises a `TypeError` under PyGObject 3.56:

```
$ solaar config "Wireless Mouse MX Master 2S" hires-smooth-resolution False
Setting hires-smooth-resolution of Wireless Mouse MX Master 2S to False
solaar: error: Traceback (most recent call last):
  File ".../solaar/cli/__init__.py", line 217, in run
    m.run(c, args, _find_receiver, _find_device)
  File ".../solaar/cli/config.py", line 234, in run
    application.run(args)
  File ".../gi/overrides/Gio.py", line 138, in run
    return Gio.Application.run(self, *args, **kwargs)
TypeError: Unable to marshal str as an array, use .encode() to convert to bytes
```

The setting is not applied; the GUI's cached state then diverges from the device's actual state. Affects current `master` and the 1.1.x release line on PyGObject >= 3.56.

## Cause

In `lib/solaar/cli/config.py` the "remote" path passes a `yaml.dump(...)` string to `Gio.Application.run()`, whose `argv` parameter is `Optional[list[str]]`. Pre-3.56 PyGObject tolerated a bare `str`; the marshaller refactor in the 3.55 dev series (MR !487) tightened this, and 3.56 -- the first stable to ship it -- now raises.

## Fix

Wrap the YAML string in a list so it becomes a single-element argv. The receiver in `lib/solaar/ui/__init__.py` (`_command_line`) already does `yaml.safe_load("".join(args))` on the argv, so a 1-element argv reconstructs the original YAML cleanly under both old and new PyGObject.

## Reproduction

With current `master` and `python-gobject >= 3.56`:

1. Start the GUI: `solaar --window=hide`
2. From another shell: `solaar config "<device>" <toggle-setting> False`
3. Observe the `TypeError`. No setting is applied.

## Verification

Patched locally against current `master` with python-gobject 3.56.3:
- No traceback on `solaar config ... True` / `False`.
- Device state actually flips (verified by reading back).
- GUI's displayed value updates to match the device.

A follow-up could drop the YAML round-trip and pass `argl` directly (with a matching receiver-side change), but that's a separate refactor; this PR is the minimal regression fix.