### PR TITLE
Support change-host notifications in rules

### DIFF
--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -47,6 +47,7 @@ else:
     import evdev
 
 from .common import NamedInt
+from .hidpp20 import Hidpp20
 from .hidpp20 import SupportedFeature
 from .special_keys import CONTROL
 
@@ -1304,6 +1305,11 @@ class Set(Action):
         if setting is None:
             logger.warning("Set action: setting %s is not the name of a setting for %s", self.args[1], dev.name)
             return None
+        if setting.name == "change-host":
+            try:
+                Hidpp20().get_host_names(dev)
+            except Exception:
+                logger.debug("Set action: failed to refresh host names before change-host write", exc_info=True)
         args = setting.acceptable(self.args[2:], setting.read())
         if args is None:
             logger.warning(
@@ -1487,6 +1493,11 @@ def process_notification(device, notification: HIDPPNotification, feature) -> No
             if notification.data[4] <= 0x01:  # when wheel starts, zero out last movement
                 thumb_wheel_displacement = 0
             thumb_wheel_displacement += signed(notification.data[0:2])
+        elif feature == SupportedFeature.CHANGE_HOST and len(notification.data) >= 2:
+            if notification.data[1] <= 2:
+                host = notification.data[1] + 1
+                key_down = CONTROL["Host_Switch_Channel_" + str(host)]
+                logger.debug("mapping change host notification into key %s", key_down)
 
     GLib.idle_add(evaluate_rules, feature, notification, device)
 

--- a/tests/logitech_receiver/test_diversion.py
+++ b/tests/logitech_receiver/test_diversion.py
@@ -111,6 +111,7 @@ def test_feature():
         (SupportedFeature.MKEYS, [0x01, 0x02, 0x03, 0x04]),
         (SupportedFeature.MR, [0x01, 0x02, 0x03, 0x04]),
         (SupportedFeature.THUMB_WHEEL, [0x01, 0x02, 0x03, 0x04, 0x05]),
+        (SupportedFeature.CHANGE_HOST, [0x00, 0x01, 0x00, 0x00]),
         (SupportedFeature.DEVICE_UNIT_ID, [0x01, 0x02, 0x03, 0x04, 0x05]),
     ],
 )
@@ -125,3 +126,29 @@ def test_process_notification(feature, data):
     )
 
     diversion.process_notification(device_mock, notification, feature)
+
+
+@pytest.mark.parametrize(
+    "data, key_name",
+    [
+        (b"\x01\x00\x00\x00", "Host Switch Channel 1"),
+        (b"\x00\x01\x00\x00", "Host Switch Channel 2"),
+        (b"\x02\x01\x00\x00", "Host Switch Channel 2"),
+        (b"\x00\x02\x00\x00", "Host Switch Channel 3"),
+        (b"\x01\x02\x00\x00", "Host Switch Channel 3"),
+    ],
+)
+def test_process_change_host_notification_maps_to_key_press(data, key_name):
+    device_mock = mock.Mock()
+    notification = HIDPPNotification(
+        report_id=0x01,
+        devnumber=1,
+        sub_id=0x13,
+        address=0x00,
+        data=data,
+    )
+
+    diversion.process_notification(device_mock, notification, SupportedFeature.CHANGE_HOST)
+
+    condition = diversion.Key([key_name, "pressed"])
+    assert condition.evaluate(SupportedFeature.CHANGE_HOST, notification, device_mock, True)


### PR DESCRIPTION
## Summary

- map `CHANGE_HOST` notifications to synthetic `Host Switch Channel N` key events
- refresh `HOSTS_INFO` before rules write the `change-host` setting
- add diversion tests for observed `CHANGE_HOST` notification formats

Related to #3228.

## Background

For MX Keys S, the Easy-Switch keys can emit HID++ x1814 `CHANGE_HOST` notifications even though the Host Switch keys are not normal divertable controls. Mapping these notifications into Solaar's existing `Host Switch Channel N` names makes them usable in rules.

On the tested MX Keys S, notification data for host switches used `01 00 ...` and `02 00 ...`. A previous experimental patch handled a `00 01 ...` shape, so this keeps support for both forms.

For the tested Signature Plus M750 L, repeated `Set: [mouse, change-host, N]` actions worked once after daemon startup but then left the mouse on the other host. Refreshing x1815 `HOSTS_INFO` immediately before writing `change-host` made repeated switching stable.

## Tested

Hardware:

- MX Keys S, WPID B378, unit ID `59A8D557`
- Signature Plus M750 L, WPID B02C, unit ID `48FB07AE`
- Bolt receiver

Manual test:

- Linux host `msi`, Windows host `L-2296`
- Solaar rule maps keyboard Host 1/2 events to mouse `change-host` values 0/1
- three consecutive Linux -> Windows -> Linux cycles worked with the final patch

Unit test:

```bash
PYTHONPATH=lib python3 -m pytest tests/logitech_receiver/test_diversion.py
```

Result:

```text
14 passed
```
