### PR TITLE
G915 TKL G-keys as F-keys

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -274,6 +274,32 @@ This rule turns
 `Brightness Down` key press notifications into `XF86_MonBrightnessDown` key taps
 and `Brightness Up` key press notifications into `XF86_MonBrightnessUp` key taps.
 
+### Keyboards whose F-keys are really G-keys
+
+A few gaming keyboards, such as the G915 TKL, have no F-keys in hardware — their
+top row is really `G1` to `G12`, and it is the onboard profile that makes those
+keys report as `F1` to `F12`.
+Whenever no onboard profile is loaded that row stops working.
+That happens when you turn on `LED Control` or set `Onboard Profiles` to
+`Disabled` in Solaar, and it can also be done by another program such as OpenRGB
+without Solaar being involved at all.
+
+On these keyboards Solaar keeps the G-keys diverted for the whole session and has
+a built-in rule that turns each one back into the matching F-key press and
+release, which is what Logitech's own software does.
+This needs write access to `/dev/uinput`, as described near the top of this page;
+without it Solaar leaves the keyboard alone and warns you, because the mapping
+could not work anyway.
+Note that the F-keys then only work while Solaar is running.
+
+The `Divert G and M Keys` setting behaves as it does on any other keyboard.
+Left off, the top row acts as `F1` to `F12`.
+Turned on, your own rules see the G-keys — and any G-key your rules do not
+mention still falls back to its F-key, so remapping `G12` does not cost you
+`F1` through `F11`.
+The fallback is dropped per key for every `Gn` named by a `Key` or `KeyIsDown`
+condition anywhere in your rule file, whichever device that rule is scoped to.
+
 ## Example Solaar Rule File
 
 Solaar reads rules from a YAML configuration file (normally `~/.config/solaar/rules.yaml`).

--- a/lib/logitech_receiver/alerts.py
+++ b/lib/logitech_receiver/alerts.py
@@ -1,0 +1,58 @@
+## Copyright (C) 2012-2013  Daniel Pavel
+## Copyright (C) 2014-2024  Solaar Contributors https://pwr-solaar.github.io/Solaar/
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License along
+## with this program; if not, write to the Free Software Foundation, Inc.,
+## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Hook for surfacing device-level problems to whatever front end is running.
+
+`logitech_receiver` must not import `solaar.ui`, so the GUI registers a handler
+here the same way `solaar.listener` registers its error callback. With no
+handler — the CLI, or the tests — alerts fall through to the log.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from enum import Enum
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+
+class AlertReason(Enum):
+    # This model's F-row only exists while Solaar maps its G-keys, and
+    # /dev/uinput is not writable, so the mapping cannot work.
+    GKEYS_NEED_UINPUT = "G-keys need uinput"
+
+
+_handler: Callable | None = None
+
+
+def set_handler(handler: Callable | None) -> None:
+    """Register the front end's alert handler, called as `handler(reason, device)`."""
+    global _handler
+    _handler = handler
+
+
+def notify(reason: AlertReason, device) -> None:
+    """Raise an alert about `device`. Always logs; shows UI only if a handler is set."""
+    logger.warning("%s: %s", device, reason.value)
+    if _handler is None:
+        return
+    try:
+        _handler(reason, device)
+    except Exception:
+        logger.exception("alert handler failed for %s", reason)

--- a/lib/logitech_receiver/device_quirks.py
+++ b/lib/logitech_receiver/device_quirks.py
@@ -19,6 +19,10 @@ Two postures, by feature class:
   field is hidden and every slot suppressed unless the exact model is listed
   here as known-good.
 
+* **Hardware the firmware leaves broken** — ``GKEYS_ARE_FKEYS``, models whose
+  F-row only exists while an onboard profile is loaded. A compatibility shim
+  rather than a safety allowlist, so it ignores ``SOLAAR_EXPERIMENTAL``.
+
 Setting ``SOLAAR_EXPERIMENTAL`` truthy bypasses the allowlists entirely — for
 testers / reverse-engineering on devices not yet validated.
 
