### PR TITLE
perkey layouts: route 0x4540 country code 4 to ISO QWERTY (observed on UK G915 TKL)

### DIFF
--- a/lib/solaar/ui/perkey/layouts/__init__.py
+++ b/lib/solaar/ui/perkey/layouts/__init__.py
@@ -76,6 +76,10 @@ _KEYBOARD_FAMILY_BY_COUNTRY: dict[int, str] = {
     1: "ansi",
     # ISO QWERTY (UK + ES/IT/PT/BE/Nordic — same shape, different keycap legends)
     2: "iso_qwerty",
+    # Observed: UK-ISO G915 TKL (model B35F408EC343, WPID 408E) reports 4 —
+    # its zone bitmap includes the ISO-only POUND (47) and ISO_BACKSLASH (97)
+    # keys and the physical board is UK QWERTY, not AZERTY.
+    4: "iso_qwerty",
     5: "iso_qwerty",
     8: "iso_qwerty",
     0x0B: "iso_qwerty",
@@ -89,8 +93,9 @@ _KEYBOARD_FAMILY_BY_COUNTRY: dict[int, str] = {
     # ISO QWERTZ (DE/Swiss)
     3: "iso_qwertz",
     7: "iso_qwertz",
-    # ISO AZERTY (FR)
-    4: "iso_azerty",
+    # ISO AZERTY (FR) — no confirmed country code; 4 was originally mapped
+    # here but a real UK-ISO G915 TKL reports 4 (see above), so AZERTY is
+    # unreachable until a confirmed FR device report arrives.
     # JIS
     9: "jis",
     0x3E: "jis",


### PR DESCRIPTION
The per-key painter's `_KEYBOARD_FAMILY_BY_COUNTRY` table maps KEYBOARD_LAYOUT_2 (0x4540) country code 4 to ISO AZERTY. A real UK-ISO G915 TKL reports 4, so its owner gets the AZERTY layout drawn in the painter: symbols on the digit row, A/Q and Z/W swapped — for a UK QWERTY board.

### Device evidence

G915 TKL LIGHTSPEED, model `B35F408EC343`, WPID `408E`, via the 046d:c547 receiver:

- 0x4540 fn 0x00 raw reply: `04000000…` → country code **4**
- The physical board is UK ISO QWERTY (POUND key next to Enter, ISO backslash next to left Shift)
- Its 0x8081 zone bitmap includes the two ISO-only zones 47 (POUND) and 97 (ISO_BACKSLASH), consistent with an ISO board
- After remapping 4 → `iso_qwerty`, the painter renders the correct shape and legends for this device

### Caveats, for review

As far as I can tell there is no public spec for the 0x4540 country enumeration (Logitech's cpg-docs lists the feature ID only), and PR #3209 doesn't cite a source for the current table — so this remap is a device-observation correction, and I can't rule out that some other device family reports 4 for AZERTY. Since zone IDs are identical across ISO families, painting still works either way; only the rendered shape/legends are affected.

With this change AZERTY keeps its layout but has no country code mapped until a confirmed FR device report arrives — the comment in the table invites exactly that. If conflicting reports show up, the table likely needs a per-device dimension rather than a global code→family map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)