### PR TITLE
Report one Logitech-style firmware version in the summary views

### DIFF
--- a/docs/devices/G560 Gaming Speaker 0A78.txt
+++ b/docs/devices/G560 Gaming Speaker 0A78.txt
@@ -1,0 +1,64 @@
+G560 Gaming Speaker
+     Device path  : /dev/hidraw11
+     USB id       : 046d:0A78
+     Codename     : G560 Gaming Speaker
+     Kind         : speaker
+     Protocol     : HID++ 4.2
+     Serial number: 
+     Model ID:      000000000A78
+     Unit ID:       FFFFFFFF
+                 0: U1  22.04.B0370
+     Supports 10 HID++ 2.0 features:
+         0: ROOT                   {0000} V0     
+         1: FEATURE SET            {0001}
+         2: DEVICE FW VERSION      {0003}
+            Firmware: 0 U1  22.04.B0370 0A78
+            Unit ID: FFFFFFFF  Model ID: 000000000A78  Transport IDs: {'btid': '0000', 'btleid': '0000'}
+         3: DEVICE NAME            {0005}
+            Name: G560 Gaming Speaker
+            Kind: speaker
+         4: COLOR LED EFFECTS      {8070}
+            Zone 0 (Left Front): 5 effect(s)
+              [0] 0x00 Disabled       caps 0x0000=none                  default 0ms  params: —
+              [1] 0x01 Static         caps 0x0000=none                  default 0ms  params: color, ramp
+              [2] 0x03 Cycle          caps 0xc005=color+period+fw       default 1000ms  params: period, intensity
+              [3] 0x07 Audio Visualizer caps 0x0067=color+fade+period++0x0060 default 1000ms  params: cycle, color, period
+              [4] 0x0a Breathe        caps 0xc105=color+period+fw++0x0100 default 60ms  params: color, period, form, intensity
+            Zone 1 (Right Front): 5 effect(s)
+              [0] 0x00 Disabled       caps 0x0000=none                  default 0ms  params: —
+              [1] 0x01 Static         caps 0x0000=none                  default 0ms  params: color, ramp
+              [2] 0x03 Cycle          caps 0xc005=color+period+fw       default 1000ms  params: period, intensity
+              [3] 0x07 Audio Visualizer caps 0x0067=color+fade+period++0x0060 default 1000ms  params: cycle, color, period
+              [4] 0x0a Breathe        caps 0xc105=color+period+fw++0x0100 default 60ms  params: color, period, form, intensity
+            Zone 2 (Left Rear): 5 effect(s)
+              [0] 0x00 Disabled       caps 0x0000=none                  default 0ms  params: —
+              [1] 0x01 Static         caps 0x0000=none                  default 0ms  params: color, ramp
+              [2] 0x03 Cycle          caps 0xc005=color+period+fw       default 1000ms  params: period, intensity
+              [3] 0x07 Audio Visualizer caps 0x0067=color+fade+period++0x0060 default 1000ms  params: cycle, color, period
+              [4] 0x0a Breathe        caps 0xc105=color+period+fw++0x0100 default 60ms  params: color, period, form, intensity
+            Zone 3 (Right Rear): 5 effect(s)
+              [0] 0x00 Disabled       caps 0x0000=none                  default 0ms  params: —
+              [1] 0x01 Static         caps 0x0000=none                  default 0ms  params: color, ramp
+              [2] 0x03 Cycle          caps 0xc005=color+period+fw       default 1000ms  params: period, intensity
+              [3] 0x07 Audio Visualizer caps 0x0067=color+fade+period++0x0060 default 1000ms  params: cycle, color, period
+              [4] 0x0a Breathe        caps 0xc105=color+period+fw++0x0100 default 60ms  params: color, period, form, intensity
+            LED Control (saved): False
+            LED Control        : False
+            LEDs Left Front (saved): !LEDEffectSetting {ID: 7, color: 0xff7800, cycle: 0, direction: 0, form: 0, intensity: 0, period: 5000, ramp: 0, saturation: 0, speed: 0}
+            LEDs Left Front        : !LEDEffectSetting {ID: 7, color: 0xff6000, cycle: 0, period: 4839}
+            LEDs Right Front (saved): !LEDEffectSetting {ID: 7, color: 0xff7800, cycle: 0, direction: 0, form: 0, intensity: 0, period: 5000, ramp: 0, saturation: 0, speed: 0}
+            LEDs Right Front        : !LEDEffectSetting {ID: 7, color: 0xff6000, cycle: 0, period: 4839}
+            LEDs Left Rear (saved): !LEDEffectSetting {ID: 7, color: 0xf6f5f4, cycle: 0, direction: 0, form: 0, intensity: 100, period: 5000, ramp: 0, saturation: 0, speed: 0}
+            LEDs Left Rear        : !LEDEffectSetting {ID: 7, color: 0xffffff, cycle: 0, period: 4839}
+            LEDs Right Rear (saved): !LEDEffectSetting {ID: 7, color: 0xf6f5f4, cycle: 0, direction: 0, form: 0, intensity: 0, period: 5000, ramp: 0, saturation: 0, speed: 0}
+            LEDs Right Rear        : !LEDEffectSetting {ID: 7, color: 0xffffff, cycle: 0, period: 4839}
+         5: GKEY                   {8010}
+            Divert G and M Keys (saved): False
+            Divert G and M Keys        : False
+         6: EQUALIZER              {8310}
+         7: HEADSET OUT            {8320}
+         8: BRIGHTNESS CONTROL     {8040}
+            Brightness Control (saved): 100
+            Brightness Control        : 100
+         9: unknown:8305           {0583} V0     
+     Battery status unavailable.

--- a/docs/devices/G560 Gaming Speaker 0A78.txt
+++ b/docs/devices/G560 Gaming Speaker 0A78.txt
@@ -4,12 +4,12 @@ G560 Gaming Speaker
      Codename     : G560 Gaming Speaker
      Kind         : speaker
      Protocol     : HID++ 4.2
-     Serial number: 
+     Serial number:
      Model ID:      000000000A78
      Unit ID:       FFFFFFFF
                  0: U1  22.04.B0370
      Supports 10 HID++ 2.0 features:
-         0: ROOT                   {0000} V0     
+         0: ROOT                   {0000} V0
          1: FEATURE SET            {0001}
          2: DEVICE FW VERSION      {0003}
             Firmware: 0 U1  22.04.B0370 0A78
@@ -60,5 +60,5 @@ G560 Gaming Speaker
          8: BRIGHTNESS CONTROL     {8040}
             Brightness Control (saved): 100
             Brightness Control        : 100
-         9: unknown:8305           {0583} V0     
+         9: unknown:8305           {0583} V0
      Battery status unavailable.

--- a/docs/devices/G560 Gaming Speaker 0A78.txt
+++ b/docs/devices/G560 Gaming Speaker 0A78.txt
@@ -1,5 +1,5 @@
 G560 Gaming Speaker
-     Device path  : /dev/hidraw11
+     Device path  : /dev/hidraw1
      USB id       : 046d:0A78
      Codename     : G560 Gaming Speaker
      Kind         : speaker
@@ -10,14 +10,14 @@ G560 Gaming Speaker
                  0: U1  22.04.B0370
      Supports 10 HID++ 2.0 features:
          0: ROOT                   {0000} V0
-         1: FEATURE SET            {0001}
-         2: DEVICE FW VERSION      {0003}
+         1: FEATURE SET            {0001} V0
+         2: DEVICE FW VERSION      {0003} V2
             Firmware: 0 U1  22.04.B0370 0A78
             Unit ID: FFFFFFFF  Model ID: 000000000A78  Transport IDs: {'btid': '0000', 'btleid': '0000'}
-         3: DEVICE NAME            {0005}
+         3: DEVICE NAME            {0005} V0
             Name: G560 Gaming Speaker
             Kind: speaker
-         4: COLOR LED EFFECTS      {8070}
+         4: COLOR LED EFFECTS      {8070} V5
             Zone 0 (Left Front): 5 effect(s)
               [0] 0x00 Disabled       caps 0x0000=none                  default 0ms  params: —
               [1] 0x01 Static         caps 0x0000=none                  default 0ms  params: color, ramp
@@ -43,22 +43,26 @@ G560 Gaming Speaker
               [3] 0x07 Audio Visualizer caps 0x0067=color+fade+period++0x0060 default 1000ms  params: cycle, color, period
               [4] 0x0a Breathe        caps 0xc105=color+period+fw++0x0100 default 60ms  params: color, period, form, intensity
             LED Control (saved): False