@@ -90,3 +94,24 @@ def headset_signature_allowed_fields(device, effect_id: int) -> set[str] | None:
         return set(_ALL_NVCONFIG_FIELDS)
     model_id = getattr(device, "modelId", None) or ""
     return HEADSET_SIGNATURE_EFFECTS_ALLOWED.get(model_id, {}).get(effect_id)
+
+
+# Models whose F-row is physically G1..Gn with no hardware F-key fallback — the
+# onboard profile is what makes those keys report as F-keys. With profiles
+# disabled (by Solaar's own SW-control claim, or by another app such as OpenRGB)
+# the row goes dead, so Solaar diverts the G-keys and synthesizes F-keys from
+# them. modelId -> number of G-keys in the F-row.
+GKEYS_ARE_FKEYS: dict[str, int] = {
+    # G915 TKL — the F-row is G1..G12 (pwr-Solaar/Solaar#3266).
+    "B35F408EC343": 12,
+}
+
+
+def gkeys_are_fkeys(device) -> int:
+    """Number of leading G-keys that stand in for this model's F-row, or 0.
+
+    Not gated on SOLAAR_EXPERIMENTAL: this is a compatibility shim for broken
+    hardware, not an allowlist protecting against bad writes.
+    """
+    model_id = getattr(device, "modelId", None) or ""
+    return GKEYS_ARE_FKEYS.get(model_id, 0)

--- a/lib/logitech_receiver/diversion.py
+++ b/lib/logitech_receiver/diversion.py
@@ -46,6 +46,7 @@ if platform.system() in ("Darwin", "Windows"):
 else:
     import evdev
 
+from . import device_quirks
 from .common import NamedInt
 from .hidpp20 import SupportedFeature
 from .special_keys import CONTROL
@@ -253,6 +254,19 @@ else:
     buttons = {}
     key_events = []
     devicecap = {}
+
+
+_UINPUT_PATH = "/dev/uinput"
+
+
+def uinput_writable() -> bool:
+    """True when simulated input can actually reach the system.
+
+    Side-effect free, unlike setup_uinput() below, which creates the device —
+    so this is safe as a precondition check. os.access reflects ACL grants,
+    which is how Solaar's udev rule hands out /dev/uinput.
+    """
+    return evdev is not None and os.access(_UINPUT_PATH, os.W_OK)
 
 
 def setup_uinput():
@@ -1412,16 +1426,60 @@ COMPONENTS = {
 }
 
 
