### PR TITLE
perkey layouts: add POUND and ISO_BACKSLASH cells to MAIN_ISO

### DIFF
--- a/lib/solaar/ui/perkey/layouts/_keyboard_base.py
+++ b/lib/solaar/ui/perkey/layouts/_keyboard_base.py
@@ -157,11 +157,17 @@ MAIN_ANSI: tuple[Cell, ...] = (
     Cell(zone_id=108, row=5, col=13, group="main", label="Ctrl"),
 )
 
-# --- Main alpha block, ISO. Same as ANSI minus the row 2 col 13 backslash;
-#     on ISO that position is the top half of the L-shape Enter, addressed
-#     by zone 37 (the main Enter cell at row 3 col 13). Zone 46 is silently
-#     unaddressable on ISO layouts — same limitation as OpenRGB's UI.
-MAIN_ISO: tuple[Cell, ...] = tuple(c for c in MAIN_ANSI if not (c.row == 2 and c.col == 13))
+# --- Main alpha block, ISO. Drops the row 2 col 13 backslash (zone 46 is the
+#     upper half of the L-shape Enter on ISO, addressed by zone 37) and adds
+#     the two ISO-only keys: POUND (zone 47) at row 3 col 12 between ' and
+#     Enter, and ISO_BACKSLASH (zone 97) at row 4 col 1 between Shift and Z.
+#     Regional layouts override the labels to match local keycaps (# / < on
+#     QWERTZ, # / \ on UK QWERTY, * / < on AZERTY).
+_ISO_EXTRA_KEYS: tuple[Cell, ...] = (
+    Cell(zone_id=47, row=3, col=12, group="main", label="#"),
+    Cell(zone_id=97, row=4, col=1, group="main", label="\\"),
+)
+MAIN_ISO: tuple[Cell, ...] = tuple(c for c in MAIN_ANSI if not (c.row == 2 and c.col == 13)) + _ISO_EXTRA_KEYS
 
 # --- Curated allowlist for unmapped device zones surfaced in the bottom strip.
 #     G-keys, logo, media, brightness — the canonical "extras" Logitech firmware

--- a/lib/solaar/ui/perkey/layouts/keyboard_iso_azerty.py
+++ b/lib/solaar/ui/perkey/layouts/keyboard_iso_azerty.py
@@ -56,6 +56,8 @@ _OVERRIDES: dict[int, str] = {
     51: ";",  # ,-position → semicolon
     52: ":",  # .-position → colon
     53: "!",  # /-position → exclamation
+    47: "*",  # POUND key (row 3 col 12) — French * / µ
+    97: "<",  # ISO_BACKSLASH (row 4 col 1), between Shift and W
 }
 
 

--- a/lib/solaar/ui/perkey/layouts/keyboard_iso_qwertz.py
+++ b/lib/solaar/ui/perkey/layouts/keyboard_iso_qwertz.py
@@ -38,6 +38,8 @@ _OVERRIDES: dict[int, str] = {
     49: "Ä",  # row 3 col 11
     26: "Y",  # row 4 col 2 — Y/Z swap
     53: "-",  # row 4 col 11
+    47: "#",  # POUND key (row 3 col 12), between Ä and Enter
+    97: "<",  # ISO_BACKSLASH (row 4 col 1), between Shift and Y
 }
 
 


### PR DESCRIPTION
ISO keyboards have two physical keys that ANSI does not — POUND (#) at row 3 col 12 between the right-of-quote position and Enter, and ISO_BACKSLASH (<) at row 4 col 1 between LShift and Z. The firmware reports them as zones 47 and 97 on G915 ISO models, but MAIN_ISO only *subtracted* the ANSI backslash at row 2 col 13 without ever adding those two cells back. They fell through to the unmapped pool and got dropped by the EXTRAS_ALLOWLIST phantom-zone filter, so PerKey lighting silently left them undrawable (issue #3239 — German G915).

Add both cells to MAIN_ISO with the UK QWERTY labels (# and \\) as the default, and override them in the regional layouts: # / < on QWERTZ DE,
* / < on AZERTY FR. UK QWERTY inherits the defaults.

ANSI is unaffected — MAIN_ANSI still omits 47/97 so they keep getting filtered as phantoms on ANSI keyboards like the G515.