-            LED Control        : False
-            LEDs Left Front (saved): !LEDEffectSetting {ID: 7, color: 0xff7800, cycle: 0, direction: 0, form: 0, intensity: 0, period: 5000, ramp: 0, saturation: 0, speed: 0}
-            LEDs Left Front        : !LEDEffectSetting {ID: 7, color: 0xff6000, cycle: 0, period: 4839}
-            LEDs Right Front (saved): !LEDEffectSetting {ID: 7, color: 0xff7800, cycle: 0, direction: 0, form: 0, intensity: 0, period: 5000, ramp: 0, saturation: 0, speed: 0}
-            LEDs Right Front        : !LEDEffectSetting {ID: 7, color: 0xff6000, cycle: 0, period: 4839}
-            LEDs Left Rear (saved): !LEDEffectSetting {ID: 7, color: 0xf6f5f4, cycle: 0, direction: 0, form: 0, intensity: 100, period: 5000, ramp: 0, saturation: 0, speed: 0}
-            LEDs Left Rear        : !LEDEffectSetting {ID: 7, color: 0xffffff, cycle: 0, period: 4839}
-            LEDs Right Rear (saved): !LEDEffectSetting {ID: 7, color: 0xf6f5f4, cycle: 0, direction: 0, form: 0, intensity: 0, period: 5000, ramp: 0, saturation: 0, speed: 0}
-            LEDs Right Rear        : !LEDEffectSetting {ID: 7, color: 0xffffff, cycle: 0, period: 4839}
-         5: GKEY                   {8010}
+            LED Control        : True
+            LEDs Left Front (saved): !LEDEffectSetting {ID: 7, color: 0x00dbff, cycle: 0, direction: 0, form: 0, intensity: 0, period: 5000, ramp: 0, saturation: 0, speed: 0}
+            LEDs Left Front        : !LEDEffectSetting {ID: 1, color: 0xd04809, ramp: 2}
+            LEDs Right Front (saved): !LEDEffectSetting {ID: 7, color: 0x00dbff, cycle: 0, direction: 0, form: 0, intensity: 100, period: 5000, ramp: 0, saturation: 0, speed: 0}
+            LEDs Right Front        : !LEDEffectSetting {ID: 1, color: 0x7f2c06, ramp: 2}
+            LEDs Left Rear (saved): !LEDEffectSetting {ID: 7, color: 0xff0081, cycle: 0, direction: 0, form: 0, intensity: 100, period: 5000, ramp: 0, saturation: 0, speed: 0}
+            LEDs Left Rear        : !LEDEffectSetting {ID: 1, color: 0x812d06, ramp: 2}
+            LEDs Right Rear (saved): !LEDEffectSetting {ID: 7, color: 0xff0081, cycle: 0, direction: 0, form: 0, intensity: 0, period: 5000, ramp: 0, saturation: 0, speed: 0}
+            LEDs Right Rear        : !LEDEffectSetting {ID: 1, color: 0x7f2c06, ramp: 2}
+            Startup Animation (saved): False
+            Startup Animation        : False
+         5: GKEY                   {8010} V0
             Divert G and M Keys (saved): False
             Divert G and M Keys        : False
-         6: EQUALIZER              {8310}
-         7: HEADSET OUT            {8320}
-         8: BRIGHTNESS CONTROL     {8040}
+         6: EQUALIZER              {8310} V3
+         7: JACK DETECTION         {8320} V0
+         8: BRIGHTNESS CONTROL     {8040} V0
             Brightness Control (saved): 100
             Brightness Control        : 100
-         9: unknown:8305           {0583} V0
+         9: BASS TONE              {8305} V0
+            Bass Level (saved): 50
+            Bass Level        : 50
      Battery status unavailable.

--- a/docs/devices/G560 Gaming Speaker 0A78.txt
+++ b/docs/devices/G560 Gaming Speaker 0A78.txt
@@ -1,5 +1,5 @@
 G560 Gaming Speaker
-     Device path  : /dev/hidraw1
+     Device path  : /dev/hidraw20
      USB id       : 046d:0A78
      Codename     : G560 Gaming Speaker
      Kind         : speaker
@@ -7,7 +7,7 @@ G560 Gaming Speaker
      Serial number:
      Model ID:      000000000A78
      Unit ID:       FFFFFFFF
-                 0: U1  22.04.B0370
+     Firmware     : 122.4.370
      Supports 10 HID++ 2.0 features:
          0: ROOT                   {0000} V0
          1: FEATURE SET            {0001} V0
@@ -45,13 +45,13 @@ G560 Gaming Speaker
             LED Control (saved): False
             LED Control        : True
             LEDs Left Front (saved): !LEDEffectSetting {ID: 7, color: 0x00dbff, cycle: 0, direction: 0, form: 0, intensity: 0, period: 5000, ramp: 0, saturation: 0, speed: 0}
-            LEDs Left Front        : !LEDEffectSetting {ID: 1, color: 0xd04809, ramp: 2}
+            LEDs Left Front        : !LEDEffectSetting {ID: 1, color: 0x7f2c06, ramp: 2}
             LEDs Right Front (saved): !LEDEffectSetting {ID: 7, color: 0x00dbff, cycle: 0, direction: 0, form: 0, intensity: 100, period: 5000, ramp: 0, saturation: 0, speed: 0}
-            LEDs Right Front        : !LEDEffectSetting {ID: 1, color: 0x7f2c06, ramp: 2}
+            LEDs Right Front        : !LEDEffectSetting {ID: 1, color: 0xff590b, ramp: 2}
             LEDs Left Rear (saved): !LEDEffectSetting {ID: 7, color: 0xff0081, cycle: 0, direction: 0, form: 0, intensity: 100, period: 5000, ramp: 0, saturation: 0, speed: 0}
-            LEDs Left Rear        : !LEDEffectSetting {ID: 1, color: 0x812d06, ramp: 2}
+            LEDs Left Rear        : !LEDEffectSetting {ID: 1, color: 0xff590b, ramp: 2}
             LEDs Right Rear (saved): !LEDEffectSetting {ID: 7, color: 0xff0081, cycle: 0, direction: 0, form: 0, intensity: 0, period: 5000, ramp: 0, saturation: 0, speed: 0}
-            LEDs Right Rear        : !LEDEffectSetting {ID: 1, color: 0x7f2c06, ramp: 2}
+            LEDs Right Rear        : !LEDEffectSetting {ID: 1, color: 0xff590b, ramp: 2}
             Startup Animation (saved): False
             Startup Animation        : False
          5: GKEY                   {8010} V0

--- a/lib/logitech_receiver/common.py
+++ b/lib/logitech_receiver/common.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import binascii
 import dataclasses
+import re
 import typing
 
 from enum import Flag
@@ -635,6 +636,27 @@ class FirmwareInfo:
     name: str
     version: str
     extras: str | None
+
+
+_FIRMWARE_VERSION_RE = re.compile(r"^(\d+)\.(\d+)(?:\.B?(\d+))?$")
+
+
+def firmware_version_tuple(firmware: FirmwareInfo) -> tuple[int, int, int] | None:
+    """A firmware's comparable (number, revision, build).
+
+    The number field only holds two digits, so a version past 99 carries its
+    hundreds digit in the name prefix ("U1 " is 1xx). That is why this takes
+    the whole FirmwareInfo: the version string alone sorts a pre-rollover
+    98.xx above a post-rollover 122.xx.
+    """
+    match = _FIRMWARE_VERSION_RE.match(firmware.version.strip())
+    if not match:
+        return None
+    number, revision, build = int(match.group(1)), int(match.group(2)), int(match.group(3) or 0)
+    name = firmware.name
+    if len(name) == 3 and name[0] == "U" and name[1].isdigit() and name[2] == " ":
+        number += int(name[1]) * 100
+    return number, revision, build
 
 
 class BatteryStatus(Flag):

--- a/lib/logitech_receiver/common.py
+++ b/lib/logitech_receiver/common.py
@@ -659,6 +659,33 @@ def firmware_version_tuple(firmware: FirmwareInfo) -> tuple[int, int, int] | Non
     return number, revision, build
 
 
+def main_firmware(firmware: Iterable[FirmwareInfo] | None) -> FirmwareInfo | None:
+    """The main firmware entity, the one Logitech versions a device by.
+
+    Several entities can report kind Firmware; take the highest, as G HUB does.
+    """
+    candidates = [fw for fw in firmware or () if fw.kind == FirmwareKind.Firmware]
+    parsed = [fw for fw in candidates if firmware_version_tuple(fw) is not None]
+    if parsed:
+        return max(parsed, key=firmware_version_tuple)
+    return candidates[0] if candidates else None
+
+
+def firmware_display_version(firmware: FirmwareInfo) -> str:
+    """A firmware version written the way Logitech writes it, e.g. "122.4.370".
+
+    Unparsable versions fall back to the raw name and version, so nothing is
+    ever hidden just because a device numbers itself unusually.
+    """
+    parsed = firmware_version_tuple(firmware)
+    if parsed is None:
+        return (firmware.name + " " + firmware.version).strip()
+    number, revision, build = parsed
+    if len(firmware.version.strip().split(".")) < 3:
+        return f"{number}.{revision}"
+    return f"{number}.{revision}.{build}"
+
+
 class BatteryStatus(Flag):
     DISCHARGING = 0x00
     RECHARGING = 0x01