-built_in_rules = Rule(
-    [
-        {
-            "Rule": [  # Implement problematic keys for Craft and MX Master
-                {"Rule": [{"Key": ["Brightness Down", "pressed"]}, {"KeyPress": "XF86_MonBrightnessDown"}]},
-                {"Rule": [{"Key": ["Brightness Up", "pressed"]}, {"KeyPress": "XF86_MonBrightnessUp"}]},
-            ]
-        },
-    ]
-)
+class GKeysAreFKeys(Condition):
+    """True when `device`'s F-row is really its first `index` G-keys.
+
+    Gates the built-in G-key -> F-key block below. Deliberately absent from
+    COMPONENTS: it exists only inside built_in_rules and must never be
+    writable from a user's rules.yaml.
+    """
+
+    def __init__(self, index=1, warn=True):
+        self.index = index if isinstance(index, int) and index > 0 else 1
+
+    def __str__(self):
+        return f"GKeysAreFKeys: {self.index}"
+
+    def evaluate(self, feature, notification: HIDPPNotification, device, last_result):
+        return device_quirks.gkeys_are_fkeys(device) >= self.index
+
+    def data(self):
+        return {"GKeysAreFKeys": self.index}
+
+
+def _gkeys_as_fkeys_rules(overridden: set[int]) -> dict:
+    """Rules restoring the F-row on models whose F-keys are really G-keys.
+
+    One pressed/released pair per key so hold and auto-repeat work, mirroring
+    what LGHUB does. G-keys named by the user's own rules are left out so their
+    rules win — see _overridden_gkeys.
+    """
+    components = [GKeysAreFKeys(1)]
+    for i in range(1, max(device_quirks.GKEYS_ARE_FKEYS.values(), default=0) + 1):
+        if i in overridden:
+            continue
+        gkey, fkey = f"G{i}", f"F{i}"
+        for gaction, faction in ((Key.DOWN, DEPRESS), (Key.UP, RELEASE)):
+            # The per-key gate keeps a shorter F-row's macro G-keys out of this.
+            components.append({"Rule": [GKeysAreFKeys(i), {"Key": [gkey, gaction]}, {"KeyPress": [fkey, faction]}]})
+    return {"Rule": components}
+
+
+def _build_built_in_rules(overridden_gkeys: set[int] = frozenset()) -> Rule:
+    return Rule(
+        [
+            {
+                "Rule": [  # Implement problematic keys for Craft and MX Master
+                    {"Rule": [{"Key": ["Brightness Down", "pressed"]}, {"KeyPress": "XF86_MonBrightnessDown"}]},
+                    {"Rule": [{"Key": ["Brightness Up", "pressed"]}, {"KeyPress": "XF86_MonBrightnessUp"}]},
+                ]
+            },
+            _gkeys_as_fkeys_rules(overridden_gkeys),
+        ]
+    )
+
+
+built_in_rules = _build_built_in_rules()
 
 
 def key_is_down(key: NamedInt) -> bool:
@@ -1435,9 +1493,28 @@ def key_is_down(key: NamedInt) -> bool:
     return key in keys_down
 
 
+def _gkeys_owned_by_built_ins(feature, device) -> bool:
+    """True when this device's G-keys are standing in for its F-row and the
+    user has left the divert switch off.
+
+    Divert is forced on for those models (see DivertGkeys), so their G-keys
+    reach the rule engine whatever the switch says. With the switch off they
+    are meant to be plain F-keys, so only the built-in mapping may run.
+    """
+    if feature != SupportedFeature.GKEY or not device_quirks.gkeys_are_fkeys(device):
+        return False
+    for s in getattr(device, "settings", None) or ():
+        if s.name == "divert-gkeys":  # settings_templates imports us, so no constant to share
+            return not s._value
+    return True
+
+
 def evaluate_rules(feature, notification: HIDPPNotification, device):
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug("evaluating rules on %s %s", feature, notification)
+    if _gkeys_owned_by_built_ins(feature, device):
+        built_in_rules.evaluate(feature, notification, device, True)
+        return
     rules.evaluate(feature, notification, device, True)
 
 
@@ -1553,7 +1630,28 @@ def load_config_rule_file():
         rules = _load_rule_config(_file_path)
 
 
+def _overridden_gkeys(component) -> set[int]:
+    """G-key indices the user's own rules already act on.
+
+    Those keys lose their built-in F-key mapping so the user's rules win, per
+    key — remapping G12 must not cost anyone F1..F11. Device scoping is not
+    considered: a rule naming G5 on some other keyboard also releases G5 here.
+    """
+    found = set()
+    if isinstance(component, (Rule, Or, And)):
+        for c in component.components:
+            found |= _overridden_gkeys(c)
+    elif isinstance(component, Not):
+        found |= _overridden_gkeys(component.component)
+    elif isinstance(component, (Key, KeyIsDown)):
+        key = getattr(component, "key", None)
+        if key and CONTROL.G1 <= key <= CONTROL.G32:
+            found.add(int(key) - int(CONTROL.G1) + 1)
+    return found
+
+
 def _load_rule_config(file_path: str) -> Rule:
+    global built_in_rules
     loaded_rules = []
     try:
         with open(file_path) as config_file:
