### PR TITLE
Fix the Centurion firmware version parse

### DIFF
--- a/lib/logitech_receiver/centurion.py
+++ b/lib/logitech_receiver/centurion.py
@@ -50,10 +50,33 @@ logger = logging.getLogger(__name__)
 # --- Centurion protocol functions (standalone, operate on any device-like object) ---
 
 
-def get_firmware_centurion(device):
-    """Reads firmware info from a Centurion device via DeviceInfo (0x0100) function 1."""
+def _parse_centurion_firmware(report):
+    """Builds a FirmwareInfo from a DeviceInfo (0x0100) function 1 response.
+
+    The response is a plain binary major.minor.build triple -- not BCD, and
+    nothing like the Feature 0x0003 encoding:
+
+        byte 0     major
+        byte 1     minor
+        bytes 2-3  build (BE16)
+        byte 4     nameLen
+        bytes 5+   name
+
+    A PRO X 2 LIGHTSPEED and its dongle both answer 01 02 00 02 00, which G HUB
+    shows as 1.2.2.  There is no firmware-type field, so the kind is chosen
+    rather than read.
+    """
     from . import common
 
+    major, minor = report[0], report[1]
+    build = struct.unpack("!H", report[2:4])[0]
+    name_len = report[4]
+    name = report[5 : 5 + name_len].decode("ascii", errors="replace").rstrip("\x00") if name_len else ""
+    return common.FirmwareInfo(FirmwareKind.Firmware, name, f"{major}.{minor}.{build}", None)
+
+
+def get_firmware_centurion(device):
+    """Reads firmware info from a Centurion device via DeviceInfo (0x0100) function 1."""
     fw = []
     seen = set()  # track response signatures to detect duplicates
     for index in range(0, 8):  # try up to 8 entities
@@ -68,13 +91,7 @@ def get_firmware_centurion(device):
         if sig in seen:
             break
         seen.add(sig)
-        fw_type = report[0]
-        version = struct.unpack("!H", report[2:4])[0]
-        name_len = report[4]
-        name = report[5 : 5 + name_len].decode("ascii", errors="replace").rstrip("\x00") if name_len else ""
-        version_str = f"{version >> 8}.{version & 0xFF:02d}"
-        kind = FirmwareKind(fw_type) if fw_type <= 3 else FirmwareKind.Other
-        fw.append(common.FirmwareInfo(kind, name, version_str, None))
+        fw.append(_parse_centurion_firmware(report))
     return tuple(fw) if fw else None
 
 
@@ -118,8 +135,6 @@ def _centurion_sub_device_info_request(device, function=0x00, *params):
 
 def get_firmware_centurion_sub(device):
     """Reads firmware info from the Centurion sub-device (headset) via bridge."""
-    from . import common
-
     fw = []
     seen = set()
     for index in range(0, 8):
@@ -130,13 +145,7 @@ def get_firmware_centurion_sub(device):
         if sig in seen:
             break
         seen.add(sig)
-        fw_type = report[0]
-        version = struct.unpack("!H", report[2:4])[0]
-        name_len = report[4]
-        name = report[5 : 5 + name_len].decode("ascii", errors="replace").rstrip("\x00") if name_len else ""
-        version_str = f"{version >> 8}.{version & 0xFF:02d}"
-        kind = FirmwareKind(fw_type) if fw_type <= 3 else FirmwareKind.Other
-        fw.append(common.FirmwareInfo(kind, name, version_str, None))
+        fw.append(_parse_centurion_firmware(report))
     return tuple(fw) if fw else None
 
 

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -105,7 +105,7 @@ def _print_centurion_dongle_features(receiver):
             hw_info = _hidpp20.get_hardware_info_centurion(receiver)
             if fw_list:
                 for fw in fw_list:
-                    print(f"          Firmware: {(str(fw.kind) + ' ' + fw.name).strip()} {fw.version}")
+                    print(f"          Firmware: {(fw.name + ' ' + fw.version).strip()}")
             if serial and serial.strip() and serial.strip().isprintable():
                 print(f"          Serial: {serial}")
             if hw_info:
@@ -344,7 +344,7 @@ def _print_device(dev, num=None):
                     hw_info = _hidpp20.get_hardware_info_centurion(dev)
                 if fw_list:
                     for fw in fw_list:
-                        print(f"            Firmware: {(str(fw.kind) + ' ' + fw.name).strip()} {fw.version}")
+                        print(f"            Firmware: {(fw.name + ' ' + fw.version).strip()}")
                 if serial and serial.strip() and serial.strip().isprintable():
                     print(f"            Serial: {serial}")
                 if hw_info:

--- a/tests/logitech_receiver/test_hidpp20_complex.py
+++ b/tests/logitech_receiver/test_hidpp20_complex.py
@@ -1039,7 +1039,7 @@ def test_centurion_bridge_request_write():
 def test_centurion_firmware_dedup():
     """get_firmware_centurion() deduplicates identical firmware entries."""
     # Simulate parent device that returns the same firmware for every entity index
-    fw_response = "00" + "00" + "0105" + "04" + "44303031" + "00" * 20  # type=0, ver=1.05, name="D001"
+    fw_response = "01" + "02" + "0105" + "04" + "44303031" + "00" * 20  # ver 1.2.261, name="D001"
     responses = fake_hidpp.r_centurion_headset + [fake_hidpp.Response(fw_response, 0x0210, f"{i:02X}") for i in range(8)]
     dev = fake_hidpp.Device("CENT_DEDUP", True, 2.6, responses, centurion=True)
 
