### PR TITLE
ui: EntryCompletion matching selecting incorrect values due to substring match

### DIFF
--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -225,7 +225,7 @@ class ChoiceControlBig(Gtk.Entry, Control):
         def norm(s):
             return s.replace("_", "").replace(" ", "").lower()
 
-        completion.set_match_func(lambda completion, key, it: norm(key) in norm(completion.get_model()[it][1]))
+        completion.set_match_func(lambda completion, key, it: norm(completion.get_model()[it][1]).startswith(norm(key)))
         completion.set_text_column(1)
         self.set_completion(completion)
         self.connect(GtkSignal.CHANGED.value, self.changed)


### PR DESCRIPTION
Previously, when changing the DPI value (e.g. from 1200 to 1600) and pressing Enter, a different value from the list could be selected (e.g. 21600) instead of the intended input.

This changes the EntryCompletion matching so that the entered value is correctly matched against the available choices and applied when confirmed.