@@ -1567,7 +1665,9 @@ def _load_rule_config(file_path: str) -> Rule:
                 logger.info("loaded %d rules from %s", len(loaded_rules), config_file.name)
     except Exception as e:
         logger.error("failed to load from %s\n%s", file_path, e)
-    return Rule([Rule(loaded_rules, source=file_path), built_in_rules])
+    user_rules = Rule(loaded_rules, source=file_path)
+    built_in_rules = _build_built_in_rules(_overridden_gkeys(user_rules))
+    return Rule([user_rules, built_in_rules])
 
 
 load_config_rule_file()

--- a/lib/logitech_receiver/settings_templates.py
+++ b/lib/logitech_receiver/settings_templates.py
@@ -30,6 +30,7 @@ import yaml
 
 from solaar.i18n import _
 
+from . import alerts
 from . import base
 from . import common
 from . import descriptors
@@ -683,6 +684,35 @@ class DivertGkeys(settings.Setting):
 
         def read(self, device):  # no way to read, so just assume not diverted
             return b"\x00"
+
+    def _fkeys_need_divert(self) -> bool:
+        """True when this model's F-row is really its G-keys.
+
+        Those keys only reach diversion's built-in G->F mapping while the wire
+        divert is on, and Solaar is not the only thing that can put the device
+        into G-key mode (OpenRGB's SW control does too), so the divert is held
+        on for the whole session rather than tracked against a claim.
+        """
+        if not device_quirks.gkeys_are_fkeys(self._device):
+            return False
+        if diversion.uinput_writable():
+            return True
+        # Without uinput the F-keys cannot be synthesized, so leave the row to
+        # the firmware rather than diverting it into a dead end.
+        alerts.notify(alerts.AlertReason.GKEYS_NEED_UINPUT, self._device)
+        return False
+
+    def write(self, value, save=True):
+        # On these models the wire divert is not the user's to turn off — doing
+        # so would kill their F-row. The switch keeps its label and its felt
+        # meaning but selects rule routing instead: off leaves the keys to the
+        # built-in F-key mapping, on lets the user's own rules see them first
+        # (see diversion._gkeys_owned_by_built_ins).
+        if not self._fkeys_need_divert():
+            return super().write(value, save)
+        result = super().write(True, save=False)
+        self.update(value, save)
+        return value if result is not None else result
 
 
 class ScrollRatchet(settings.Setting):

--- a/lib/solaar/gtk.py
+++ b/lib/solaar/gtk.py
@@ -29,6 +29,8 @@ import tempfile
 
 from traceback import format_exc
 
+from logitech_receiver import alerts
+
 from solaar import NAME
 from solaar import __version__
 from solaar import cli
@@ -192,6 +194,7 @@ def main():
         logger.warning("See https://pwr-solaar.github.io/Solaar/installation for more information")
     try:
         listener.setup_scanner(ui.status_changed, ui.setting_changed, ui.common.error_dialog)
+        alerts.set_handler(ui.common.alert_dialog)
 
         if args.restart_on_wake_up:
             dbus.watch_suspend_resume(listener.start_all, listener.stop_all)

--- a/lib/solaar/ui/common.py
+++ b/lib/solaar/ui/common.py
@@ -21,6 +21,8 @@ from typing import Tuple
 
 import gi
 
+from logitech_receiver.alerts import AlertReason
+
 from solaar.i18n import _
 from solaar.tasks import TaskRunner
 
@@ -79,6 +81,55 @@ def _error_dialog(reason: ErrorReason, object_):
 
 def error_dialog(reason: ErrorReason, object_):
     GLib.idle_add(_error_dialog, reason, object_)