@@ -1049,6 +1049,33 @@ def test_centurion_firmware_dedup():
     assert fw is not None
     assert len(fw) == 1
     assert fw[0].name == "D001"
+    assert fw[0].version == "1.2.261"
+    assert fw[0].kind == common.FirmwareKind.Firmware
+
+
+@pytest.mark.parametrize(
+    "codename, response, version",
+    [
+        # PRO X 2 LIGHTSPEED and its dongle both answer this; G HUB shows 1.2.2.
+        ("CENT_PROX2", "0102000200", "1.2.2"),
+        # G325 LIGHTSPEED. Byte 2 is non-zero here, which is what pins the build
+        # to a BE16: a uint8 build in byte 3 would read 129, and published G HUB
+        # screenshots of this model read 1.0.2177.
+        ("CENT_G325", "0100088100", "1.0.2177"),
+    ],
+)
+def test_centurion_firmware_version(codename, response, version):
+    responses = fake_hidpp.r_centurion_headset + [
+        fake_hidpp.Response(response + "00" * 11, 0x0210, f"{i:02X}") for i in range(8)
+    ]
+    dev = fake_hidpp.Device(codename, True, 2.6, responses, centurion=True)
+
+    fw = _hidpp20.get_firmware_centurion(dev)
+
+    assert len(fw) == 1
+    assert fw[0].version == version
+    assert fw[0].kind == common.FirmwareKind.Firmware
+    assert fw[0].name == ""
 
 
 def test_centurion_sub_device_firmware():
@@ -1057,10 +1084,10 @@ def test_centurion_sub_device_firmware():
     dev._centurion_bridge_index = 3
     dev._centurion_sub_features = set()
     dev._centurion_sub_indices = {hidpp20_constants.SupportedFeature.CENTURION_DEVICE_INFO: 2}
-    # Sub-device firmware: type=0 (firmware), ver=3.02, name="H001"
+    # Sub-device firmware: version 3.2.4, name="H001"
     dev._bridge_responses = {
-        (2, 0x10, "00"): bytes([0x00, 0x00, 0x03, 0x02, 0x04]) + b"H001",
-        (2, 0x10, "01"): bytes([0x00, 0x00, 0x03, 0x02, 0x04]) + b"H001",  # duplicate → dedup stops
+        (2, 0x10, "00"): bytes([0x03, 0x02, 0x00, 0x04, 0x04]) + b"H001",
+        (2, 0x10, "01"): bytes([0x03, 0x02, 0x00, 0x04, 0x04]) + b"H001",  # duplicate → dedup stops
     }
 
     fw = _hidpp20.get_firmware_centurion_sub(dev)
@@ -1068,7 +1095,7 @@ def test_centurion_sub_device_firmware():
     assert fw is not None
     assert len(fw) == 1
     assert fw[0].name == "H001"
-    assert fw[0].version == "3.02"
+    assert fw[0].version == "3.2.4"
 
 
 def test_centurion_sub_device_serial():


### PR DESCRIPTION
DeviceInfo (0x0100) function 1 returns a plain binary major.minor.build triple:

    byte 0     major
    byte 1     minor
    bytes 2-3  build (BE16)
    byte 4     nameLen
    bytes 5+   name

It was being read as a firmware-type byte followed by a version word, which is the Feature 0x0003 shape and not this one.  That took byte 0 as a FirmwareKind, took the build as the version, and never read byte 1 at all.

A PRO X 2 LIGHTSPEED and its dongle both answer 01 02 00 02 00 -- version 1.2.2, which is what G HUB shows for both.  Solaar printed

    Firmware: 1 0.02

labelling the main firmware as a bootloader and showing its build number as the version.  It now prints 1.2.2 with kind Firmware.

Read over hidraw from the dongle 2026-08-17: function 1 returns the same 01 02 00 02 00 for every entity index (the existing dedup-on-signature loop is still needed and unchanged), and function 0 returns 1a ff 05 08.

The response carries no firmware-type field, so the kind is chosen rather than parsed; Firmware is the sensible default for what is the only entity these devices report.

A G325 LIGHTSPEED settles the build field.  It answers 01 00 08 81 00 in a solaar show log captured while adding support for it.  Byte 2 is non-zero there, so the two candidate readings finally disagree: a reserved byte 2 plus a uint8 build in byte 3 gives 129, a BE16 gives 2177.

Published G HUB screenshots of the G325 read 1.0.2177.  Those are not the unit the log came from, so this is corroboration rather than a paired observation -- but every G325 capture found carries that same version, and 2177 is exactly what the BE16 reading yields from the logged bytes while the alternative yields a number no screenshot shows.  Bytes 2-3 are a BE16 build.

Byte 4 as nameLen is still inherited from the previous reading rather than observed -- it is 00 on both devices seen so far, so neither sample exercises it.  Function 2 does use that layout, which makes it plausible; a device reporting a non-empty firmware name would confirm it.

The parse is now shared by the device and sub-device readers instead of duplicated.  The existing tests encoded the old misreading in their fixtures; they are rebuilt around the layout above, plus the bytes read off the hardware.

The CENTURION DEVICE INFO dump stops printing the kind with the version. That field is chosen by this parser, not sent by the device, and a raw dump is the one place that should show only what came off the wire -- it read "Firmware: 0 1.2.2" as though the 0 were reported.  Synthesizing a kind for the model itself is unchanged and matches what get_firmware for HID++ 1.0 already does, where the kind comes from which register was read rather than from any type byte.