--- a/lib/logitech_receiver/device_quirks.py
+++ b/lib/logitech_receiver/device_quirks.py
@@ -98,15 +98,9 @@ SETTING_INERT_FIRMWARE: dict[str, dict[str, tuple[tuple | None, tuple | None]]] 
 
 
 def _main_firmware_version(device) -> tuple[int, int, int] | None:
-    """Highest main-firmware version on the device, the entity G HUB reports."""
-    versions = [
-        version
-        for fw in getattr(device, "firmware", None) or ()
-        if fw.kind == common.FirmwareKind.Firmware
-        for version in (common.firmware_version_tuple(fw),)
-        if version is not None
-    ]
-    return max(versions, default=None)
+    """The device's main-firmware version, or None if it can't be read."""
+    firmware = common.main_firmware(getattr(device, "firmware", None))
+    return common.firmware_version_tuple(firmware) if firmware else None
 
 
 def setting_inert(device, setting_name: str) -> bool:

--- a/lib/logitech_receiver/device_quirks.py
+++ b/lib/logitech_receiver/device_quirks.py
@@ -1,4 +1,4 @@
-"""Per-device-model quirks for RGB lighting.
+"""Per-device-model quirks for RGB lighting and firmware-gated settings.
 
 Keyed by ``device.modelId``. For normal HID++ devices that is the string
 Logitech composes by concatenating every transport PID (btid + btleid + wpid
@@ -19,6 +19,12 @@ Two postures, by feature class:
   field is hidden and every slot suppressed unless the exact model is listed
   here as known-good.
 
+* **Settings a firmware revision stubbed out** — default-ALLOW, suppressed only
+  over the firmware ranges named in ``SETTING_INERT_FIRMWARE``. A feature that
+  is advertised and round-trips cleanly but does nothing is indistinguishable
+  from a working one over the wire, so the version boundary has to be recorded
+  by hand.
+
 Setting ``SOLAAR_EXPERIMENTAL`` truthy bypasses the allowlists entirely — for
 testers / reverse-engineering on devices not yet validated.
 
@@ -27,7 +33,12 @@ Entries are hand-curated; document the observation in a comment.
 
 from __future__ import annotations
 
+import logging
 import os
+
+from . import common
+
+logger = logging.getLogger(__name__)
 
 _ALL_NVCONFIG_FIELDS = {"color1", "color2", "speed"}
 
@@ -67,6 +78,62 @@ HEADSET_SIGNATURE_EFFECTS_ALLOWED: dict[str, dict[int, set[str]]] = {
         1: {"color1", "color2"},
     },
 }
+
+
+# Settings the firmware only backs over part of a device's version history.
+# modelId -> setting name -> (inert_from, inert_before), each a
+# (number, revision, build) tuple or None for an open end. The setting is
+# suppressed at or above `inert_from`, and below `inert_before`.
+SETTING_INERT_FIRMWARE: dict[str, dict[str, tuple[tuple | None, tuple | None]]] = {
+    # G560 Gaming Speaker — firmware 122.3.23 retired the hardware equalizer
+    # (0x8310) and brought up subwoofer level (0x8305). From that version on
+    # the EQ still advertises and round-trips but is audibly silent; verified
+    # inert on 122.4.370, where bass does work. Older firmware appears not to
+    # carry 0x8305 at all, so that bound is defensive.
+    "000000000A78": {
+        "equalizer": ((122, 3, 23), None),
+        "bass_tone": (None, (122, 3, 23)),
+    },
+}
+
+
+def _main_firmware_version(device) -> tuple[int, int, int] | None:
+    """Highest main-firmware version on the device, the entity G HUB reports."""
+    versions = [
+        version
+        for fw in getattr(device, "firmware", None) or ()
+        if fw.kind == common.FirmwareKind.Firmware
+        for version in (common.firmware_version_tuple(fw),)
+        if version is not None
+    ]
+    return max(versions, default=None)
+
+
+def setting_inert(device, setting_name: str) -> bool:
+    """True when this device's firmware is known not to back the named setting.
+
+    Fails open: firmware that can't be read or parsed exposes the setting rather
+    than risk hiding a working control.
+    """
+    if _experimental():
+        return False
+    model_id = getattr(device, "modelId", None) or ""
+    bounds = SETTING_INERT_FIRMWARE.get(model_id, {}).get(setting_name)
+    if bounds is None:
+        return False
+    version = _main_firmware_version(device)
+    if version is None:
+        return False
+    inert_from, inert_before = bounds
+    inert = (inert_from is not None and version >= inert_from) or (inert_before is not None and version < inert_before)
+    if inert:
+        logger.info(
+            "%s: hiding %s — firmware %s does not back it",
+            model_id,
+            setting_name,
+            ".".join(str(part) for part in version),
+        )
+    return inert
 
 
 def rgb_effects_nvconfig_allowed_fields(device, cap_id: int) -> set[str] | None:

--- a/lib/logitech_receiver/hidpp10_constants.py
+++ b/lib/logitech_receiver/hidpp10_constants.py
@@ -43,6 +43,16 @@ DEVICE_KIND = NamedInts(
     headset=0x0D,  # not from Logitech documentation
     remote_control=0x0E,  # for compatibility with HID++ 2.0
     receiver=0x0F,  # for compatibility with HID++ 2.0
+    # 0x10 and up: not HID++ 1.0 protocol values, only for compatibility with HID++ 2.0
+    webcam=0x10,
+    steering_wheel=0x11,
+    dock=0x12,
+    speaker=0x13,
+    microphone=0x14,
+    illumination_light=0x15,
+    programmable_controller=0x16,
+    car_sim_pedals=0x17,
+    adapter=0x18,
 )
 
 

--- a/lib/logitech_receiver/hidpp20.py
+++ b/lib/logitech_receiver/hidpp20.py
@@ -1170,10 +1170,15 @@ class LEDParam:
     form = "form"
     saturation = "saturation"
     direction = "direction"
+    cycle = "cycle"
 
 
 # NamedInts (not IntEnum) so the GTK ComboBoxText shows readable labels.
 LedRampChoice = common.NamedInts(Default=0, Yes=1, No=2)