+
+
+_RULES_DOC_URL = "https://pwr-solaar.github.io/Solaar/rules"
+_ALERT_DISMISSED = "_gkeys_alert_dismissed"
+_alerts_shown = set()  # (reason, device path) pairs already shown this session
+
+
+def _create_alert_text(reason: AlertReason, device) -> Tuple[str, str]:
+    if reason == AlertReason.GKEYS_NEED_UINPUT:
+        title = _("Function keys need setup")
+        text = (
+            _("Your %s has no F-keys in hardware.") % device.name
+            + "\n"
+            + _("Solaar maps its G-keys to F1-F12, which needs write access to /dev/uinput.")
+            + "\n\n"
+            + _("Setup: %s") % _RULES_DOC_URL
+        )
+        return title, text
+    raise Exception("ui.alert_dialog: don't know how to handle (%s, %s)", reason.name, device)
+
+
+def _alert_dialog(reason: AlertReason, device):
+    title, text = _create_alert_text(reason, device)
+
+    m = Gtk.MessageDialog(None, Gtk.DialogFlags.MODAL, Gtk.MessageType.WARNING, Gtk.ButtonsType.OK, text)
+    m.set_title(title)
+    never = Gtk.CheckButton.new_with_label(_("Never show this again"))
+    never.set_halign(Gtk.Align.START)
+    never.show()
+    m.get_content_area().pack_end(never, False, False, 6)
+    m.run()
+    dismissed = never.get_active()
+    m.destroy()
+
+    persister = getattr(device, "persister", None)
+    if dismissed and persister is not None:
+        persister[_ALERT_DISMISSED] = True
+
+
+def alert_dialog(reason: AlertReason, device):
+    """Warn about `device`, once per session unless the user dismissed it for good."""
+    persister = getattr(device, "persister", None)
+    if persister is not None and persister.get(_ALERT_DISMISSED):
+        return
+    key = (reason, getattr(device, "path", None), getattr(device, "number", None))
+    if key in _alerts_shown:
+        return
+    _alerts_shown.add(key)
+    GLib.idle_add(_alert_dialog, reason, device)
 
 
 _task_runner = None

--- a/tests/logitech_receiver/test_device_quirks.py
+++ b/tests/logitech_receiver/test_device_quirks.py
@@ -1,0 +1,53 @@
+## Copyright (C) 2024  Solaar Contributors https://pwr-solaar.github.io/Solaar/
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License along
+## with this program; if not, write to the Free Software Foundation, Inc.,
+## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import pytest
+
+from logitech_receiver import device_quirks
+
+G915_TKL = "B35F408EC343"
+G502_X_PLUS = "4099C0950000"  # a mouse, listed for another quirk but not this one
+
+
+class FakeDevice:
+    def __init__(self, model_id):
+        self.modelId = model_id
+
+
+@pytest.mark.parametrize(
+    "model_id, expected",
+    [
+        (G915_TKL, 12),  # F-row is G1..G12
+        (G502_X_PLUS, 0),
+        ("", 0),
+        ("NOTAMODEL", 0),
+    ],
+)
+def test_gkeys_are_fkeys(model_id, expected):
+    assert device_quirks.gkeys_are_fkeys(FakeDevice(model_id=model_id)) == expected
+
+
+def test_gkeys_are_fkeys_ignores_experimental(monkeypatch):
+    """A compatibility shim, not a safety allowlist — SOLAAR_EXPERIMENTAL must not
+    hand the quirk to a device that was never listed for it."""
+    monkeypatch.setenv("SOLAAR_EXPERIMENTAL", "1")
+
+    assert device_quirks.gkeys_are_fkeys(FakeDevice(model_id=G502_X_PLUS)) == 0
+    assert device_quirks.gkeys_are_fkeys(FakeDevice(model_id=G915_TKL)) == 12
+
+
+def test_gkeys_are_fkeys_missing_model_id():
+    assert device_quirks.gkeys_are_fkeys(object()) == 0

--- a/tests/logitech_receiver/test_diversion.py
+++ b/tests/logitech_receiver/test_diversion.py
@@ -125,3 +125,146 @@ def test_process_notification(feature, data):
     )
 
     diversion.process_notification(device_mock, notification, feature)
