### PR TITLE
Fix crashes on invalid UTF-8 in device name fields

### DIFF
--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -1891,7 +1891,7 @@ class Hidpp20:
                     logger.error("failed to read whole name of %s (expected %d chars)", device, name_length)
                     return None
 
-            return name.decode("utf-8")
+            return name.decode("utf-8", errors="replace")
 
     def get_battery_status(self, device: Device):
         report = device.feature_request(SupportedFeature.BATTERY_STATUS)

--- a/lib/logitech_receiver/notifications.py
+++ b/lib/logitech_receiver/notifications.py
@@ -531,7 +531,7 @@ def handle_device_discovery(receiver: Receiver, notification: HIDPPNotification)
             receiver.pairing.device_address = notification.data[6:12]
             receiver.pairing.device_authentication = notification.data[14]
         elif notification.data[1] == 1:
-            receiver.pairing.device_name = notification.data[3 : 3 + notification.data[2]].decode("utf-8")
+            receiver.pairing.device_name = notification.data[3 : 3 + notification.data[2]].decode("utf-8", errors="replace")
         return True
 
 

--- a/lib/logitech_receiver/receiver.py
+++ b/lib/logitech_receiver/receiver.py
@@ -497,7 +497,7 @@ class BoltReceiver(Receiver):
         codename = self.read_register(Registers.RECEIVER_INFO, InfoSubRegisters.BOLT_DEVICE_NAME + n, 0x01)
         if codename:
             codename = codename[3 : 3 + min(14, ord(codename[2:3]))]
-            return codename.decode("ascii")
+            return codename.decode("ascii", errors="replace")
 
     def device_pairing_information(self, n: int) -> dict:
         pair_info = self.read_register(Registers.RECEIVER_INFO, InfoSubRegisters.BOLT_PAIRING_INFORMATION + n)


### PR DESCRIPTION
Fixes #3292

A device name is display-only, but three code paths decode it strictly and raise `UnicodeDecodeError`, aborting the whole operation:

- `handle_device_discovery` — crashes `solaar pair` during Bolt discovery
- `BoltReceiver.device_codename` — crashes `solaar show` and `solaar unpair`
- `get_friendly_name` — crashes `solaar show` after device enumeration

Observed in the wild with an MX Master 3S whose user-writable friendly name field (HID++ 0x0007) contained `c3 23` (invalid UTF-8). The Bolt receiver copies this name at pairing time, so the bad bytes surface from both the receiver registers and the live feature read, making the device impossible to pair, list, or unpair. Full tracebacks and raw register dumps are in the linked issue.

This change decodes with `errors="replace"` in those three sites, so a garbage name renders as replacement characters (`�#`) instead of making the device unusable. Verified on the affected hardware: with these three changes, `pair`, `show`, and `unpair` all work against the corrupted device.

Note: `get_name` (DEVICE NAME 0x0005) has the same decode pattern but is factory-set and was left strict to keep the diff to the demonstrated crash sites — happy to include it if you'd prefer the sweep.

EDIT: This PR was done using Fable 5 in Claude Code.