### PR TITLE
fix: KeyPress drops repeated characters with consecutive same keys

### DIFF
--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -1164,13 +1164,20 @@ class KeyPress(Action):
                 simulate_key(sk, direction)
 
     def keyDown(self, keysyms_, modifiers):
+        pressed_codes = set()
         for k in keysyms_:
             (keycode, level) = keysym_to_keycode(k, modifiers)
             if keycode is None:
                 logger.warning("rule KeyPress key symbol not currently available %s", self)
             elif self.action != CLICK or self.needed(keycode, modifiers):  # only check needed when clicking
+                if self.action == CLICK and keycode in pressed_codes:
+                    # The kernel drops key-down events for keys already held; release first so the
+                    # second occurrence registers as a fresh press (needed for repeated chars like "ss").
+                    simulate_key(keycode, _KEY_RELEASE)
+                    self.mods(level, modifiers, _KEY_RELEASE)
                 self.mods(level, modifiers, _KEY_PRESS)
                 simulate_key(keycode, _KEY_PRESS)
+                pressed_codes.add(keycode)
 
     def keyUp(self, keysyms_, modifiers):
         for k in keysyms_:


### PR DESCRIPTION

## Problem

A `KeyPress` action with a key list containing the same key more than once (example: `[m, i, s, s, i, s, s, i, p, p, i]`) silently drops the duplicate presses. The Linux kernel input subsystem discards `EV_KEY value=1` events for a key that is already held — only state *changes* are passed to handlers. So the second `s` in `[s, s]` is a no-op and never reaches the application.

## Fix

Track which keycodes have been pressed within a single `keyDown` call. When a keycode is encountered again during a `CLICK` action, send an intermediate `_KEY_RELEASE` first. This gives the kernel the state transition it requires before the second press, so each occurrence produces a distinct keystroke.

`keyUp` may attempt to release a keycode that was already released as part of an intermediate cycle; the kernel drops those silently (same logic, inverse direction), so no spurious events reach the application.