+
+
+G915_TKL = "B35F408EC343"
+
+
+def _gkey_block(built_in):
+    """The generated G-key -> F-key block of a built_in_rules tree."""
+    return built_in.components[1]
+
+
+def _fake_device(model_id=G915_TKL, divert=None):
+    device = mock.Mock()
+    device.modelId = model_id
+    if divert is None:
+        device.settings = []
+    else:
+        setting = mock.Mock()
+        setting.name = "divert-gkeys"
+        setting._value = divert
+        device.settings = [setting]
+    return device
+
+
+def test_built_in_gkey_rules_cover_the_whole_f_row():
+    block = _gkey_block(diversion._build_built_in_rules())
+
+    assert isinstance(block.components[0], diversion.GKeysAreFKeys)
+    assert len(block.components) == 1 + 2 * 12  # gate + press/release per key
+
+    first = block.components[1]
+    assert [type(c) for c in first.components] == [diversion.GKeysAreFKeys, diversion.Key, diversion.KeyPress]
+    assert first.components[1].key == diversion.CONTROL.G1
+    assert first.components[1].action == diversion.Key.DOWN
+    assert first.components[2].key_names == ["F1"]
+    assert first.components[2].action == diversion.DEPRESS
+
+    last = block.components[-1]
+    assert last.components[1].key == diversion.CONTROL.G12
+    assert last.components[1].action == diversion.Key.UP
+    assert last.components[2].key_names == ["F12"]
+    assert last.components[2].action == diversion.RELEASE
+
+
+def test_built_in_gkey_rules_yield_per_key():
+    block = _gkey_block(diversion._build_built_in_rules({5, 12}))
+
+    mapped = {c.components[1].key for c in block.components[1:]}
+    assert diversion.CONTROL.G5 not in mapped
+    assert diversion.CONTROL.G12 not in mapped
+    # remapping one key must not cost the rest of the row
+    assert diversion.CONTROL.G1 in mapped
+    assert diversion.CONTROL.G11 in mapped
+    assert len(block.components) == 1 + 2 * 10
+
+
+def test_gkeys_are_fkeys_condition_is_per_device():
+    notification = mock.Mock()
+    gate = diversion.GKeysAreFKeys(1)
+
+    assert gate.evaluate(SupportedFeature.GKEY, notification, _fake_device(), True) is True
+    assert gate.evaluate(SupportedFeature.GKEY, notification, _fake_device("000000000A78"), True) is False
+
+
+def test_gkeys_are_fkeys_condition_respects_row_length():
+    notification = mock.Mock()
+    device = _fake_device()
+
+    assert diversion.GKeysAreFKeys(12).evaluate(SupportedFeature.GKEY, notification, device, True) is True
+    # a 13th G-key on such a model would be a macro key, not part of the F-row
+    assert diversion.GKeysAreFKeys(13).evaluate(SupportedFeature.GKEY, notification, device, True) is False
+
+
+def test_gkeys_are_fkeys_condition_is_not_user_writable():
+    assert "GKeysAreFKeys" not in diversion.COMPONENTS
+
+
+def test_overridden_gkeys_finds_nested_keys():
+    rule = diversion.Rule(
+        [
+            {"Rule": [{"Key": ["G3", "pressed"]}, {"KeyPress": "a"}]},
+            {"Rule": [{"Not": {"KeyIsDown": "G7"}}, {"KeyPress": "b"}]},
+            {"Rule": [{"Or": [{"Key": ["G9", "released"]}, {"Key": ["M1", "pressed"]}]}, {"KeyPress": "c"}]},
+            {"Rule": [{"Key": ["Brightness Up", "pressed"]}, {"KeyPress": "d"}]},
+        ]
+    )
+
+    assert diversion._overridden_gkeys(rule) == {3, 7, 9}
+
+
+def test_overridden_gkeys_of_rules_without_gkeys():
+    rule = diversion.Rule([{"Rule": [{"Key": ["Brightness Up", "pressed"]}, {"KeyPress": "d"}]}])
+
+    assert diversion._overridden_gkeys(rule) == set()
+
+
+@pytest.mark.parametrize(
+    "feature, model_id, divert, expected",
+    [
+        (SupportedFeature.GKEY, G915_TKL, False, True),  # switch off: built-ins own the row
+        (SupportedFeature.GKEY, G915_TKL, True, False),  # switch on: user rules see the keys
+        (SupportedFeature.GKEY, G915_TKL, None, True),  # no setting yet, default to F-keys
+        (SupportedFeature.GKEY, "000000000A78", False, False),  # other keyboards are untouched
+        (SupportedFeature.MKEYS, G915_TKL, False, False),  # only G-keys are remapped
+    ],
+)
+def test_gkeys_owned_by_built_ins(feature, model_id, divert, expected):
+    device = _fake_device(model_id, divert)
+
+    assert diversion._gkeys_owned_by_built_ins(feature, device) is expected
+
+
+def test_evaluate_rules_skips_user_rules_when_built_ins_own_the_row():
+    device = _fake_device(divert=False)
+    notification = mock.Mock()
+
+    with mock.patch.object(diversion, "rules") as user_rules:
+        with mock.patch.object(diversion, "built_in_rules") as built_ins:
+            diversion.evaluate_rules(SupportedFeature.GKEY, notification, device)
+
+    user_rules.evaluate.assert_not_called()
+    built_ins.evaluate.assert_called_once()
+
+
+def test_evaluate_rules_uses_all_rules_otherwise():
+    device = _fake_device(divert=True)
+    notification = mock.Mock()
+
+    with mock.patch.object(diversion, "rules") as user_rules:
+        diversion.evaluate_rules(SupportedFeature.GKEY, notification, device)
+
+    user_rules.evaluate.assert_called_once()
+
+
+def test_uinput_writable(monkeypatch):
+    monkeypatch.setattr(diversion, "evdev", object())
+    monkeypatch.setattr(diversion.os, "access", lambda path, mode: path == diversion._UINPUT_PATH)
+    assert diversion.uinput_writable() is True
+
+    monkeypatch.setattr(diversion.os, "access", lambda path, mode: False)
+    assert diversion.uinput_writable() is False
+
+    monkeypatch.setattr(diversion, "evdev", None)
+    assert diversion.uinput_writable() is False