+
+# Audio Visualizer color mode: values >= 2 select unmapped non-pulsing
+# sub-modes, so only the two known ones are exposed.
+LedCycleChoices = common.NamedInts(Off=0, On=1)
 
 LedFormChoices = common.NamedInts(
     Default=0,
@@ -1211,6 +1216,7 @@ LEDParamSize = {
     LEDParam.form: 1,
     LEDParam.saturation: 1,
     LEDParam.direction: 1,
+    LEDParam.cycle: 1,
 }
 # Entry: [NamedInt, params, defaults, ranges] — trailing dicts optional.
 # ranges overrides a field's global min/max, e.g. period: (2, 200).
@@ -1228,6 +1234,13 @@ LEDEffects = {
     0x04: [
         NamedInt(0x04, _("Wave")),
         {LEDParam.period: 6, LEDParam.direction: 9},
+        {LEDParam.period: 5000},
+    ],
+    # G560 factory default: pulses brightness with audio; cycle On
+    # self-cycles hue (color ignored), Off pulses the fixed color.
+    0x07: [
+        NamedInt(0x07, _("Audio Visualizer")),
+        {LEDParam.cycle: 0, LEDParam.color: 1, LEDParam.period: 5},
         {LEDParam.period: 5000},
     ],
     0x08: [NamedInt(0x08, _("Boot")), {}],
@@ -1350,13 +1363,23 @@ LEDZoneLocations[0x09] = _("Primary 4")
 LEDZoneLocations[0x0A] = _("Primary 5")
 LEDZoneLocations[0x0B] = _("Primary 6")
 
+# Location codes mean different things per device kind; these override the
+# mouse/keyboard table above, falling back to it for codes they don't name.
+LEDZoneLocationsByKind = {"speaker": common.NamedInts()}
+LEDZoneLocationsByKind["speaker"][0x01] = _("Left Front")
+LEDZoneLocationsByKind["speaker"][0x02] = _("Right Front")
+LEDZoneLocationsByKind["speaker"][0x03] = _("Left Rear")
+LEDZoneLocationsByKind["speaker"][0x04] = _("Right Rear")
+
 
 class LEDZoneInfo:  # effects that a zone can do
     def __init__(self, feature, function, offset, effect_function, device, index):
         info = device.feature_request(feature, function, index, 0xFF, 0x00)
         self.location, self.count = struct.unpack("!HB", info[1 + offset : 4 + offset])
         self.index = index
-        self.location = LEDZoneLocations[self.location] if LEDZoneLocations[self.location] else self.location
+        kind_locations = LEDZoneLocationsByKind.get(str(getattr(device, "kind", None)))
+        location = kind_locations[self.location] if kind_locations else None
+        self.location = location or LEDZoneLocations[self.location] or self.location
         self.effects = []
         for i in range(0, self.count):
             self.effects.append(LEDEffectInfo(feature, effect_function, device, index, i))

--- a/lib/logitech_receiver/hidpp20_constants.py
+++ b/lib/logitech_receiver/hidpp20_constants.py
@@ -175,10 +175,11 @@ class SupportedFeature(IntEnum):
     OPERATING_RANGE = 0x8138
     TRUE_FORCE = 0x8139
     FFB_FILTER = 0x8140
-    # Headsets
+    # Headsets / speakers
     SIDETONE = 0x8300
+    BASS_TONE = 0x8305
     EQUALIZER = 0x8310
-    HEADSET_OUT = 0x8320
+    JACK_DETECTION = 0x8320  # jack presence (was HEADSET_OUT)
     # Centurion core
     CENTURION_DEVICE_INFO = 0x0100
     CENTURION_DEVICE_NAME = 0x0101

--- a/lib/logitech_receiver/hidpp20_constants.py
+++ b/lib/logitech_receiver/hidpp20_constants.py
@@ -257,6 +257,18 @@ DEVICE_KIND = NamedInts(
     trackball=0x05,
     presenter=0x06,
     receiver=0x07,
+    headset=0x08,
+    webcam=0x09,
+    steering_wheel=0x0A,
+    joystick=0x0B,
+    gamepad=0x0C,
+    dock=0x0D,
+    speaker=0x0E,
+    microphone=0x0F,
+    illumination_light=0x10,
+    programmable_controller=0x11,
+    car_sim_pedals=0x12,
+    adapter=0x13,
 )
 
 

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -3246,6 +3246,18 @@ class LEDControl(settings.Setting):
                         logger.warning("%s: post-claim repaint of %s failed: %s", self._device, s.name, e)
         return result
 
+    def apply(self):
+        # Off = leave the lighting alone on connect (don't send the release);
+        # another app may own it. Only an explicit On claim is applied.
+        try:
+            value = self.read(self.persist)
+        except Exception:
+            value = None
+        if value:
+            super().apply()
+        elif logger.isEnabledFor(logging.DEBUG):
+            logger.debug("%s: LED control off — leaving lighting untouched on %s", self.name, self._device)
+
 
 colors = special_keys.COLORS
 _LEDP = hidpp20.LEDParam
@@ -3257,6 +3269,20 @@ class LEDZoneSetting(settings.Setting):
     label = _("LED Zone Effects")
     description = _("Set effect for LED Zone") + "\n" + _("LED Control needs to be enabled.")
     feature = _F.COLOR_LED_EFFECTS
+    gate_setting_name = LEDControl.name
+
+    def apply(self):
+        # Skip when the control gate is off (SETTINGS order runs it first, so
+        # its _value is set) — leave the lighting to whatever owns it.
+        for s in self._device.settings:
+            if s.name == self.gate_setting_name:
+                if not s._value:
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.debug("%s: %s off — not applying on %s", self.name, s.name, self._device)
+                    return
+                break
+        super().apply()
+
     color_field = {"name": _LEDP.color, "kind": settings.Kind.COLOR, "label": _("Color")}
     speed_field = {"name": _LEDP.speed, "kind": settings.Kind.RANGE, "label": _("Speed"), "min": 0, "max": 255}
     period_field = {
@@ -3809,6 +3835,7 @@ class RGBEffectSetting(LEDZoneSetting):
     label = _("LED Zone Effects")
     description = _("Set effect for LED Zone") + "\n" + _("LED Control needs to be enabled.")
     feature = _F.RGB_EFFECTS
+    gate_setting_name = RGBControl.name
     # 0x8071 firmware-fixes ramp/form bytes; drop those widgets here.
     possible_fields = [
         LEDZoneSetting.color_field,

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -3330,6 +3330,34 @@ class LEDZoneSetting(settings.Setting):
         return cls.setup(device, 0xE0, 0x30, b"")
 
 
+class LEDStartupAnimation(settings.Setting):
+    """Startup effect on/off via 0x8070 NvConfig (funcs 4/5, cap 0x0001, V1+).
+
+    A pure toggle with no color payload; GetNvConfig echoes the capability ID
+    ahead of the value.
+    """
+
+    name = "led_startup_animation"
+    label = _("Startup Animation")
+    description = (
+        _("Firmware-played animation when the device powers on.") + "\n" + _("Setting persists on the device (non-volatile).")
+    )
+    feature = _F.COLOR_LED_EFFECTS
+    min_version = 1
+    rw_options = {"read_fnid": 0x40, "write_fnid": 0x50, "prefix": b"\x00\x01"}  # NvConfig capability 0x0001
+    validator_class = settings_validator.BooleanValidator
+    validator_options = {"true_value": 0x01, "false_value": 0x02, "read_skip_byte_count": 2}
+
+    @classmethod
+    def build(cls, device):
+        try:  # gate on the device actually supporting the capability
+            if not device.feature_request(cls.feature, 0x40, b"\x00\x01"):
+                return None
+        except exceptions.FeatureCallError:
+            return None
+        return super().build(device)
+
+
 class RGBControl(settings.Setting):
     name = "rgb_control"
     label = _("LED Control")
@@ -4503,6 +4531,7 @@ SETTINGS: list[settings.Setting] = [
     Backlight3,
     LEDControl,
     LEDZoneSetting,
+    LEDStartupAnimation,
     RGBControl,
     RGBEffectSetting,
     PerKeyLighting,

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1587,6 +1587,16 @@ class Sidetone(settings.Setting):
     max_value = 100
 
 
+class BassTone(settings.Setting):
+    name = "bass_tone"
+    label = _("Bass Level")
+    description = _("Set subwoofer bass level.")
+    feature = _F.BASS_TONE
+    validator_class = settings_validator.RangeValidator
+    min_value = 0
+    max_value = 100
+
+
 class Equalizer(settings.RangeFieldSetting):
     name = "equalizer"
     label = _("Equalizer")
@@ -1596,16 +1606,21 @@ class Equalizer(settings.RangeFieldSetting):
     keys_universe = []
 
     class validator_class(settings_validator.PackedRangeValidator):
+        kind = settings.Kind.GRAPHIC_EQ
+
         @classmethod
         def build(cls, setting_class, device):
             data = device.feature_request(_F.EQUALIZER, 0x00)
             if not data:
                 return None
-            count, dbRange, _x, dbMin, dbMax = struct.unpack("!BBBBB", data[:5])
-            if dbMin == 0:
-                dbMin = -dbRange
-            if dbMax == 0:
-                dbMax = dbRange
+            # dbMin/dbMax are signed; the G560 reports an asymmetric -20..+6
+            count, dbRange, _x, dbMin, dbMax = struct.unpack("!BBBbb", data[:5])
+            if dbMin == 0 and dbMax == 0:
+                dbMin, dbMax = -dbRange, dbRange
+            else:
+                # reported bounds are exclusive: the G560 NACKs writes at
+                # exactly dbMin/dbMax but accepts dbMin+1..dbMax-1
+                dbMin, dbMax = dbMin + 1, dbMax - 1
             map = common.NamedInts()
             for g in range((count + 6) // 7):
                 freqs = device.feature_request(_F.EQUALIZER, 0x10, g * 7)
@@ -4520,6 +4535,7 @@ SETTINGS: list[settings.Setting] = [
     HapticLevel,
     PlayHapticWaveForm,
     Sidetone,
+    BassTone,
     Equalizer,
     ADCPower,
     HeadsetEcoMode,

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -3219,6 +3219,18 @@ class LEDControl(settings.Setting):
         if isinstance(self._value, int) and not isinstance(self._value, bool):
             self._value = self._value != 0
 
+    def write(self, value, save=True):
+        result = super().write(value, save)
+        # Repaint saved zone effects after a fresh claim — firmware starts blank.
+        if value and result is not None:
+            for s in self._device.settings:
+                if s.name.startswith(LEDZoneSetting.name) and s._value is not None:
+                    try:
+                        s.write(s._value, save=False)
+                    except Exception as e:
+                        logger.warning("%s: post-claim repaint of %s failed: %s", self._device, s.name, e)
+        return result
+
 
 colors = special_keys.COLORS
 _LEDP = hidpp20.LEDParam
@@ -3250,6 +3262,12 @@ class LEDZoneSetting(settings.Setting):
         "label": _("Direction"),
         "choices": hidpp20.LedDirectionChoices,
     }
+    cycle_field = {
+        "name": _LEDP.cycle,
+        "kind": settings.Kind.CHOICE,
+        "label": _("Color Cycling"),
+        "choices": hidpp20.LedCycleChoices,
+    }
     # Per-widget visibility driven by LEDEffects[ID][1]; RGBEffectSetting
     # overrides this list to drop ramp/form on 0x8071.
     possible_fields = [
@@ -3261,6 +3279,7 @@ class LEDZoneSetting(settings.Setting):
         saturation_field,
         form_field,
         direction_field,
+        cycle_field,
     ]
 
     @classmethod
@@ -3272,11 +3291,14 @@ class LEDZoneSetting(settings.Setting):
             prefix = common.int2bytes(zone.index, 1)
             rw = settings.FeatureRW(cls.feature, read_fnid, write_fnid, prefix=prefix, suffix=suffix)
             validator = settings_validator.HeteroValidator(
-                data_class=hidpp20.LEDEffectSetting, options=zone.effects, readable=infos.readable and read_fnid is not None
+                data_class=hidpp20.LEDEffectSetting,
+                options=zone.effects,
+                readable=infos.readable and read_fnid is not None,
+                read_skip_byte_count=len(prefix),  # GetEffect echoes the zone index
             )
             setting = cls(device, rw, validator)
             setting.name = cls.name + str(int(zone.location))
-            setting.label = _("LEDs") + " " + str(hidpp20.LEDZoneLocations[zone.location])
+            setting.label = _("LEDs") + " " + str(zone.location)
             choices = [hidpp20.LEDEffects[e.ID][0] for e in zone.effects if e.ID in hidpp20.LEDEffects]
             ID_field = {"name": "ID", "kind": settings.Kind.CHOICE, "label": None, "choices": choices}
             setting.possible_fields = [ID_field] + possible_fields

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -1596,6 +1596,12 @@ class BassTone(settings.Setting):
     min_value = 0
     max_value = 100
 
+    @classmethod
+    def build(cls, device):
+        if device_quirks.setting_inert(device, cls.name):
+            return None
+        return super().build(device)
+
 
 class Equalizer(settings.RangeFieldSetting):
     name = "equalizer"
@@ -1604,6 +1610,12 @@ class Equalizer(settings.RangeFieldSetting):
     feature = _F.EQUALIZER
     rw_options = {"read_fnid": 0x20, "write_fnid": 0x30, "read_prefix": b"\x00"}
     keys_universe = []
+
+    @classmethod
+    def build(cls, device):
+        if device_quirks.setting_inert(device, cls.name):
+            return None
+        return super().build(device)
 
     class validator_class(settings_validator.PackedRangeValidator):
         kind = settings.Kind.GRAPHIC_EQ

--- a/lib/logitech_receiver/settings_validator.py
+++ b/lib/logitech_receiver/settings_validator.py
@@ -583,17 +583,18 @@ class HeteroValidator(Validator):
     def build(cls, setting_class, device, **kwargs):
         return cls(**kwargs)
 
-    def __init__(self, data_class=None, options=None, readable=True):
+    def __init__(self, data_class=None, options=None, readable=True, read_skip_byte_count=0):
         # options=None for purely host-side settings — data_class handles bytes[0] as the ID.
         assert data_class is not None
         self.data_class = data_class
         self.options = options
         self.readable = readable
+        self.read_skip_byte_count = read_skip_byte_count  # e.g. request-echo bytes before the payload
         self.needs_current_value = False
 
     def validate_read(self, reply_bytes):
         if self.readable:
-            reply_value = self.data_class.from_bytes(reply_bytes, options=self.options)
+            reply_value = self.data_class.from_bytes(reply_bytes[self.read_skip_byte_count :], options=self.options)
             return reply_value
 
     def prepare_write(self, new_value, current_value=None):

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -239,11 +239,9 @@ def _print_device(dev, num=None):
             # For centurion child, skip dongle features (already shown on the receiver)
             if is_centurion_child and not in_sub_device:
                 continue
-            if isinstance(feature, str):
-                feature_bytes = bytes.fromhex(feature[-4:])
-            else:
-                feature_bytes = feature.to_bytes(2, byteorder="little")
-            feature_int = int.from_bytes(feature_bytes, byteorder="little")
+            # ROOT.getFeature takes the feature ID big-endian.
+            feature_int = int(feature[-4:], 16) if isinstance(feature, str) else int(feature)
+            feature_bytes = feature_int.to_bytes(2, byteorder="big")
             display_name = feature
             if is_centurion_child and in_sub_device:
                 # Use cached version — skip slow bridge ROOT queries

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -51,9 +51,15 @@ def _print_receiver(receiver):
         pending = hidpp10.get_configuration_pending_flags(receiver)
         if pending:
             print(f"  C Pending    : {pending:02x}")
-    if receiver.firmware:
-        for f in receiver.firmware:
-            print("    %-11s: %s" % (f.kind, f.version))
+    # Lead with the main firmware the way Logitech writes it, then the remaining
+    # entities raw -- a receiver has no feature dump, so this is the only place
+    # its bootloader and hardware revision are ever reported.
+    main_firmware = common.main_firmware(receiver.firmware)
+    if main_firmware:
+        print("  Firmware     :", common.firmware_display_version(main_firmware))
+    for f in receiver.firmware or ():
+        if f is not main_firmware:
+            print("    %-11s: %s" % (common.FirmwareKind(f.kind).name, f.version))
 
     if is_centurion:
         print("  Has", paired_count, f"device(s) out of a maximum of {int(receiver.max_devices)}.")

--- a/lib/solaar/cli/show.py
+++ b/lib/solaar/cli/show.py
@@ -190,9 +190,15 @@ def _print_device(dev, num=None):
         print("     Model ID:     ", dev.modelId)
     if dev.unitId:
         print("     Unit ID:      ", dev.unitId)
-    if dev.firmware:
-        for fw in dev.firmware:
-            print(f"       {fw.kind:11}:", (fw.name + " " + fw.version).strip())
+    # Lead with the main firmware the way Logitech writes it, then the remaining
+    # entities as before -- solaar show is a dump, so nothing stops being printed.
+    main_firmware = common.main_firmware(dev.firmware)
+    if main_firmware:
+        print("     Firmware     :", common.firmware_display_version(main_firmware))
+    for fw in dev.firmware or ():
+        entity = (fw.name + " " + fw.version).strip()
+        if fw is not main_firmware and entity:
+            print("       %-11s: %s" % (common.FirmwareKind(fw.kind).name, entity))
 
     if dev.power_switch_location:
         print(f"     The power switch is located on the {dev.power_switch_location}.")

--- a/lib/solaar/ui/config_panel.py
+++ b/lib/solaar/ui/config_panel.py
@@ -816,6 +816,8 @@ _icons_allowables = {v: k for k, v in _allowables_icons.items()}
 # the zone index (rgb_zone_1, rgb_zone_2, ...).
 _SW_CONTROL_DEPENDENT_NAMES = ("rgb_idle_timeout", "rgb_idle_effect", "rgb_sleep_timeout")
 _SW_CONTROL_DEPENDENT_PREFIXES = ("rgb_zone_",)
+# 0x8070 analog of rgb_control/rgb_zone_: led_zone_* rows need led_control on.
+_LED_CONTROL_DEPENDENT_PREFIXES = ("led_zone_",)
 # headset_led_control = whether Solaar holds the live-coloring claim (off lets
 # another app drive the LEDs). The 0x0620 per-zone painting and the 0x0621
 # onboard effect are both live LED control, so both need the claim; per-zone
@@ -844,6 +846,25 @@ def _sw_control_blocked(device):
         return False
     # Solaar = bool True or legacy int 3; everything else (False, 0, …) blocks.
     return value not in (True, 3)
+
+
+def _led_control_blocked(device):
+    """True when the 0x8070 LED Control is off (Device/firmware mode) — its
+    led_zone_* rows have no effect. Reads setting._value first, then the
+    persister; accepts the current bool or a legacy int 0/1."""
+    persister = getattr(device, "persister", None)
+    if persister is None:
+        return False
+    value = None
+    for s in getattr(device, "settings", []) or []:
+        if s.name == "led_control":
+            value = s._value
+            break
+    if value is None:
+        value = persister.get("led_control")
+    if value is None:
+        return False
+    return value not in (True, 1)
 
 
 def _headset_led_blocked(device):
@@ -919,6 +940,8 @@ def _gate_blocks(device, name):
     completions can't undo the grey-out when their callbacks land later."""
     if name in _SW_CONTROL_DEPENDENT_NAMES or any(name.startswith(p) for p in _SW_CONTROL_DEPENDENT_PREFIXES):
         return _sw_control_blocked(device)
+    if any(name.startswith(p) for p in _LED_CONTROL_DEPENDENT_PREFIXES):
+        return _led_control_blocked(device)
     if name == "per-key-lighting":
         return _sw_control_blocked(device) or _zone_effect_blocks_perkey(device)
     if name in _HEADSET_LED_DEPENDENT_NAMES:
@@ -943,6 +966,7 @@ def _apply_rgb_gates(device):
         if (
             name in _SW_CONTROL_DEPENDENT_NAMES
             or any(name.startswith(p) for p in _SW_CONTROL_DEPENDENT_PREFIXES)
+            or any(name.startswith(p) for p in _LED_CONTROL_DEPENDENT_PREFIXES)
             or name == "per-key-lighting"
             or name in _HEADSET_LED_DEPENDENT_NAMES
         ):
@@ -993,9 +1017,13 @@ def _change_click(button, sbox):
     # The lock icon on rgb_control, any zone, per-key, or headset_led_control
     # can change whether a dependent row is functional — re-evaluate the gate.
     name = sbox.setting.name
-    if name in ("rgb_control", "per-key-lighting", "headset_led_control", "headset-onboard-effect") or name.startswith(
-        "rgb_zone_"
-    ):
+    if name in (
+        "rgb_control",
+        "led_control",
+        "per-key-lighting",
+        "headset_led_control",
+        "headset-onboard-effect",
+    ) or name.startswith(("rgb_zone_", "led_zone_")):
         _apply_rgb_gates(sbox.setting._device)
     return True
 
@@ -1099,9 +1127,13 @@ def _update_setting_item(sbox, value, is_online=True, sensitive=True, null_okay=
         logger.warning("%s: error setting control value (%s): %s", sbox.setting.name, sbox.setting._device, repr(e))
     sbox._control.set_sensitive(sensitive is True and can_function)
     _change_icon(sensitive, sbox._change_icon)
-    # rgb_control / rgb_zone_* gate per-key; headset_led_control and the
-    # headset-onboard-effect gate the per-zone row — re-evaluate on a change.
-    if name in ("rgb_control", "headset_led_control", "headset-onboard-effect") or name.startswith("rgb_zone_"):
+    # A control/zone/onboard-effect change can flip a dependent row's gate.
+    if name in (
+        "rgb_control",
+        "led_control",
+        "headset_led_control",
+        "headset-onboard-effect",
+    ) or name.startswith(("rgb_zone_", "led_zone_")):
         _apply_rgb_gates(sbox.setting._device)
 
 

--- a/lib/solaar/ui/icons.py
+++ b/lib/solaar/ui/icons.py
@@ -136,6 +136,12 @@ def device_icon_set(name="_", kind=None):
                 icon_set += ("input-mouse",)
             elif str(kind) == "headset":
                 icon_set += ("audio-headphones", "audio-headset")
+            elif str(kind) == "speaker":
+                icon_set += ("audio-speakers",)
+            elif str(kind) == "microphone":
+                icon_set += ("audio-input-microphone",)
+            elif str(kind) == "webcam":
+                icon_set += ("camera-web",)
             icon_set += (f"input-{str(kind)}",)
         # icon_set += (name.replace(' ', '-'),)
         _ICON_SETS[name] = icon_set

--- a/lib/solaar/ui/window.py
+++ b/lib/solaar/ui/window.py
@@ -23,6 +23,7 @@ from enum import IntEnum
 import gi
 
 from gi.repository.GObject import TYPE_PYOBJECT
+from logitech_receiver import common
 from logitech_receiver import hidpp10_constants
 from logitech_receiver.common import LOGITECH_VENDOR_ID
 from logitech_receiver.common import NamedInt
@@ -554,11 +555,11 @@ def _update_details(button):
                     yield _("Unit ID"), device.unitId
 
             if read_all:
-                if device.firmware:
-                    for fw in list(device.firmware):
-                        yield "  " + _(str(fw.kind)), (fw.name + " " + fw.version).strip()
+                main_firmware = common.main_firmware(device.firmware)
+                if main_firmware:
+                    yield _("Firmware"), common.firmware_display_version(main_firmware)
             elif device.kind is None or device.online:
-                yield f"  {_('Firmware')}", "..."
+                yield _("Firmware"), "..."
 
             flag_bits = device.notification_flags
             if flag_bits is not None:

--- a/tests/logitech_receiver/fake_hidpp.py
+++ b/tests/logitech_receiver/fake_hidpp.py
@@ -264,6 +264,11 @@ zone_responses_2 = [  # responses for RGB EFFECTS
     Response("0000000300040005", 0x0700, "000000"),
     Response("0001000200080009", 0x0700, "000100"),
 ]
+zone_responses_speaker = [  # COLOR LED EFFECTS zone with Audio Visualizer (G560)
+    Response("00000102", 0x0710, "00FF00"),
+    Response("0000000300040005", 0x0720, "000000"),
+    Response("0001000700040005", 0x0720, "000100"),
+]
 effects_responses_1 = [Response("0100000001", 0x0700)] + zone_responses_1
 effects_responses_2 = [Response("FFFF0100000001", 0x0700, "FFFF00")] + zone_responses_2
 

--- a/tests/logitech_receiver/test_common.py
+++ b/tests/logitech_receiver/test_common.py
@@ -361,3 +361,50 @@ def test_firmware_version_tuple(name, version, expected):
     firmware = common.FirmwareInfo(common.FirmwareKind.Firmware, name, version, None)
 
     assert common.firmware_version_tuple(firmware) == expected
+
+
+def _fw(name, version, kind=common.FirmwareKind.Firmware):
+    return common.FirmwareInfo(kind, name, version, None)
+
+
+@pytest.mark.parametrize(
+    "name, version, expected",
+    [
+        ("U1 ", "22.04.B0370", "122.4.370"),  # G560, hundreds digit folded in
+        ("U  ", "98.03.B0027", "98.3.27"),  # G933
+        ("MPM", "27.00.B0016", "27.0.16"),  # prefix dropped, as Logitech writes it
+        ("MPM", "27.00", "27.0"),  # no build reported, none invented
+        ("", "1.16", "1.16"),  # Centurion two-part form
+        ("MPM", "1A.2B", "MPM 1A.2B"),  # unparsable falls back to the raw fields
+        ("", "5", "5"),  # hardware revision is a bare integer
+        ("", "", ""),
+    ],
+)
+def test_firmware_display_version(name, version, expected):
+    assert common.firmware_display_version(_fw(name, version)) == expected
+
+
+def test_main_firmware_skips_bootloader():
+    bootloader = _fw("BL2", "19.00.B0010", kind=common.FirmwareKind.Bootloader)
+    main = _fw("MPK", "25.02.B0013")
+
+    assert common.main_firmware([bootloader, main, _fw("", "", kind=common.FirmwareKind.Other)]) is main
+
+
+def test_main_firmware_takes_the_highest():
+    older = _fw("U1 ", "22.02.B0001")
+    newer = _fw("U1 ", "22.04.B0370")
+
+    assert common.main_firmware([newer, older]) is newer
+    assert common.main_firmware([older, newer]) is newer
+
+
+def test_main_firmware_falls_back_to_an_unparsable_entry():
+    odd = _fw("MPM", "nonsense")
+
+    assert common.main_firmware([odd]) is odd
+
+
+@pytest.mark.parametrize("firmware", [None, (), [_fw("BL1", "42.00.B0016", kind=common.FirmwareKind.Bootloader)]])
+def test_main_firmware_absent(firmware):
+    assert common.main_firmware(firmware) is None

--- a/tests/logitech_receiver/test_common.py
+++ b/tests/logitech_receiver/test_common.py
@@ -375,6 +375,7 @@ def _fw(name, version, kind=common.FirmwareKind.Firmware):
         ("MPM", "27.00.B0016", "27.0.16"),  # prefix dropped, as Logitech writes it
         ("MPM", "27.00", "27.0"),  # no build reported, none invented
         ("", "1.16", "1.16"),  # Centurion two-part form
+        ("", "04.02.B0009", "4.2.9"),  # HID++ 1.0 receiver, as the official app writes it
         ("MPM", "1A.2B", "MPM 1A.2B"),  # unparsable falls back to the raw fields
         ("", "5", "5"),  # hardware revision is a bare integer
         ("", "", ""),

--- a/tests/logitech_receiver/test_common.py
+++ b/tests/logitech_receiver/test_common.py
@@ -337,3 +337,27 @@ def test_battery_offline():
     assert battery.ok()
     assert not battery.charging()
     assert battery.to_str() == "Battery: 58% (offline)"
+
+
+@pytest.mark.parametrize(
+    "name, version, expected",
+    [
+        # the G-audio family carries a version past 99 in its name prefix
+        ("U1 ", "22.04.B0370", (122, 4, 370)),  # G560
+        ("U1 ", "37.00.B0131", (137, 0, 131)),  # G733
+        ("U  ", "98.03.B0027", (98, 3, 27)),  # G933, no hundreds digit yet
+        # "BL1" is a bootloader name, not a version prefix: no fold
+        ("BL1", "42.00.B0016", (42, 0, 16)),
+        ("MPM", "27.00.B0016", (27, 0, 16)),
+        ("MPM", "27.00", (27, 0, 0)),
+        ("", "1.16", (1, 16, 0)),  # Centurion two-part form
+        ("", "3.02.15", (3, 2, 15)),  # build without the B marker
+        ("MPM", "", None),
+        ("MPM", "nonsense", None),
+        ("MPM", "1A.2B", None),  # a device reporting non-BCD is not comparable
+    ],
+)
+def test_firmware_version_tuple(name, version, expected):
+    firmware = common.FirmwareInfo(common.FirmwareKind.Firmware, name, version, None)
+
+    assert common.firmware_version_tuple(firmware) == expected

--- a/tests/logitech_receiver/test_device_quirks.py
+++ b/tests/logitech_receiver/test_device_quirks.py
@@ -1,0 +1,123 @@
+## Copyright (C) 2024  Solaar Contributors https://pwr-solaar.github.io/Solaar/
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License along
+## with this program; if not, write to the Free Software Foundation, Inc.,
+## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import pytest
+
+from logitech_receiver import common
+from logitech_receiver import device_quirks
+from logitech_receiver import settings_templates
+from logitech_receiver.hidpp20_constants import SupportedFeature
+
+from . import fake_hidpp
+
+G560 = "000000000A78"
+
+
+def _firmware(*versions, kind=common.FirmwareKind.Firmware):
+    return tuple(common.FirmwareInfo(kind, "U", version, None) for version in versions)
+
+
+class FakeDevice:
+    def __init__(self, model_id=G560, firmware=()):
+        self.modelId = model_id
+        self.firmware = firmware
+
+
+@pytest.mark.parametrize(
+    "version, equalizer_inert, bass_inert",
+    [
+        ("122.04.B0370", True, False),  # verified on hardware: EQ silent, bass audible
+        ("122.03.B0023", True, False),  # the swap version itself
+        ("122.03.B0022", False, True),  # one build below the swap
+        ("122.02.B9999", False, True),
+        ("98.03.B0027", False, True),  # pre-rollover: mis-decoding this as 98 vs 122 flips both
+    ],
+)
+def test_setting_inert_g560_firmware_boundary(version, equalizer_inert, bass_inert):
+    device = FakeDevice(firmware=_firmware(version))
+
+    assert device_quirks.setting_inert(device, "equalizer") is equalizer_inert
+    assert device_quirks.setting_inert(device, "bass_tone") is bass_inert
+
+
+def test_setting_inert_folds_hundreds_digit_from_name_prefix():
+    """The G560 reports version 122 on the wire as name "U1 " plus number 22."""
+    device = FakeDevice(firmware=(common.FirmwareInfo(common.FirmwareKind.Firmware, "U1 ", "22.04.B0370", None),))
+
+    assert device_quirks.setting_inert(device, "equalizer") is True
+    assert device_quirks.setting_inert(device, "bass_tone") is False
+
+
+def test_setting_inert_uses_highest_main_firmware():
+    device = FakeDevice(firmware=_firmware("122.02.B0001", "122.04.B0370"))
+
+    assert device_quirks.setting_inert(device, "equalizer") is True
+
+
+def test_setting_inert_ignores_non_main_firmware():
+    device = FakeDevice(firmware=_firmware("122.04.B0370", kind=common.FirmwareKind.Bootloader) + _firmware("122.02.B0001"))
+
+    assert device_quirks.setting_inert(device, "equalizer") is False
+
+
+@pytest.mark.parametrize(
+    "device",
+    [
+        FakeDevice(firmware=()),  # firmware unreadable
+        FakeDevice(firmware=_firmware("nonsense")),  # firmware unparsable
+        FakeDevice(firmware=_firmware("122.04.B0370", kind=common.FirmwareKind.Bootloader)),
+        FakeDevice(model_id="", firmware=_firmware("122.04.B0370")),
+        FakeDevice(model_id="B38940B4C355", firmware=_firmware("122.04.B0370")),  # unlisted model
+    ],
+)
+def test_setting_inert_fails_open(device):
+    assert device_quirks.setting_inert(device, "equalizer") is False
+    assert device_quirks.setting_inert(device, "bass_tone") is False
+
+
+def test_setting_inert_unlisted_setting():
+    device = FakeDevice(firmware=_firmware("122.04.B0370"))
+
+    assert device_quirks.setting_inert(device, "sidetone") is False
+
+
+def test_setting_inert_experimental_bypass(monkeypatch):
+    monkeypatch.setenv("SOLAAR_EXPERIMENTAL", "1")
+    device = FakeDevice(firmware=_firmware("122.04.B0370"))
+
+    assert device_quirks.setting_inert(device, "equalizer") is False
+
+
+def _g560_equalizer_device(version):
+    """A G560 reporting the EQ capabilities from its docs/devices scan."""
+    device = fake_hidpp.Device(
+        feature=SupportedFeature.EQUALIZER,
+        responses=[
+            fake_hidpp.Response("021A00EC06", 0x0400),
+            fake_hidpp.Response("0000200040", 0x0410, "00"),
+        ],
+    )
+    device.modelId = G560
+    device.firmware = _firmware(version)
+    return device
+
+
+def test_equalizer_suppressed_on_stubbed_firmware():
+    assert settings_templates.Equalizer.build(_g560_equalizer_device("122.04.B0370")) is None
+
+
+def test_equalizer_built_on_firmware_with_hardware_eq():
+    assert settings_templates.Equalizer.build(_g560_equalizer_device("122.03.B0022")) is not None

--- a/tests/logitech_receiver/test_hidpp20_complex.py
+++ b/tests/logitech_receiver/test_hidpp20_complex.py
@@ -692,6 +692,19 @@ def test_LEDEffectSetting(hex, ID, color, speed, period, intensity, ramp, form):
     assert yaml.safe_load(str(setting)) == setting
 
 
+def test_LEDEffectSetting_audio_visualizer():
+    # G560 factory readback: cycle on, BE16 period 0x1388 (5000 ms)
+    byt = bytes.fromhex("0701000000001388000000")
+    setting = hidpp20.LEDEffectSetting.from_bytes(byt)
+
+    assert setting.ID == common.NamedInt(0x7, "Audio Visualizer")
+    assert setting.cycle == 1
+    assert setting.color == 0
+    assert setting.period == 0x1388  # regression: mis-split as intensity/period pre-0x07
+    assert setting.to_bytes() == byt
+    assert yaml.safe_load(str(setting)) == setting
+
+
 @pytest.mark.parametrize(
     "feature, function, response, ID, capabilities, period",
     [
@@ -744,6 +757,17 @@ def test_LEDZoneInfo(feature, function, offset, effect_function, responses, inde
     assert zone.effects[1].ID == id_1
 
 
+def test_LEDZoneInfo_speaker_locations():
+    feature = hidpp20_constants.SupportedFeature.COLOR_LED_EFFECTS
+    device = fake_hidpp.Device(feature=feature, responses=fake_hidpp.zone_responses_1, offset=0x07)
+    device.kind = "speaker"
+
+    zone = hidpp20.LEDZoneInfo(feature, 0x10, 0, 0x20, device, 0)
+
+    assert zone.location == 1
+    assert str(zone.location) == "Left Front"
+
+
 @pytest.mark.parametrize(
     "responses, setting, expected_command",
     [
@@ -753,6 +777,11 @@ def test_LEDZoneInfo(feature, function, offset, effect_function, responses, inde
             fake_hidpp.zone_responses_1,
             hidpp20.LEDEffectSetting(ID=0xB, color=0x808080, period=0x20),
             "000180808000002000000000",
+        ],
+        [
+            fake_hidpp.zone_responses_speaker,
+            hidpp20.LEDEffectSetting(ID=0x7, cycle=1, color=0, period=0x1388),
+            "000101000000001388000000",
         ],
     ],
 )

--- a/tests/logitech_receiver/test_hidpp20_simple.py
+++ b/tests/logitech_receiver/test_hidpp20_simple.py
@@ -52,14 +52,23 @@ def test_get_ids():
     assert tid_map == {"btid": "1234", "wpid": "5678", "usbid": "9ABC"}
 
 
-def test_get_kind():
-    responses = [fake_hidpp.Response("00", 0x0420)]
+@pytest.mark.parametrize(
+    "response, name, value",
+    [
+        ("00", "keyboard", 0x01),
+        ("08", "headset", 0x0D),
+        ("0E", "speaker", 0x13),
+        ("13", "adapter", 0x18),
+    ],
+)
+def test_get_kind(response, name, value):
+    responses = [fake_hidpp.Response(response, 0x0420)]
     device = fake_hidpp.Device(responses=responses, feature=SupportedFeature.DEVICE_NAME)
 
     result = _hidpp20.get_kind(device)
 
-    assert result == "keyboard"
-    assert result == 1
+    assert result == name
+    assert result == value
 
 
 def test_get_name():

--- a/tests/logitech_receiver/test_setting_templates.py
+++ b/tests/logitech_receiver/test_setting_templates.py
@@ -272,6 +272,11 @@ simple_tests = [
         fake_hidpp.Response("0A", 0x0410, "0A"),
     ),
     Setup(
+        FeatureTest(settings_templates.BassTone, 0x46, 0x50),
+        fake_hidpp.Response("46", 0x0400),
+        fake_hidpp.Response("50", 0x0410, "50"),
+    ),
+    Setup(
         FeatureTest(settings_templates.ADCPower, 5, 0xA, version=0x03),
         fake_hidpp.Response("05", 0x0410),
         fake_hidpp.Response("0A", 0x0420, "0A"),
@@ -661,6 +666,15 @@ key_tests = [
         fake_hidpp.Response("E010", 0x0420, "00"),
         fake_hidpp.Response("E010", 0x0430, "02E010"),
         fake_hidpp.Response("E018", 0x0430, "02E018"),
+    ),
+    Setup(  # signed asymmetric dB range as reported by the G560 (-20..+6, bounds exclusive)
+        FeatureTest(settings_templates.Equalizer, {0: -4, 1: 2}, {1: 5}, 2),
+        [-19, 5],
+        fake_hidpp.Response("021A00EC06", 0x0400),
+        fake_hidpp.Response("0000200040", 0x0410, "00"),
+        fake_hidpp.Response("FC02", 0x0420, "00"),
+        fake_hidpp.Response("FC02", 0x0430, "02FC02"),
+        fake_hidpp.Response("FC05", 0x0430, "02FC05"),
     ),
     Setup(  # HeadsetOnboardEQ: 2 bands, 128Hz/-2dB/Q10 and 256Hz/+3dB/Q10
         FeatureTest(settings_templates.HeadsetOnboardEQ, {0: -2, 1: 3}, {1: 5}, 2),

--- a/tests/logitech_receiver/test_setting_templates.py
+++ b/tests/logitech_receiver/test_setting_templates.py
@@ -291,7 +291,7 @@ simple_tests = [
         fake_hidpp.Response("00000102", 0x0410, "00FF00"),
         fake_hidpp.Response("0000000300040005", 0x0420, "000000"),
         fake_hidpp.Response("0001000B00080009", 0x0420, "000100"),
-        fake_hidpp.Response("000000000000010050", 0x04E0, "00"),
+        fake_hidpp.Response("00000000000000010050", 0x04E0, "00"),  # GetEffect echoes the zone index
         fake_hidpp.Response("000000000000000101500000", 0x0430, "000000000000000101500000"),
     ),
     Setup(

--- a/tests/logitech_receiver/test_setting_templates.py
+++ b/tests/logitech_receiver/test_setting_templates.py
@@ -286,6 +286,11 @@ simple_tests = [
         fake_hidpp.Response("00", 0x0470),
         fake_hidpp.Response("01", 0x0480, "01"),
     ),
+    Setup(  # NvConfig startup toggle: GetNvConfig echoes the cap ID; 0x01 on / 0x02 off
+        FeatureTest(settings_templates.LEDStartupAnimation, False, True, version=5),
+        fake_hidpp.Response("00010200000000000000", 0x0440, "0001"),
+        fake_hidpp.Response("000101", 0x0450, "000101"),
+    ),
     Setup(
         FeatureTest(
             settings_templates.LEDZoneSetting,

--- a/tests/logitech_receiver/test_setting_templates.py
+++ b/tests/logitech_receiver/test_setting_templates.py
@@ -1072,3 +1072,49 @@ def test_HeadsetOnboardEffect_absent_animated_fields_seed_defaults():
 
     assert effect.intensity == 100
     assert effect.period == 5000
+
+
+def _led_lighting_device():
+    responses = [
+        fake_hidpp.Response("0100000001", 0x0400),
+        fake_hidpp.Response("00000102", 0x0410, "00FF00"),
+        fake_hidpp.Response("0000000300040005", 0x0420, "000000"),
+        fake_hidpp.Response("0001000B00080009", 0x0420, "000100"),
+        fake_hidpp.Response("01", 0x0480, "01"),
+        fake_hidpp.Response("000000000000000020500000", 0x0430, "000000000000000020500000"),
+    ]
+    device = fake_hidpp.Device(responses=responses, feature=hidpp20_constants.SupportedFeature.COLOR_LED_EFFECTS, offset=4)
+    control = settings_templates.check_feature(device, settings_templates.LEDControl)
+    zones = settings_templates.check_feature(device, settings_templates.LEDZoneSetting)
+    device.settings = [control] + zones
+    return device
+
+
+def test_lighting_apply_led_control_off_leaves_lighting_alone(mocker):
+    """With led_control persisted off, connect-time apply must not send any
+    lighting traffic — the device or another app (e.g. OpenRGB) owns it."""
+    device = _led_lighting_device()
+    device.persister["led_control"] = False
+    device.persister[device.settings[1].name] = hidpp20.LEDEffectSetting(ID=3, period=0x20, intensity=0x50)
+    spy = mocker.spy(device, "request")
+
+    for s in device.settings:
+        s.apply()
+
+    assert spy.call_count == 0
+
+
+def test_lighting_apply_led_control_on_claims_and_repaints(mocker):
+    """With led_control persisted on, apply claims SW control and pushes the
+    saved zone effect."""
+    device = _led_lighting_device()
+    device.persister["led_control"] = True
+    device.persister[device.settings[1].name] = hidpp20.LEDEffectSetting(ID=3, period=0x20, intensity=0x50)
+    spy = mocker.spy(device, "request")
+
+    for s in device.settings:
+        s.apply()
+
+    request_ids = [c.args[0] for c in spy.call_args_list]
+    assert 0x0480 in request_ids  # SetSWControl claim
+    assert 0x0430 in request_ids  # zone effect write

--- a/tests/solaar/ui/test_config_panel_gates.py
+++ b/tests/solaar/ui/test_config_panel_gates.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+from solaar.ui import config_panel
+
+
+def _device(settings, persister):
+    return SimpleNamespace(settings=settings, persister=persister)
+
+
+def _setting(name, value):
+    return SimpleNamespace(name=name, _value=value)
+
+
+def test_led_control_blocked_reads_setting_value_first():
+    device = _device([_setting("led_control", False)], {"led_control": True})
+    assert config_panel._led_control_blocked(device) is True
+
+    device = _device([_setting("led_control", True)], {"led_control": False})
+    assert config_panel._led_control_blocked(device) is False
+
+
+def test_led_control_blocked_falls_back_to_persister():
+    device = _device([_setting("led_control", None)], {"led_control": False})
+    assert config_panel._led_control_blocked(device) is True
+
+
+def test_led_control_blocked_unknown_does_not_block():
+    device = _device([], {})
+    assert config_panel._led_control_blocked(device) is False
+
+
+def test_gate_blocks_led_zone_follows_led_control():
+    off = _device([_setting("led_control", False), _setting("led_zone_1", None)], {})
+    assert config_panel._gate_blocks(off, "led_zone_1") is True
+
+    on = _device([_setting("led_control", True), _setting("led_zone_1", None)], {})
+    assert config_panel._gate_blocks(on, "led_zone_1") is False
+
+
+def test_gate_blocks_rgb_zone_unaffected_by_led_control():
+    # rgb_zone_ still keys off rgb_control, not led_control
+    device = _device([_setting("led_control", False), _setting("rgb_control", True), _setting("rgb_zone_1", None)], {})
+    assert config_panel._gate_blocks(device, "rgb_zone_1") is False


### PR DESCRIPTION
Depends on #3282 since this uses common.firmware_version_tuple(), which is introduced there

This adjusts the formatting for `solaar show` to give decoded version numbers in the standard Logitech format so they're directly relevant and comparable to what the official app and website show.

```
Lightspeed Receiver
  Device path  : /dev/hidraw18
  USB id       : 046d:C547
  Serial       : 26665F54
  C Pending    : ff
  Firmware     : 4.2.9
    Bootloader : 02.09
    Other      : 6C.DE
  Has 1 paired device(s) out of a maximum of 2.
  Notifications: software present, wireless (0x000900)
  Device activity counters: 1=182

  1: G502 X PLUS
     Device path  : /dev/hidraw19
     WPID         : 4099
     Codename     : G502 X PLUS
     Kind         : mouse
     Protocol     : HID++ 4.2
     Report Rate  : 1ms
     Serial number: 6FF83E8B
     Model ID     : 4099C0950000
     Unit ID      : 6FF83E8B
     Firmware     : 27.0.16
       Bootloader : BL1 42.00.B0016
     The power switch is located on the unknown.
     Supports 32 HID++ 2.0 features:
         0: ROOT                   {0000} V0     
         1: FEATURE SET            {0001} V0     
         2: DEVICE FW VERSION      {0003} V4     
            Firmware: 1 BL1 42.00.B0016 AB0BFBB13A33
            Firmware: 0 MPM 27.00.B0016 4099FBB13A33
            Firmware: 3   
            Firmware: 3   
            Firmware: 3   
            Firmware: 3   
            Firmware: 3   
            Firmware: 3   
            Firmware: 3   
            Firmware: 3   
            Firmware: 3   
            Firmware: 3   
            Unit ID: 6FF83E8B  Model ID: 4099C0950000  Transport IDs: {'wpid': '4099', 'usbid': 'C095'}
         3: DEVICE NAME            {0005} V0     
            Name: G502 X PLUS
...
```

And also updates the "Show Technical Details" button in the UI to present only the relevant firmware version that end users care about.


```
Path         : /dev/hidraw15
Index        : 1
Wireless PID : 40B4
Protocol     : HID++ 4.2
Polling rate : 8ms
Serial       : 0D125D47
Firmware     : 25.2.13
```