### PR TITLE
Align the colons in the solaar show device summary

### DIFF
--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -184,12 +184,12 @@ def _print_device(dev, num=None):
     else:
         print("     Protocol     : unknown (device is offline)")
     if not is_centurion and dev.polling_rate:
-        print("     Report Rate :", dev.polling_rate)
+        print("     Report Rate  :", dev.polling_rate)
     print("     Serial number:", dev.serial)
     if dev.modelId:
-        print("     Model ID:     ", dev.modelId)
+        print("     Model ID     :", dev.modelId)
     if dev.unitId:
-        print("     Unit ID:      ", dev.unitId)
+        print("     Unit ID      :", dev.unitId)
     if dev.firmware:
         for fw in dev.firmware:
             print(f"       {fw.kind:11}:", (fw.name + " " + fw.version).strip())


### PR DESCRIPTION
Three labels in the device summary sit a column off from the rest:

     Protocol     : HID++ 4.2
     Report Rate : 1ms
     Serial number: 6FF83E8B
     Model ID:      4099C0950000
     Unit ID:       6FF83E8B

Neither offset looks deliberate.  "Report Rate" arrived in a6f7507c as a rename of "Polling rate", one character shorter, and kept the old single trailing space, so its label is 12 columns where every neighbour is 13. "Model ID" and "Unit ID" arrived in b1d4b2f3 written as label, colon, then padding, rather than the padded label then colon used above them; both still land their values in the shared column, so the values were clearly being aligned and the colon simply followed the other style.

Pad all three to the 13-column label the rest of the block uses, so the colons line up with the values that already did.

Battery, Notifications and Features are left alone -- those read as sentences rather than as entries in this column.