--- a/tests/logitech_receiver/test_setting_templates.py
+++ b/tests/logitech_receiver/test_setting_templates.py
@@ -1053,3 +1053,108 @@ def test_HeadsetOnboardEffect_absent_animated_fields_seed_defaults():
 
     assert effect.intensity == 100
     assert effect.period == 5000
+
+
+G915_TKL = "B35F408EC343"
+_DIVERT_ON = b"\x01"
+
+
+class _RecordingRW:
+    """Captures the bytes a setting puts on the wire."""
+
+    kind = 2  # settings.FeatureRW.kind
+
+    def __init__(self):
+        self.written = []
+
+    def read(self, device):
+        return b"\x00"  # DivertGkeys cannot be read back
+
+    def write(self, device, data_bytes):
+        self.written.append(data_bytes)
+        return b""
+
+
+class _GkeysDevice:
+    def __init__(self, model_id):
+        self.modelId = model_id
+        self.online = True
+        # a real persister always carries device identity, and Setting._pre_write
+        # skips an empty one
+        self.persister = {"_name": "Test Keyboard"}
+        self.settings = []
+
+
+def _divert_gkeys(monkeypatch, model_id=G915_TKL, uinput=True):
+    monkeypatch.setattr(settings_templates.diversion, "uinput_writable", lambda: uinput)
+    device = _GkeysDevice(model_id)
+    rw = _RecordingRW()
+    validator = settings_validator.BooleanValidator(**settings_templates.DivertGkeys.validator_options)
+    setting = settings_templates.DivertGkeys(device, rw, validator)
+    device.settings = [setting]
+    return device, setting, rw
+
+
+def test_divert_gkeys_normal_device_writes_what_the_user_asked(monkeypatch):
+    device, setting, rw = _divert_gkeys(monkeypatch, model_id="000000000A78")
+
+    setting.write(True)
+    setting.write(False)
+
+    assert rw.written == [b"\x01", b"\x00"]
+    assert setting._value is False
+
+
+def test_divert_gkeys_forced_on_when_fkeys_are_gkeys(monkeypatch):
+    """The switch selects rule routing on these models; the wire divert has to
+    stay on or the user loses their whole F-row."""
+    device, setting, rw = _divert_gkeys(monkeypatch)
+
+    setting.write(False)
+
+    assert rw.written == [_DIVERT_ON]
+    assert setting._value is False  # the switch still records the user's choice
+    assert device.persister["divert-gkeys"] is False
+
+
+def test_divert_gkeys_forced_on_with_switch_on(monkeypatch):
+    device, setting, rw = _divert_gkeys(monkeypatch)
+
+    setting.write(True)
+
+    assert rw.written == [_DIVERT_ON]
+    assert setting._value is True
+
+
+def test_divert_gkeys_apply_forces_divert_on_connect(monkeypatch):
+    """SETTINGS order runs other settings first, so apply must not let a saved
+    False reach the wire."""
+    device, setting, rw = _divert_gkeys(monkeypatch)
+    device.persister["divert-gkeys"] = False
+
+    setting.apply()
+
+    assert rw.written == [_DIVERT_ON]
+    assert setting._value is False
+
+
+def test_divert_gkeys_leaves_device_alone_without_uinput(monkeypatch, mocker):
+    """Without uinput the F-keys cannot be synthesized, so diverting the row
+    would only take it away from the firmware."""
+    notify = mocker.patch.object(settings_templates.alerts, "notify")
+    device, setting, rw = _divert_gkeys(monkeypatch, uinput=False)
+
+    setting.write(False)
+
+    assert rw.written == [b"\x00"]
+    assert setting._value is False
+    assert notify.call_args.args[0] is settings_templates.alerts.AlertReason.GKEYS_NEED_UINPUT
+
+
+def test_divert_gkeys_does_not_alert_on_normal_devices(monkeypatch, mocker):
+    notify = mocker.patch.object(settings_templates.alerts, "notify")
+    device, setting, rw = _divert_gkeys(monkeypatch, model_id="000000000A78", uinput=False)
+
+    setting.write(True)
+
+    notify.assert_not_called()


### PR DESCRIPTION
The G915 TKL has no F-keys in hardware. Its top row is physically G1..G12, and the onboard profile is what makes those keys report as F1..F12. Whenever no profile is loaded the row goes dead. Solaar 1.1.20 started disabling onboard profiles as part of claiming software LED control, so turning on LED Control - or setting Onboard Profiles to Disabled - takes the whole F-row away (#3266). Another program such as OpenRGB can do the same without Solaar being involved, so this is not tracked against Solaar's own claim.

Add a GKEYS_ARE_FKEYS quirk table keyed by modelId, hold the wire divert on for those models, and add a built-in rule that turns each G-key press and release back into the matching F-key, the way Logitech's own software does. The mapping steps aside per key for any Gn a user rule names, so remapping G12 does not cost anyone F1..F11.

The Divert G and M Keys switch keeps its label and its felt meaning: left off the row acts as F1..F12, turned on the user's rules see the keys first. What changes is that the switch selects rule routing rather than the wire state, which the user must not be able to turn off.

Synthesizing keys needs write access to /dev/uinput. Without it the mapping cannot work, so leave the row to the firmware and warn instead, through a new alerts hook so logitech_receiver stays clear of solaar.ui.